### PR TITLE
No implicit imports in proc macro

### DIFF
--- a/draft/src/lib.rs
+++ b/draft/src/lib.rs
@@ -73,12 +73,12 @@ fn make_fn_body(schema: &Value, data: &Value, description: &str, valid: bool) ->
     output.push_str(&format!(
         r###"
     let schema_str = r##"{}"##;
-    let schema: Value = serde_json::from_str(schema_str).unwrap();
+    let schema: serde_json::Value = serde_json::from_str(schema_str).unwrap();
     let data_str = r##"{}"##;
-    let data: Value = serde_json::from_str(data_str).unwrap();
+    let data: serde_json::Value = serde_json::from_str(data_str).unwrap();
     let description = r#"{}"#;
     println!("Description: {{}}", description);
-    let compiled = JSONSchema::compile(&schema, None).unwrap();
+    let compiled = jsonschema::JSONSchema::compile(&schema, None).unwrap();
     let result = compiled.validate(&data);
     assert_eq!(result.is_ok(), compiled.is_valid(&data));
     "###,

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -1,6 +1,4 @@
 use draft::test_draft;
-use jsonschema::JSONSchema;
-use serde_json::Value;
 
 //test_draft!("tests/suite/tests/draft6/");
 test_draft!("tests/suite/tests/draft7/");


### PR DESCRIPTION
The goal of this PR is to remove the presence of implicit imports in the procedural macro implementation.
