### PR TITLE
feat: Add test_to_exclude capability into test_draft procedural macro

### DIFF
--- a/draft/Cargo.toml
+++ b/draft/Cargo.toml
@@ -8,6 +8,10 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]
 proc-macro = true
+
 [dependencies]
 serde_json = "1.0.48"
 heck = "0.3.1"
+quote = "1.0.5"
+syn = "1.0.21"
+proc-macro2 = "1.0.12"

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -1,5 +1,5 @@
 use draft::test_draft;
 
-test_draft!("tests/suite/tests/draft4/");
+test_draft!("tests/suite/tests/draft4/", {"optional_bignum_0_0", "optional_bignum_2_0"});
 test_draft!("tests/suite/tests/draft6/");
 test_draft!("tests/suite/tests/draft7/");


### PR DESCRIPTION
This is needed because there might be integration tests for which we would
like to ignore the outcome (for example it is an optional test).

In order to achieve this result the procedural macro has been rewritten to exploit
`syn` and `quote` capabilities (enhanced parsing as well as less string concatenations).
Additionally the new testing methods:
 *  do rely on 2 base methods `test_valid` and `test_invalid` and this allow less binary code to be generated and
 * are under `quote` macro but essentially is fully correct rust code so eventual future modifications are simples
 * do rely on users input to exclude test cases (so no changes into `draft` project for excluding including new tests)
 * are divided  into modules so it will be simpler to run the integration tests for a specific draft (`cargo test --tests draft4`)