### PR TITLE
Store instance in ValidationError

### DIFF
--- a/src/compilation.rs
+++ b/src/compilation.rs
@@ -1,10 +1,13 @@
 //! Schema compilation.
 //! The main idea is to compile the input JSON Schema to a validators tree that will contain
 //! everything needed to perform such validation in runtime.
-use crate::error::{CompilationError, ErrorIterator};
-use crate::keywords::Validators;
-use crate::resolver::Resolver;
-use crate::{keywords, schemas};
+use crate::{
+    error::{CompilationError, ErrorIterator},
+    keywords,
+    keywords::Validators,
+    resolver::Resolver,
+    schemas,
+};
 use serde_json::Value;
 use std::borrow::Cow;
 use url::{ParseError, Url};
@@ -166,10 +169,7 @@ mod tests {
     use super::*;
     use crate::error::ValidationError;
     use serde_json::*;
-    use std::borrow::Cow;
-    use std::fs::File;
-    use std::io::Read;
-    use std::path::Path;
+    use std::{borrow::Cow, fs::File, io::Read, path::Path};
     use url::Url;
 
     fn load(path: &str, idx: usize) -> Value {
@@ -237,8 +237,11 @@ mod tests {
         assert_eq!(errors.len(), 2);
         assert_eq!(
             format!("{}", errors[0]),
-            r#"{"a":3} does not have enough properties"#
+            r#"{"a":3} has less than 2 properties"#
         );
-        assert_eq!(format!("{}", errors[1]), r#"'a' is too short"#);
+        assert_eq!(
+            format!("{}", errors[1]),
+            r#"'"a"' is shorter than 3 characters"#
+        );
     }
 }

--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -1,7 +1,8 @@
-use super::boolean::TrueValidator;
-use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use super::{boolean::TrueValidator, CompilationResult, Validate, Validators};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct AdditionalItemsObjectValidator {
@@ -72,7 +73,10 @@ impl Validate for AdditionalItemsBooleanValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
             if items.len() > self.items_count {
-                return ValidationError::additional_items(items.clone(), self.items_count);
+                return error(ValidationError::additional_items(
+                    instance,
+                    self.items_count,
+                ));
             }
         }
         no_error()

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use regex::Regex;
 use serde_json::{Map, Value};
 
@@ -58,7 +60,7 @@ impl Validate for AdditionalPropertiesFalseValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
             if let Some((_, value)) = item.iter().next() {
-                return ValidationError::false_schema(value.clone());
+                return error(ValidationError::false_schema(value));
             }
         }
         no_error()
@@ -97,7 +99,9 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
             for property in item.keys() {
                 if !self.properties.contains_key(property) {
                     // No extra properties are allowed
-                    return ValidationError::false_schema(Value::String(property.to_string()));
+                    return error(ValidationError::false_schema(&Value::String(
+                        property.to_string(),
+                    )));
                 }
             }
         }
@@ -243,7 +247,9 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
         if let Value::Object(item) = instance {
             for (property, _) in item {
                 if !self.pattern.is_match(property) {
-                    return ValidationError::false_schema(Value::String(property.to_string()));
+                    return error(ValidationError::false_schema(&Value::String(
+                        property.to_string(),
+                    )));
                 }
             }
         }
@@ -354,7 +360,9 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
         if let Value::Object(item) = instance {
             for property in item.keys() {
                 if !self.properties.contains_key(property) && !self.pattern.is_match(property) {
-                    return ValidationError::false_schema(Value::String(property.to_string()));
+                    return error(ValidationError::false_schema(&Value::String(
+                        property.to_string(),
+                    )));
                 }
             }
         }

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -99,9 +99,8 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
             for property in item.keys() {
                 if !self.properties.contains_key(property) {
                     // No extra properties are allowed
-                    return error(ValidationError::false_schema(&Value::String(
-                        property.to_string(),
-                    )));
+                    let property_value = Value::String(property.to_string());
+                    return error(ValidationError::false_schema(&property_value).into_owned());
                 }
             }
         }
