### PR TITLE
chore: Run CI on pull requests & pushes to master

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: Continuous integration
 
-on: [push, pull_request]
+on:
+  pull_request: []
+  push:
+    branches:
+      - master
 
 jobs:
 


### PR DESCRIPTION
The goal is to avoid running the same checks twice in pull requests