### PR TITLE
test: Add more tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ criterion = "0.3.1"
 draft = {path = "draft"}
 jsonschema-valid = "0.4.0"
 valico = "3.2.0"
+test-case = "1.0.0"
 
 [[bench]]
 name = "jsonschema"

--- a/src/error.rs
+++ b/src/error.rs
@@ -545,11 +545,11 @@ impl<'a> fmt::Display for ValidationError<'a> {
                 kind: TypeKind::Multiple(types),
             } => write!(
                 f,
-                "'{}' is not of types '{}'",
+                "'{}' is not of types {}",
                 self.instance,
                 types
                     .iter()
-                    .map(|t| format!("{}", t))
+                    .map(|t| format!("'{}'", t))
                     .collect::<Vec<String>>()
                     .join(", ")
             ),
@@ -563,15 +563,21 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    fn type_error() {
+    fn single_type_error() {
         let instance = json!(42);
-        let err = error(ValidationError::single_type_error(
-            &instance,
-            PrimitiveType::String,
-        ))
-        .next()
-        .unwrap();
+        let err = ValidationError::single_type_error(&instance, PrimitiveType::String);
         let repr = format!("{}", err);
         assert_eq!(repr, "'42' is not of type 'string'")
+    }
+
+    #[test]
+    fn multiple_types_error() {
+        let instance = json!(42);
+        let err = ValidationError::multiple_type_error(
+            &instance,
+            vec![PrimitiveType::String, PrimitiveType::Number],
+        );
+        let repr = format!("{}", err);
+        assert_eq!(repr, "'42' is not of types 'string', 'number'")
     }
 }

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -35,7 +35,14 @@ impl Validate for EnumValidator {
     }
 
     fn name(&self) -> String {
-        format!("<enum: {:?}>", self.items)
+        format!(
+            "<enum: {}>",
+            self.items
+                .iter()
+                .map(|item| format!("{}", item))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -173,3 +173,17 @@ pub(crate) fn compile(
         None => Some(Err(CompilationError::SchemaError)),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ignored_format() {
+        let schema = json!({"format": "custom", "type": "string"});
+        let instance = json!("foo");
+        let compiled = JSONSchema::compile(&schema, None).unwrap();
+        assert!(compiled.is_valid(&instance))
+    }
+}

--- a/src/keywords/items.rs
+++ b/src/keywords/items.rs
@@ -115,7 +115,7 @@ impl Validate for ItemsObjectValidator {
     }
 
     fn name(&self) -> String {
-        format!("<items: {:#?}>", self.validators)
+        format!("<items: {:?}>", self.validators)
     }
 }
 

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -59,7 +59,14 @@ impl Validate for MultipleTypesValidator {
     }
 
     fn name(&self) -> String {
-        format!("<type: {:?}>", self.types)
+        format!(
+            "<type: {}>",
+            self.types
+                .iter()
+                .map(|type_| format!("{}", type_))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -62,86 +62,155 @@ pub type Validators = Vec<BoxedValidator>;
 #[cfg(test)]
 mod tests {
     use super::JSONSchema;
-    use serde_json::{from_str, json, Value};
-    use std::{fs::File, io::Read, path::Path};
+    use serde_json::{json, Value};
+    use test_case::test_case;
 
-    macro_rules! t {
-        ($t:ident : $schema:tt => $expected:expr) => {
-            #[test]
-            fn $t() {
-                let schema = json!($schema);
-                let compiled = JSONSchema::compile(&schema, None).unwrap();
-                assert_eq!(format!("{:?}", compiled.validators[0]), $expected);
-            }
-        };
+    #[test_case(json!({"additionalItems": false, "items": [{"type": "string"}]}), "<additional items: 1>")]
+    #[test_case(json!({"additionalItems": {"type": "integer"}, "items": [{"type": "string"}]}), "<additional items (1): [<type: integer>]>")]
+    #[test_case(json!({"additionalProperties": {"type": "string"}}), "<additional properties: [<type: string>]>")]
+    #[test_case(json!({"additionalProperties": {"type": "string"}, "properties": {"foo": {}}}), "<additional properties: [<type: string>]>")]
+    #[test_case(json!({"additionalProperties": {"type": "string"}, "patternProperties": {"f.*o": {"type": "integer"}}}), "<additional properties: [<type: string>]>")]
+    #[test_case(json!({"additionalProperties": {"type": "string"}, "properties": {"foo": {}}, "patternProperties": {"f.*o": {"type": "integer"}}}), "<additional properties: [<type: string>]>")]
+    #[test_case(json!({"additionalProperties": false}), "<additional properties: false>")]
+    #[test_case(json!({"additionalProperties": false, "properties": {"foo": {}}}), "<additional properties: false>")]
+    #[test_case(json!({"additionalProperties": false, "patternProperties": {"f.*o": {"type": "integer"}}}), "<additional properties: false>")]
+    #[test_case(json!({"additionalProperties": false, "properties": {"foo": {}}, "patternProperties": {"f.*o": {"type": "integer"}}}), "<additional properties: false>")]
+    #[test_case(json!({"allOf": [{"type": "integer"}, {"minimum": 2}]}), "<all of: [[<type: integer>], [<minimum: 2>]]>")]
+    #[test_case(json!({"anyOf": [{"type": "integer"}, {"minimum": 2}]}), "<any of: [[<type: integer>], [<minimum: 2>]]>")]
+    #[test_case(json!(true), "<true>")]
+    #[test_case(json!(false), "<false>")]
+    #[test_case(json!({"const": 1}), "<const: 1>")]
+    #[test_case(json!({"contains": {"minimum": 5}}), "<contains: [<minimum: 5>]>")]
+    #[test_case(json!({"contentMediaType": "application/json"}), "<contentMediaType: application/json>")]
+    #[test_case(json!({"contentEncoding": "base64"}), "<contentEncoding: base64>")]
+    #[test_case(json!({"contentEncoding": "base64", "contentMediaType": "application/json"}), "<contentMediaType - contentEncoding: application/json - base64>")]
+    #[test_case(json!({"dependencies": {"bar": ["foo"]}}), "<dependencies: [(\"bar\", [<required: [\"foo\"]>])]>")]
+    #[test_case(json!({"enum": [1]}), "<enum: 1>")]
+    #[test_case(json!({"exclusiveMaximum": 1}), "<exclusive maximum: 1>")]
+    #[test_case(json!({"exclusiveMinimum": 1}), "<exclusive minimum: 1>")]
+    #[test_case(json!({"format": "date"}), "<format: date>")]
+    #[test_case(json!({"format": "date-time"}), "<format: date-time>")]
+    #[test_case(json!({"format": "email"}), "<format: email>")]
+    #[test_case(json!({"format": "hostname"}), "<format: hostname>")]
+    #[test_case(json!({"format": "idn-email"}), "<format: idn-email>")]
+    #[test_case(json!({"format": "idn-hostname"}), "<format: idn-hostname>")]
+    #[test_case(json!({"format": "ipv4"}), "<format: ipv4>")]
+    #[test_case(json!({"format": "ipv6"}), "<format: ipv6>")]
+    #[test_case(json!({"format": "iri"}), "<format: iri>")]
+    #[test_case(json!({"format": "iri-reference"}), "<format: iri-reference>")]
+    #[test_case(json!({"format": "json-pointer"}), "<format: json-pointer>")]
+    #[test_case(json!({"format": "regex"}), "<format: regex>")]
+    #[test_case(json!({"format": "relative-json-pointer"}), "<format: relative-json-pointer>")]
+    #[test_case(json!({"format": "time"}), "<format: time>")]
+    #[test_case(json!({"format": "uri"}), "<format: uri>")]
+    #[test_case(json!({"format": "uri-reference"}), "<format: uri-reference>")]
+    #[test_case(json!({"format": "uri-template"}), "<format: uri-template>")]
+    #[test_case(json!({"if": {"exclusiveMaximum": 0}, "then": {"minimum": -10}}), "<if-then: [<exclusive maximum: 0>] [<minimum: -10>]>")]
+    #[test_case(json!({"if": {"exclusiveMaximum": 0}, "else": {"minimum": -10}}), "<if-else: [<exclusive maximum: 0>] [<minimum: -10>]>")]
+    #[test_case(json!({"if": {"exclusiveMaximum": 0}, "then": {"minimum": -10}, "else": {"multipleOf": 2}}), "<if-then-else: [<exclusive maximum: 0>] [<minimum: -10>] [<multiple of: 2>]>")]
+    #[test_case(json!({"items": [{"type": "string"}]}), "<items: [[<type: string>]]>")]
+    #[test_case(json!({"items": {"type": "integer"}}), "<items: [<type: integer>]>")]
+    #[test_case(json!({"maxItems": 1}), "<max items: 1>")]
+    #[test_case(json!({"maxLength": 1}), "<max length: 1>")]
+    #[test_case(json!({"maxProperties": 1}), "<max properties: 1>")]
+    #[test_case(json!({"maximum": 1}), "<maximum: 1>")]
+    #[test_case(json!({"minItems": 1}), "<min items: 1>")]
+    #[test_case(json!({"minLength": 1}), "<min length: 1>")]
+    #[test_case(json!({"minProperties": 1}), "<min properties: 1>")]
+    #[test_case(json!({"minimum": 1}), "<minimum: 1>")]
+    #[test_case(json!({"multipleOf": 1}), "<multiple of: 1>")]
+    #[test_case(json!({"multipleOf": 1.5}), "<multiple of: 1.5>")]
+    #[test_case(json!({"not": true}), "<not: [<true>]>")]
+    #[test_case(json!({"oneOf": [{"type": "integer"}, {"minimum": 2}]}), "<one of: [[<type: integer>], [<minimum: 2>]]>")]
+    #[test_case(json!({"pattern": "^a*$"}), "<pattern: ^a*$>")]
+    #[test_case(json!({"patternProperties": {"f.*o": {"type": "integer"}}}), "<pattern properties: [(f.*o, [<type: integer>])]>")]
+    #[test_case(json!({"properties": {"foo": {}}}), "<properties: [(\"foo\", [])]>")]
+    #[test_case(json!({"propertyNames": {"maxLength": 3}}), "<property names: [<max length: 3>]>")]
+    #[test_case(json!({"propertyNames": false}), "<property names: false>")]
+    #[test_case(json!({"$ref": "#/properties/foo"}), "<ref: json-schema:///#/properties/foo>")]
+    #[test_case(json!({"required": ["foo"]}), "<required: [\"foo\"]>")]
+    #[test_case(json!({"type": "null"}), "<type: null>")]
+    #[test_case(json!({"type": "boolean"}), "<type: boolean>")]
+    #[test_case(json!({"type": "string"}), "<type: string>")]
+    #[test_case(json!({"type": "array"}), "<type: array>")]
+    #[test_case(json!({"type": "object"}), "<type: object>")]
+    #[test_case(json!({"type": "number"}), "<type: number>")]
+    #[test_case(json!({"type": "integer"}), "<type: integer>")]
+    #[test_case(json!({"type": "integer", "$schema": "http://json-schema.org/draft-04/schema#"}), "<type: integer>")]
+    #[test_case(json!({"type": ["integer", "null"]}), "<type: integer, null>")]
+    #[test_case(json!({"type": ["integer", "null"], "$schema": "http://json-schema.org/draft-04/schema#"}), "<type: integer, null>")]
+    #[test_case(json!({"uniqueItems": true}), "<unique items>")]
+    fn debug_representation(schema: Value, expected: &str) {
+        let compiled = JSONSchema::compile(&schema, None).unwrap();
+        assert_eq!(format!("{:?}", compiled.validators[0]), expected);
     }
-    t!(content_media_type_validator: {"contentMediaType": "application/json"} => "<contentMediaType: application/json>");
-    t!(content_encoding_validator: {"contentEncoding": "base64"} => "<contentEncoding: base64>");
-    t!(combined_validator: {"contentEncoding": "base64", "contentMediaType": "application/json"} => "<contentMediaType - contentEncoding: application/json - base64>");
-    t!(date_format: {"format": "date"} => "<format: date>");
-    t!(date_time_format: {"format": "date-time"} => "<format: date-time>");
-    t!(email_format: {"format": "email"} => "<format: email>");
-    t!(hostname_format: {"format": "hostname"} => "<format: hostname>");
-    t!(idn_email_format: {"format": "idn-email"} => "<format: idn-email>");
-    t!(idn_hostname_format: {"format": "idn-hostname"} => "<format: idn-hostname>");
-    t!(ipv4_format: {"format": "ipv4"} => "<format: ipv4>");
-    t!(ipv6_format: {"format": "ipv6"} => "<format: ipv6>");
-    t!(iri_format: {"format": "iri"} => "<format: iri>");
-    t!(iri_reference_format: {"format": "iri-reference"} => "<format: iri-reference>");
-    t!(json_pointer_format: {"format": "json-pointer"} => "<format: json-pointer>");
-    t!(regex_format: {"format": "regex"} => "<format: regex>");
-    t!(relative_json_pointer_format: {"format": "relative-json-pointer"} => "<format: relative-json-pointer>");
-    t!(time_format: {"format": "time"} => "<format: time>");
-    t!(uri_format: {"format": "uri"} => "<format: uri>");
-    t!(uri_reference_format: {"format": "uri-reference"} => "<format: uri-reference>");
-    t!(uri_template_format: {"format": "uri-template"} => "<format: uri-template>");
 
-    fn load(path: &str) -> Value {
-        let full_path = format!("tests/suite/tests/draft7/{}", path);
-        let path = Path::new(&full_path);
-        let mut file = File::open(&path).unwrap();
-        let mut content = String::new();
-        file.read_to_string(&mut content).ok().unwrap();
-        let data: Value = from_str(&content).unwrap();
-        data
+    #[test_case(json!({"items": [{}], "additionalItems": {"type": "integer"}}), json!([ null, 2, 3, "foo" ]), r#"'"foo"' is not of type 'integer'"#)]
+    #[test_case(json!({"items": [{}, {}, {}], "additionalItems": false}), json!([ 1, 2, 3, 4 ]), r#"Additional items are not allowed (4 was unexpected)"#)]
+    #[test_case(json!({"items": [{}, {}, {}], "additionalItems": false}), json!([ 1, 2, 3, 4, 5 ]), r#"Additional items are not allowed (4, 5 were unexpected)"#)]
+    #[test_case(json!({"properties": {"foo": {}, "bar": {}}, "patternProperties": { "^v": {} }, "additionalProperties": false}), json!({"foo" : 1, "bar" : 2, "quux" : "boom"}), r#"False schema does not allow '"quux"'"#)]
+    #[test_case(json!({"anyOf": [{"type": "integer"}, {"minimum": 2}]}), json!(1.5), r#"'1.5' is not valid under any of the given schemas"#)]
+    #[test_case(json!({"const": 2}), json!(5), r#"'2' was expected"#)]
+    #[test_case(json!({"contains": {"minimum": 5}}), json!([2, 3, 4]), r#"None of '[2,3,4]' are valid under the given schema"#)]
+    #[test_case(json!({"enum": [1, 2, 3]}), json!(4), r#"'4' is not one of '[1,2,3]'"#)]
+    #[test_case(json!({"exclusiveMaximum": 3.0}), json!(3.0), r#"3.0 is greater than or equal to the maximum of 3"#)]
+    #[test_case(json!({"exclusiveMinimum": 1.1}), json!(1.1), r#"1.1 is less than or equal to the minimum of 1.1"#)]
+    #[test_case(json!({"format": "ipv4"}), json!("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), r#"'"2001:0db8:85a3:0000:0000:8a2e:0370:7334"' is not a 'ipv4'"#)]
+    #[test_case(json!({"maximum": 3.0}), json!(3.5), r#"3.5 is greater than the maximum of 3"#)]
+    #[test_case(json!({"maxItems": 2}), json!([1, 2, 3]), r#"[1,2,3] has more than 2 items"#)]
+    #[test_case(json!({"maxLength": 2}), json!("foo"), r#"'"foo"' is longer than 2 characters"#)]
+    #[test_case(json!({"maxProperties": 2}), json!({"foo": 1, "bar": 2, "baz": 3}), r#"{"bar":2,"baz":3,"foo":1} has more than 2 properties"#)]
+    #[test_case(json!({"minimum": 1.1}), json!(0.6), r#"0.6 is less than the minimum of 1.1"#)]
+    #[test_case(json!({"minItems": 1}), json!([]), r#"[] has less than 1 item"#)]
+    #[test_case(json!({"minLength": 2}), json!("f"), r#"'"f"' is shorter than 2 characters"#)]
+    #[test_case(json!({"minProperties": 1}), json!({}), r#"{} has less than 1 property"#)]
+    #[test_case(json!({"multipleOf": 2}), json!(7), r#"7 is not a multiple of 2"#)]
+    #[test_case(json!({"not": {"type": "integer"}}), json!(1), r#"{"type":"integer"} is not allowed for 1"#)]
+    #[test_case(json!({"oneOf": [{"type": "integer"}, {"minimum": 2}]}), json!(1.1), r#"'1.1' is not valid under any of the given schemas"#)]
+    #[test_case(json!({"oneOf": [{"type": "integer"}, {"minimum": 2}]}), json!(3), r#"'3' is valid under more than one of the given schemas"#)]
+    #[test_case(json!({"pattern": "^a*$"}), json!("abc"), r#"'"abc"' does not match '^a*$'"#)]
+    #[test_case(json!({"properties": {"foo": {}, "bar": {}}, "required": ["foo"]}), json!({"bar": 1}), r#"'foo' is a required property"#)]
+    #[test_case(json!({"type": "integer"}), json!(1.1), r#"'1.1' is not of type 'integer'"#)]
+    #[test_case(json!({"type": ["integer", "string"]}), json!(null), r#"'null' is not of types 'integer', 'string'"#)]
+    #[test_case(json!({"uniqueItems": true}), json!([1, 1]), r#"'[1,1]' has non-unique elements"#)]
+    fn error_message(schema: Value, instance: Value, expected: &str) {
+        let compiled = JSONSchema::compile(&schema, None).unwrap();
+        let errors: Vec<_> = compiled.validate(&instance).unwrap_err().collect();
+        assert_eq!(format!("{}", errors[0]), expected);
     }
 
-    macro_rules! e {
-        ($t:ident : $file:expr, $case:expr, $test_id:expr, $expected:expr) => {
-            #[test]
-            fn $t() {
-                let content = load($file);
-                let case = &content.as_array().unwrap()[$case];
-                let schema = case.get("schema").unwrap();
-                let instance = case.get("tests").unwrap().as_array().unwrap()[$test_id]
-                    .get("data")
-                    .unwrap();
-                let compiled = JSONSchema::compile(&schema, None).unwrap();
-                let errors: Vec<_> = compiled.validate(&instance).unwrap_err().collect();
-                assert_eq!(format!("{}", errors[0]), $expected);
-            }
-        };
+    // Extra cases not covered by JSON test suite
+    #[test_case(json!({"additionalProperties": {"type": "string"}}))]
+    #[test_case(json!({"additionalProperties": {"type": "string"}, "properties": {"foo": {}}}))]
+    #[test_case(json!({"additionalProperties": {"type": "string"}, "patternProperties": {"f.*o": {"type": "integer"}}}))]
+    #[test_case(json!({"additionalProperties": {"type": "string"}, "properties": {"foo": {}}, "patternProperties": {"f.*o": {"type": "integer"}}}))]
+    #[test_case(json!({"additionalProperties": false}))]
+    #[test_case(json!({"additionalProperties": false, "properties": {"foo": {}}}))]
+    #[test_case(json!({"additionalProperties": false, "patternProperties": {"f.*o": {"type": "integer"}}}))]
+    #[test_case(json!({"additionalProperties": false, "properties": {"foo": {}}, "patternProperties": {"f.*o": {"type": "integer"}}}))]
+    #[test_case(json!({"additionalItems": false, "items": [{"type": "string"}]}))]
+    #[test_case(json!({"additionalItems": {"type": "integer"}, "items": [{"type": "string"}]}))]
+    #[test_case(json!({"contains": {"minimum": 5}}))]
+    #[test_case(json!({"contentMediaType": "application/json"}))]
+    #[test_case(json!({"contentEncoding": "base64"}))]
+    #[test_case(json!({"contentEncoding": "base64", "contentMediaType": "application/json"}))]
+    #[test_case(json!({"dependencies": {"bar": ["foo"]}}))]
+    #[test_case(json!({"exclusiveMaximum": 5}))]
+    #[test_case(json!({"exclusiveMinimum": 5}))]
+    #[test_case(json!({"format": "ipv4"}))]
+    #[test_case(json!({"maximum": 2}))]
+    #[test_case(json!({"maxItems": 2}))]
+    #[test_case(json!({"maxProperties": 2}))]
+    #[test_case(json!({"minProperties": 2}))]
+    #[test_case(json!({"multipleOf": 2.5}))]
+    #[test_case(json!({"multipleOf": 2}))]
+    #[test_case(json!({"required": ["a"]}))]
+    #[test_case(json!({"pattern": "^a"}))]
+    #[test_case(json!({"patternProperties": {"f.*o": {"type": "integer"}}}))]
+    #[test_case(json!({"propertyNames": {"maxLength": 3}}))]
+    fn is_valid_another_type(schema: Value) {
+        let instance = json!(null);
+        let compiled = JSONSchema::compile(&schema, None).unwrap();
+        assert!(compiled.is_valid(&instance))
     }
-
-    e!(e1: "additionalItems.json", 0, 1, r#"'"foo"' is not of type 'integer'"#);
-    e!(e2: "additionalItems.json", 2, 2, r#"Additional items are not allowed (4 was unexpected)"#);
-    e!(e3: "additionalProperties.json", 0, 1, r#"False schema does not allow '"quux"'"#);
-    e!(e4: "const.json", 0, 1, r#"'2' was expected"#);
-    e!(e5: "contains.json", 0, 3, r#"None of '[2,3,4]' are valid under the given schema"#);
-    e!(e6: "enum.json", 0, 1, r#"'4' is not one of '[1,2,3]'"#);
-    e!(e7: "exclusiveMaximum.json", 0, 1, r#"3.0 is greater than or equal to the maximum of 3"#);
-    e!(e8: "exclusiveMinimum.json", 0, 1, r#"1.1 is less than or equal to the minimum of 1.1"#);
-    e!(e9: "maxItems.json", 0, 2, r#"[1,2,3] has more than 2 items"#);
-    e!(e10: "maxLength.json", 0, 2, r#"'"foo"' is longer than 2 characters"#);
-    e!(e11: "maxProperties.json", 0, 2, r#"{"bar":2,"baz":3,"foo":1} has more than 2 properties"#);
-    e!(e12: "minimum.json", 0, 2, r#"0.6 is less than the minimum of 1.1"#);
-    e!(e13: "minItems.json", 0, 2, r#"[] has less than 1 item"#);
-    e!(e14: "minLength.json", 0, 2, r#"'"f"' is shorter than 2 characters"#);
-    e!(e15: "minProperties.json", 0, 2, r#"{} has less than 1 property"#);
-    e!(e16: "multipleOf.json", 0, 1, r#"7 is not a multiple of 2"#);
-    e!(e17: "not.json", 0, 1, r#"{"type":"integer"} is not allowed for 1"#);
-    e!(e18: "pattern.json", 0, 1, r#"'"abc"' does not match '^a*$'"#);
-    e!(e19: "required.json", 0, 1, r#"'foo' is a required property"#);
-    e!(e20: "type.json", 0, 2, r#"'1.1' is not of type 'integer'"#);
-    e!(e21: "uniqueItems.json", 0, 1, r#"'[1,1]' has non-unique elements"#);
 }

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -59,7 +59,14 @@ impl Validate for MultipleTypesValidator {
     }
 
     fn name(&self) -> String {
-        format!("<type: {:?}>", self.types)
+        format!(
+            "<type: {}>",
+            self.types
+                .iter()
+                .map(|type_| format!("{}", type_))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 


### PR DESCRIPTION
Resolves #49

- Fixes various formatting issues in debug representation of validators.
- Removes `Draft3` since it is not supported (hope to add it before the next release)
- Fixes a bug in `draft_from_url` where URLs should have `#` in them


It covers mostly:
- debug representation 
- no-op branches where the checked instance has a type to which the validator is not applicable