@@ -247,9 +246,8 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
         if let Value::Object(item) = instance {
             for (property, _) in item {
                 if !self.pattern.is_match(property) {
-                    return error(ValidationError::false_schema(&Value::String(
-                        property.to_string(),
-                    )));
+                    let property_value = Value::String(property.to_string());
+                    return error(ValidationError::false_schema(&property_value).into_owned());
                 }
             }
         }
@@ -360,9 +358,8 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
         if let Value::Object(item) = instance {
             for property in item.keys() {
                 if !self.properties.contains_key(property) && !self.pattern.is_match(property) {
-                    return error(ValidationError::false_schema(&Value::String(
-                        property.to_string(),
-                    )));
+                    let property_value = Value::String(property.to_string());
+                    return error(ValidationError::false_schema(&property_value).into_owned());
                 }
             }
         }

--- a/src/keywords/all_of.rs
+++ b/src/keywords/all_of.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{CompilationError, ErrorIterator};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{CompilationError, ErrorIterator},
+};
 use serde_json::{Map, Value};
 
 pub struct AllOfValidator {

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct AnyOfValidator {
@@ -28,7 +30,7 @@ impl Validate for AnyOfValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            return ValidationError::any_of(instance.clone());
+            return error(ValidationError::any_of(instance));
         }
     }
 

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -25,10 +25,11 @@ impl AnyOfValidator {
 
 impl Validate for AnyOfValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
             return ValidationError::any_of(instance.clone());
         }
-        no_error()
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/boolean.rs
+++ b/src/keywords/boolean.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::JSONSchema;
-use crate::error::{no_error, ErrorIterator, ValidationError};
+use crate::{
+    compilation::JSONSchema,
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
 use serde_json::Value;
 
 pub struct TrueValidator {}
@@ -35,7 +37,7 @@ impl FalseValidator {
 
 impl Validate for FalseValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        ValidationError::false_schema(instance.clone())
+        error(ValidationError::false_schema(instance))
     }
 
     fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -1,17 +1,17 @@
 use super::{helpers, CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct ConstValidator {
-    error_message: String,
     value: Value,
 }
 
 impl ConstValidator {
     pub(crate) fn compile(value: &Value) -> CompilationResult {
         Ok(Box::new(ConstValidator {
-            error_message: format!("'{}' was expected", value),
             value: value.clone(),
         }))
     }
@@ -22,7 +22,7 @@ impl Validate for ConstValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::constant(self.error_message.clone())
+            error(ValidationError::constant(instance, &self.value))
         }
     }
 

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -19,10 +19,11 @@ impl ConstValidator {
 
 impl Validate for ConstValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::constant(self.error_message.clone());
-        };
-        no_error()
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::constant(self.error_message.clone())
+        }
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct ContainsValidator {
@@ -27,7 +29,7 @@ impl Validate for ContainsValidator {
                     return no_error();
                 }
             }
-            return ValidationError::contains(instance.clone());
+            return error(ValidationError::contains(instance));
         }
         no_error()
     }

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -88,7 +88,7 @@ pub struct ContentMediaTypeAndEncodingValidator {
     media_type: String,
     encoding: String,
     func: for<'a> fn(&'a Value, &str) -> ErrorIterator<'a>,
-    converter: fn(&Value, &str) -> Result<String, ValidationError>,
+    converter: for<'a> fn(&'a Value, &str) -> Result<String, ValidationError<'a>>,
 }
 
 impl ContentMediaTypeAndEncodingValidator {
@@ -96,7 +96,7 @@ impl ContentMediaTypeAndEncodingValidator {
         media_type: &str,
         encoding: &str,
         func: for<'a> fn(&'a Value, &str) -> ErrorIterator<'a>,
-        converter: fn(&Value, &str) -> Result<String, ValidationError>,
+        converter: for<'a> fn(&'a Value, &str) -> Result<String, ValidationError<'a>>,
     ) -> CompilationResult {
         Ok(Box::new(ContentMediaTypeAndEncodingValidator {
             media_type: media_type.to_string(),
@@ -159,10 +159,10 @@ pub(crate) fn is_base64<'a>(instance: &'a Value, instance_string: &str) -> Error
     no_error()
 }
 
-pub(crate) fn from_base64(
-    instance: &Value,
+pub(crate) fn from_base64<'a>(
+    instance: &'a Value,
     instance_string: &str,
-) -> Result<String, ValidationError> {
+) -> Result<String, ValidationError<'a>> {
     match base64::decode(instance_string) {
         Ok(value) => Ok(String::from_utf8(value)?),
         Err(_) => Err(ValidationError::format(instance, "base64".to_string())),

--- a/src/keywords/dependencies.rs
+++ b/src/keywords/dependencies.rs
@@ -1,7 +1,9 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator};
-use crate::keywords::required::RequiredValidator;
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{no_error, CompilationError, ErrorIterator},
+    keywords::required::RequiredValidator,
+};
 use serde_json::{Map, Value};
 
 pub struct DependenciesValidator {

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -1,6 +1,8 @@
 use super::{helpers, CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct EnumValidator {
@@ -23,7 +25,7 @@ impl EnumValidator {
 impl Validate for EnumValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if !self.is_valid(schema, instance) {
-            return ValidationError::enumeration(instance.clone(), self.options.clone());
+            return error(ValidationError::enumeration(instance, &self.options));
         }
         no_error()
     }

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct ExclusiveMaximumValidator {
@@ -23,7 +25,7 @@ impl Validate for ExclusiveMaximumValidator {
         if let Value::Number(item) = instance {
             let item = item.as_f64().unwrap();
             if item >= self.limit {
-                return ValidationError::exclusive_maximum(item, self.limit);
+                return error(ValidationError::exclusive_maximum(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct ExclusiveMinimumValidator {
@@ -22,7 +24,7 @@ impl Validate for ExclusiveMinimumValidator {
         if let Value::Number(item) = instance {
             let item = item.as_f64().unwrap();
             if item <= self.limit {
-                return ValidationError::exclusive_minimum(item, self.limit);
+                return error(ValidationError::exclusive_minimum(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -1,7 +1,9 @@
 //! Validator for `format` keyword.
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{error, no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct FormatValidator {
@@ -22,10 +24,7 @@ impl Validate for FormatValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if !(self.check)(item) {
-                return error(ValidationError::format(
-                    item.to_owned(),
-                    self.format.clone(),
-                ));
+                return error(ValidationError::format(instance, self.format.clone()));
             }
         }
         no_error()
@@ -46,8 +45,7 @@ impl Validate for FormatValidator {
 mod checks {
     use chrono::{DateTime, NaiveDate};
     use regex::Regex;
-    use std::net::IpAddr;
-    use std::str::FromStr;
+    use std::{net::IpAddr, str::FromStr};
     use url::Url;
     lazy_static! {
         static ref IRI_REFERENCE_RE: Regex =

--- a/src/keywords/if_.rs
+++ b/src/keywords/if_.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, ErrorIterator};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{no_error, ErrorIterator},
+};
 use serde_json::{Map, Value};
 
 pub struct IfThenValidator {

--- a/src/keywords/items.rs
+++ b/src/keywords/items.rs
@@ -1,7 +1,8 @@
-use super::boolean::TrueValidator;
-use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, ErrorIterator};
+use super::{boolean::TrueValidator, CompilationResult, Validate, Validators};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{no_error, ErrorIterator},
+};
 use rayon::prelude::*;
 use serde_json::{Map, Value};
 

--- a/src/keywords/legacy/maximum_draft_4.rs
+++ b/src/keywords/legacy/maximum_draft_4.rs
@@ -1,5 +1,4 @@
-use super::super::CompilationResult;
-use super::super::{exclusive_maximum, maximum};
+use super::super::{exclusive_maximum, maximum, CompilationResult};
 use crate::compilation::CompilationContext;
 use serde_json::{Map, Value};
 

--- a/src/keywords/legacy/minimum_draft_4.rs
+++ b/src/keywords/legacy/minimum_draft_4.rs
@@ -1,5 +1,4 @@
-use super::super::CompilationResult;
-use super::super::{exclusive_minimum, minimum};
+use super::super::{exclusive_minimum, minimum, CompilationResult};
 use crate::compilation::CompilationContext;
 use serde_json::{Map, Value};
 

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -1,6 +1,8 @@
 use super::super::{type_, CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, PrimitiveType, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, PrimitiveType, ValidationError},
+};
 use serde_json::{Map, Number, Value};
 
 pub struct MultipleTypesValidator {
@@ -34,7 +36,10 @@ impl Validate for MultipleTypesValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::multiple_type_error(instance.clone(), self.types.clone())
+            error(ValidationError::multiple_type_error(
+                instance,
+                self.types.clone(),
+            ))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -71,7 +76,10 @@ impl Validate for IntegerTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Integer)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Integer,
+            ))
         }
     }
 

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -31,10 +31,11 @@ impl MultipleTypesValidator {
 
 impl Validate for MultipleTypesValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::multiple_type_error(instance.clone(), self.types.clone());
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::multiple_type_error(instance.clone(), self.types.clone())
         }
-        no_error()
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         for type_ in self.types.iter() {
@@ -67,10 +68,11 @@ impl IntegerTypeValidator {
 
 impl Validate for IntegerTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Integer);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Integer)
         }
-        no_error()
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MaxItemsValidator {
@@ -21,7 +23,7 @@ impl Validate for MaxItemsValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
             if items.len() > self.limit {
-                return ValidationError::max_items(instance.clone());
+                return error(ValidationError::max_items(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MaxLengthValidator {
@@ -21,7 +23,7 @@ impl Validate for MaxLengthValidator {
     fn validate<'a>(&self, _schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if item.chars().count() > self.limit {
-                return ValidationError::max_length(item.clone());
+                return error(ValidationError::max_length(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MaxPropertiesValidator {
@@ -21,7 +23,7 @@ impl Validate for MaxPropertiesValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
             if item.len() > self.limit {
-                return ValidationError::max_properties(instance.clone());
+                return error(ValidationError::max_properties(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MaximumValidator {
@@ -22,7 +24,7 @@ impl Validate for MaximumValidator {
         if let Value::Number(item) = instance {
             let item = item.as_f64().unwrap();
             if item > self.limit {
-                return ValidationError::maximum(item, self.limit);
+                return error(ValidationError::maximum(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MinItemsValidator {
@@ -21,7 +23,7 @@ impl Validate for MinItemsValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
             if items.len() < self.limit {
-                return ValidationError::min_items(instance.clone());
+                return error(ValidationError::min_items(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MinLengthValidator {
@@ -21,7 +23,7 @@ impl Validate for MinLengthValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if item.chars().count() < self.limit {
-                return ValidationError::min_length(item.clone());
+                return error(ValidationError::min_length(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MinPropertiesValidator {
@@ -21,7 +23,7 @@ impl Validate for MinPropertiesValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
             if item.len() < self.limit {
-                return ValidationError::min_properties(instance.clone());
+                return error(ValidationError::min_properties(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct MinimumValidator {
@@ -22,7 +24,7 @@ impl Validate for MinimumValidator {
         if let Value::Number(item) = instance {
             let item = item.as_f64().unwrap();
             if item < self.limit {
-                return ValidationError::minimum(item, self.limit);
+                return error(ValidationError::minimum(instance, self.limit));
             }
         }
         no_error()

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -34,9 +34,7 @@ pub(crate) mod ref_;
 pub(crate) mod required;
 pub(crate) mod type_;
 pub(crate) mod unique_items;
-use crate::compilation::JSONSchema;
-use crate::error;
-use crate::error::ErrorIterator;
+use crate::{compilation::JSONSchema, error, error::ErrorIterator};
 use serde_json::Value;
 use std::fmt::{Debug, Error, Formatter};
 
@@ -65,9 +63,7 @@ pub type Validators = Vec<BoxedValidator>;
 mod tests {
     use super::JSONSchema;
     use serde_json::{from_str, json, Value};
-    use std::fs::File;
-    use std::io::Read;
-    use std::path::Path;
+    use std::{fs::File, io::Read, path::Path};
 
     macro_rules! t {
         ($t:ident : $schema:tt => $expected:expr) => {
@@ -133,18 +129,18 @@ mod tests {
     e!(e4: "const.json", 0, 1, r#"'2' was expected"#);
     e!(e5: "contains.json", 0, 3, r#"None of '[2,3,4]' are valid under the given schema"#);
     e!(e6: "enum.json", 0, 1, r#"'4' is not one of '[1,2,3]'"#);
-    e!(e7: "exclusiveMaximum.json", 0, 1, r#"3 is greater than or equal to the maximum of 3"#);
+    e!(e7: "exclusiveMaximum.json", 0, 1, r#"3.0 is greater than or equal to the maximum of 3"#);
     e!(e8: "exclusiveMinimum.json", 0, 1, r#"1.1 is less than or equal to the minimum of 1.1"#);
-    e!(e9: "maxItems.json", 0, 2, r#"[1,2,3] is too long"#);
-    e!(e10: "maxLength.json", 0, 2, r#"'foo' is too long"#);
-    e!(e11: "maxProperties.json", 0, 2, r#"{"bar":2,"baz":3,"foo":1} has too many properties"#);
+    e!(e9: "maxItems.json", 0, 2, r#"[1,2,3] has more than 2 items"#);
+    e!(e10: "maxLength.json", 0, 2, r#"'"foo"' is longer than 2 characters"#);
+    e!(e11: "maxProperties.json", 0, 2, r#"{"bar":2,"baz":3,"foo":1} has more than 2 properties"#);
     e!(e12: "minimum.json", 0, 2, r#"0.6 is less than the minimum of 1.1"#);
-    e!(e13: "minItems.json", 0, 2, r#"[] is too short"#);
-    e!(e14: "minLength.json", 0, 2, r#"'f' is too short"#);
-    e!(e15: "minProperties.json", 0, 2, r#"{} does not have enough properties"#);
+    e!(e13: "minItems.json", 0, 2, r#"[] has less than 1 item"#);
+    e!(e14: "minLength.json", 0, 2, r#"'"f"' is shorter than 2 characters"#);
+    e!(e15: "minProperties.json", 0, 2, r#"{} has less than 1 property"#);
     e!(e16: "multipleOf.json", 0, 1, r#"7 is not a multiple of 2"#);
     e!(e17: "not.json", 0, 1, r#"{"type":"integer"} is not allowed for 1"#);
-    e!(e18: "pattern.json", 0, 1, r#"'abc' does not match '^a*$'"#);
+    e!(e18: "pattern.json", 0, 1, r#"'"abc"' does not match '^a*$'"#);
     e!(e19: "required.json", 0, 1, r#"'foo' is a required property"#);
     e!(e20: "type.json", 0, 2, r#"'1.1' is not of type 'integer'"#);
     e!(e21: "uniqueItems.json", 0, 1, r#"'[1,1]' has non-unique elements"#);

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 use std::f64::EPSILON;
 
@@ -20,7 +22,7 @@ impl Validate for MultipleOfFloatValidator {
             let item = item.as_f64().unwrap();
             let remainder = (item / self.multiple_of) % 1.;
             if !(remainder < EPSILON && remainder < (1. - EPSILON)) {
-                return ValidationError::multiple_of(item, self.multiple_of);
+                return error(ValidationError::multiple_of(instance, self.multiple_of));
             }
         }
         no_error()
@@ -63,7 +65,7 @@ impl Validate for MultipleOfIntegerValidator {
                 remainder < EPSILON && remainder < (1. - EPSILON)
             };
             if !is_multiple {
-                return ValidationError::multiple_of(item, self.multiple_of);
+                return error(ValidationError::multiple_of(instance, self.multiple_of));
             }
         }
         no_error()

--- a/src/keywords/not.rs
+++ b/src/keywords/not.rs
@@ -20,10 +20,10 @@ impl NotValidator {
 
 impl Validate for NotValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            ValidationError::not(instance.clone(), self.original.clone())
-        } else {
+        if self.is_valid(schema, instance) {
             no_error()
+        } else {
+            ValidationError::not(instance.clone(), self.original.clone())
         }
     }
 

--- a/src/keywords/not.rs
+++ b/src/keywords/not.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct NotValidator {
@@ -23,7 +25,7 @@ impl Validate for NotValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::not(instance.clone(), self.original.clone())
+            error(ValidationError::not(instance, self.original.clone()))
         }
     }
 

--- a/src/keywords/one_of.rs
+++ b/src/keywords/one_of.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct OneOfValidator {
@@ -58,10 +60,10 @@ impl Validate for OneOfValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         let (first_valid, first_valid_idx) = self.get_first_valid(schema, instance);
         if first_valid.is_none() {
-            return ValidationError::one_of_not_valid(instance.clone());
+            return error(ValidationError::one_of_not_valid(instance));
         }
         if self.are_others_valid(schema, instance, first_valid_idx) {
-            return ValidationError::one_of_multiple_valid(instance.clone());
+            return error(ValidationError::one_of_multiple_valid(instance));
         }
         no_error()
     }

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use regex::{Captures, Regex};
 use serde_json::{Map, Value};
 
@@ -34,7 +36,7 @@ impl Validate for PatternValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if !self.pattern.is_match(item) {
-                return ValidationError::pattern(item.clone(), self.original.clone());
+                return error(ValidationError::pattern(instance, self.original.clone()));
             }
         }
         no_error()

--- a/src/keywords/pattern_properties.rs
+++ b/src/keywords/pattern_properties.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{no_error, CompilationError, ErrorIterator},
+};
 use regex::Regex;
 use serde_json::{Map, Value};
 

--- a/src/keywords/properties.rs
+++ b/src/keywords/properties.rs
@@ -1,7 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::CompilationContext;
-use crate::compilation::{compile_validators, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{no_error, CompilationError, ErrorIterator},
+};
 use serde_json::{Map, Value};
 
 pub struct PropertiesValidator {

--- a/src/keywords/property_names.rs
+++ b/src/keywords/property_names.rs
@@ -62,10 +62,11 @@ impl PropertyNamesBooleanValidator {
 
 impl Validate for PropertyNamesBooleanValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::false_schema(instance.clone());
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::false_schema(instance.clone())
         }
-        no_error()
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/property_names.rs
+++ b/src/keywords/property_names.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate, Validators};
-use crate::compilation::{compile_validators, CompilationContext, JSONSchema};
-use crate::error::{no_error, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 use std::borrow::Borrow;
 
@@ -65,7 +67,7 @@ impl Validate for PropertyNamesBooleanValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::false_schema(instance.clone())
+            error(ValidationError::false_schema(instance))
         }
     }
 

--- a/src/keywords/property_names.rs
+++ b/src/keywords/property_names.rs
@@ -27,7 +27,10 @@ impl Validate for PropertyNamesObjectValidator {
                 .flat_map(move |validator| {
                     item.keys().flat_map(move |key| {
                         let wrapper = Value::String(key.to_string());
-                        let errors: Vec<_> = validator.validate(schema, &wrapper).collect();
+                        let errors: Vec<_> = validator
+                            .validate(schema, &wrapper)
+                            .map(|validation_error| validation_error.into_owned())
+                            .collect();
                         errors.into_iter()
                     })
                 })

--- a/src/keywords/ref_.rs
+++ b/src/keywords/ref_.rs
@@ -1,7 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::CompilationContext;
-use crate::compilation::{compile_validators, JSONSchema};
-use crate::error::{error, ErrorIterator};
+use crate::{
+    compilation::{compile_validators, CompilationContext, JSONSchema},
+    error::{error, ErrorIterator},
+};
 use serde_json::Value;
 use url::Url;
 

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
 
 pub struct RequiredValidator {
@@ -30,7 +32,7 @@ impl Validate for RequiredValidator {
         if let Value::Object(item) = instance {
             for property_name in self.required.iter() {
                 if !item.contains_key(property_name) {
-                    return ValidationError::required(property_name.clone());
+                    return error(ValidationError::required(instance, property_name.clone()));
                 }
             }
         }

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -31,10 +31,11 @@ impl MultipleTypesValidator {
 
 impl Validate for MultipleTypesValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::multiple_type_error(instance.clone(), self.types.clone());
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::multiple_type_error(instance.clone(), self.types.clone())
         }
-        no_error()
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         for type_ in self.types.iter() {
@@ -67,10 +68,11 @@ impl NullTypeValidator {
 
 impl Validate for NullTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Null);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Null)
         }
-        no_error()
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_null()
@@ -91,10 +93,11 @@ impl BooleanTypeValidator {
 
 impl Validate for BooleanTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Boolean);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Boolean)
         }
-        no_error()
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_boolean()
@@ -115,10 +118,11 @@ impl StringTypeValidator {
 
 impl Validate for StringTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::String);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::String)
         }
-        no_error()
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -140,10 +144,11 @@ impl ArrayTypeValidator {
 
 impl Validate for ArrayTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Array);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Array)
         }
-        no_error()
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -165,10 +170,11 @@ impl ObjectTypeValidator {
 
 impl Validate for ObjectTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Object);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Object)
         }
-        no_error()
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_object()
@@ -189,10 +195,11 @@ impl NumberTypeValidator {
 
 impl Validate for NumberTypeValidator {
     fn validate<'a>(&self, config: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(config, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Number);
+        if self.is_valid(config, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Number)
         }
-        no_error()
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_number()
@@ -213,10 +220,11 @@ impl IntegerTypeValidator {
 
 impl Validate for IntegerTypeValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::single_type_error(instance.clone(), PrimitiveType::Integer);
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::single_type_error(instance.clone(), PrimitiveType::Integer)
         }
-        no_error()
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -1,6 +1,8 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::{CompilationContext, JSONSchema};
-use crate::error::{no_error, CompilationError, ErrorIterator, PrimitiveType, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, CompilationError, ErrorIterator, PrimitiveType, ValidationError},
+};
 use serde_json::{Map, Number, Value};
 
 pub struct MultipleTypesValidator {
@@ -34,7 +36,10 @@ impl Validate for MultipleTypesValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::multiple_type_error(instance.clone(), self.types.clone())
+            error(ValidationError::multiple_type_error(
+                instance,
+                self.types.clone(),
+            ))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -71,7 +76,10 @@ impl Validate for NullTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Null)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Null,
+            ))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -96,7 +104,10 @@ impl Validate for BooleanTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Boolean)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Boolean,
+            ))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -121,7 +132,10 @@ impl Validate for StringTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::String)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::String,
+            ))
         }
     }
 
@@ -147,7 +161,10 @@ impl Validate for ArrayTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Array)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Array,
+            ))
         }
     }
 
@@ -173,7 +190,10 @@ impl Validate for ObjectTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Object)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Object,
+            ))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -198,7 +218,10 @@ impl Validate for NumberTypeValidator {
         if self.is_valid(config, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Number)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Number,
+            ))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -223,7 +246,10 @@ impl Validate for IntegerTypeValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::single_type_error(instance.clone(), PrimitiveType::Integer)
+            error(ValidationError::single_type_error(
+                instance,
+                PrimitiveType::Integer,
+            ))
         }
     }
 

--- a/src/keywords/unique_items.rs
+++ b/src/keywords/unique_items.rs
@@ -65,10 +65,11 @@ impl UniqueItemsValidator {
 
 impl Validate for UniqueItemsValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return ValidationError::unique_items(instance.clone());
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            ValidationError::unique_items(instance.clone())
         }
-        no_error()
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/unique_items.rs
+++ b/src/keywords/unique_items.rs
@@ -1,11 +1,13 @@
 use super::{CompilationResult, Validate};
-use crate::compilation::CompilationContext;
-use crate::compilation::JSONSchema;
-use crate::error::{no_error, ErrorIterator, ValidationError};
+use crate::{
+    compilation::{CompilationContext, JSONSchema},
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
 use serde_json::{Map, Value};
-use std::collections::hash_map::DefaultHasher;
-use std::collections::HashSet;
-use std::hash::{Hash, Hasher};
+use std::{
+    collections::{hash_map::DefaultHasher, HashSet},
+    hash::{Hash, Hasher},
+};
 
 // Based on implementation proposed by Sven Marnach:
 // https://stackoverflow.com/questions/60882381/what-is-the-fastest-correct-way-to-detect-that-there-are-no-duplicates-in-a-json
@@ -68,7 +70,7 @@ impl Validate for UniqueItemsValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            ValidationError::unique_items(instance.clone())
+            error(ValidationError::unique_items(instance))
         }
     }
 

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,11 +1,12 @@
 //! Reference resolver. Implements logic, required by `$ref` keyword.
 //! Is able to load documents from remote locations via HTTP(S).
-use crate::compilation::DEFAULT_ROOT_URL;
-use crate::error::{CompilationError, ValidationError};
-use crate::schemas::{id_of, Draft};
+use crate::{
+    compilation::DEFAULT_ROOT_URL,
+    error::{CompilationError, ValidationError},
+    schemas::{id_of, Draft},
+};
 use serde_json::Value;
-use std::borrow::Cow;
-use std::collections::HashMap;
+use std::{borrow::Cow, collections::HashMap};
 use url::Url;
 
 pub(crate) struct Resolver<'a> {
@@ -207,10 +208,7 @@ fn parse_index(s: &str) -> Option<usize> {
 mod tests {
     use super::*;
     use serde_json::*;
-    use std::borrow::Cow;
-    use std::fs::File;
-    use std::io::Read;
-    use std::path::Path;
+    use std::{borrow::Cow, fs::File, io::Read, path::Path};
     use url::Url;
 
     fn load(path: &str, idx: usize) -> Value {

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1,5 +1,4 @@
-use crate::compilation::CompilationContext;
-use crate::keywords;
+use crate::{compilation::CompilationContext, keywords};
 use serde_json::{Map, Value};
 
 #[derive(Debug, PartialEq, Copy, Clone)]


### PR DESCRIPTION
The goal of this PR is to unify the content of all the possible `ValidationError` instances.
In order to do so:
 * instance is always stored into `ValidationError` and not in `ValidationErrorKind`
 * `ValidationErrorKind` contains only the details of the specific kind of error (and all are structs instead of mixture of struct/tuples)
 * `ValidationError` stores a `CoW` instance of the instance in order to reduce the amount of `Clone::clone` invocations

The idea, in the long run, would be to ensure that `ValidationError` stores only references to the instance that caused the validation error by always avoiding cloning them (this will have memory and runtime benefits).
Not doing it in this PR due to PR size (`ValidationError::into_owned` should ideally be removed)