### PR TITLE
Use serde_json APIs instead relying on value enum

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,7 @@
 use serde_json::Value;
 use std::{
     borrow::Cow,
+    convert::TryFrom,
     error, fmt,
     fmt::{Error, Formatter},
     io,
@@ -128,6 +129,23 @@ pub enum PrimitiveType {
     Array,
     Object,
     Number,
+}
+
+impl TryFrom<&str> for PrimitiveType {
+    type Error = ();
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "integer" => Ok(PrimitiveType::Integer),
+            "null" => Ok(PrimitiveType::Null),
+            "boolean" => Ok(PrimitiveType::Boolean),
+            "string" => Ok(PrimitiveType::String),
+            "array" => Ok(PrimitiveType::Array),
+            "object" => Ok(PrimitiveType::Object),
+            "number" => Ok(PrimitiveType::Number),
+            _ => Err(()),
+        }
+    }
 }
 
 impl fmt::Display for PrimitiveType {

--- a/src/error.rs
+++ b/src/error.rs
@@ -47,7 +47,7 @@ pub(crate) fn no_error<'a>() -> ErrorIterator<'a> {
     Box::new(empty())
 }
 // A wrapper for one error
-pub(crate) fn error<'a>(instance: ValidationError<'a>) -> ErrorIterator<'a> {
+pub(crate) fn error(instance: ValidationError) -> ErrorIterator {
     Box::new(once(instance))
 }
 
@@ -120,7 +120,7 @@ pub enum ValidationErrorKind {
 
 /// For faster error handling in "type" keyword validator we have this enum, to match
 /// with it instead of a string.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum PrimitiveType {
     Integer,
     Null,
@@ -144,6 +144,26 @@ impl TryFrom<&str> for PrimitiveType {
             "object" => Ok(PrimitiveType::Object),
             "number" => Ok(PrimitiveType::Number),
             _ => Err(()),
+        }
+    }
+}
+
+impl From<&Value> for PrimitiveType {
+    fn from(value: &Value) -> Self {
+        if value.is_array() {
+            PrimitiveType::Array
+        } else if value.is_boolean() {
+            PrimitiveType::Boolean
+        } else if value.is_null() {
+            PrimitiveType::Null
+        } else if value.is_object() {
+            PrimitiveType::Object
+        } else if value.is_string() {
+            PrimitiveType::String
+        } else if value.is_u64() || value.is_i64() {
+            PrimitiveType::Integer
+        } else {
+            PrimitiveType::Number
         }
     }
 }
@@ -231,7 +251,7 @@ impl<'a> ValidationError<'a> {
     }
     pub(crate) fn file_not_found(error: io::Error) -> ValidationError<'a> {
         ValidationError {
-            instance: Cow::Owned(Value::Null),
+            instance: Cow::Owned(Value::default()),
             kind: ValidationErrorKind::FileNotFound { error },
         }
     }
@@ -243,19 +263,19 @@ impl<'a> ValidationError<'a> {
     }
     pub(crate) fn from_utf8(error: FromUtf8Error) -> ValidationError<'a> {
         ValidationError {
-            instance: Cow::Owned(Value::Null),
+            instance: Cow::Owned(Value::default()),
             kind: ValidationErrorKind::FromUtf8 { error },
         }
     }
     pub(crate) fn json_parse(error: serde_json::Error) -> ValidationError<'a> {
         ValidationError {
-            instance: Cow::Owned(Value::Null),
+            instance: Cow::Owned(Value::default()),
             kind: ValidationErrorKind::JSONParse { error },
         }
     }
     pub(crate) fn invalid_reference(reference: String) -> ValidationError<'a> {
         ValidationError {
-            instance: Cow::Owned(Value::Null),
+            instance: Cow::Owned(Value::default()),
             kind: ValidationErrorKind::InvalidReference { reference },
         }
     }
@@ -345,7 +365,7 @@ impl<'a> ValidationError<'a> {
     }
     pub(crate) fn schema() -> ValidationError<'a> {
         ValidationError {
-            instance: Cow::Owned(Value::Null),
+            instance: Cow::Owned(Value::default()),
             kind: ValidationErrorKind::Schema,
         }
     }
@@ -379,7 +399,7 @@ impl<'a> ValidationError<'a> {
     }
     pub(crate) fn unknown_reference_scheme(scheme: String) -> ValidationError<'a> {
         ValidationError {
-            instance: Cow::Owned(Value::Null),
+            instance: Cow::Owned(Value::default()),
             kind: ValidationErrorKind::UnknownReferenceScheme { scheme },
         }
     }

--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -27,7 +27,7 @@ impl AdditionalItemsObjectValidator {
     }
 }
 
-impl<'a> AdditionalItemsBooleanValidator {
+impl AdditionalItemsBooleanValidator {
     pub(crate) fn compile(items_count: usize) -> CompilationResult {
         Ok(Box::new(AdditionalItemsBooleanValidator { items_count }))
     }

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -50,7 +50,7 @@ impl Validate for AdditionalPropertiesValidator {
 }
 pub struct AdditionalPropertiesFalseValidator {}
 
-impl<'a> AdditionalPropertiesFalseValidator {
+impl AdditionalPropertiesFalseValidator {
     pub(crate) fn compile() -> CompilationResult {
         Ok(Box::new(AdditionalPropertiesFalseValidator {}))
     }
@@ -233,7 +233,7 @@ pub struct AdditionalPropertiesWithPatternsFalseValidator {
     pattern: Regex,
 }
 
-impl<'a> AdditionalPropertiesWithPatternsFalseValidator {
+impl AdditionalPropertiesWithPatternsFalseValidator {
     pub(crate) fn compile(pattern: Regex) -> CompilationResult {
         Ok(Box::new(AdditionalPropertiesWithPatternsFalseValidator {
             pattern,

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -20,7 +20,7 @@ impl AdditionalPropertiesValidator {
 
 impl Validate for AdditionalPropertiesValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             let errors: Vec<_> = self
                 .validators
                 .iter()
@@ -35,7 +35,7 @@ impl Validate for AdditionalPropertiesValidator {
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             return self.validators.iter().all(move |validator| {
                 item.values()
                     .all(move |value| validator.is_valid(schema, value))
@@ -58,7 +58,7 @@ impl<'a> AdditionalPropertiesFalseValidator {
 
 impl Validate for AdditionalPropertiesFalseValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             if let Some((_, value)) = item.iter().next() {
                 return error(ValidationError::false_schema(value));
             }
@@ -67,7 +67,7 @@ impl Validate for AdditionalPropertiesFalseValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             return item.iter().next().is_some();
         }
         true
@@ -84,7 +84,7 @@ pub struct AdditionalPropertiesNotEmptyFalseValidator {
 
 impl AdditionalPropertiesNotEmptyFalseValidator {
     pub(crate) fn compile(properties: &Value) -> CompilationResult {
-        if let Value::Object(properties) = properties {
+        if let Some(properties) = properties.as_object() {
             return Ok(Box::new(AdditionalPropertiesNotEmptyFalseValidator {
                 properties: properties.clone(),
             }));
@@ -95,7 +95,7 @@ impl AdditionalPropertiesNotEmptyFalseValidator {
 
 impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             for property in item.keys() {
                 if !self.properties.contains_key(property) {
                     // No extra properties are allowed
@@ -108,7 +108,7 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             for property in item.keys() {
                 if !self.properties.contains_key(property) {
                     // No extra properties are allowed
@@ -135,7 +135,7 @@ impl AdditionalPropertiesNotEmptyValidator {
         properties: &Value,
         context: &CompilationContext,
     ) -> CompilationResult {
-        if let Value::Object(properties) = properties {
+        if let Some(properties) = properties.as_object() {
             return Ok(Box::new(AdditionalPropertiesNotEmptyValidator {
                 properties: properties.clone(),
                 validators: compile_validators(schema, context)?,
@@ -147,7 +147,7 @@ impl AdditionalPropertiesNotEmptyValidator {
 
 impl Validate for AdditionalPropertiesNotEmptyValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(ref item) = instance {
+        if let Some(ref item) = instance.as_object() {
             let errors: Vec<_> = self
                 .validators
                 .iter()
@@ -163,7 +163,7 @@ impl Validate for AdditionalPropertiesNotEmptyValidator {
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(ref item) = instance {
+        if let Some(ref item) = instance.as_object() {
             return self.validators.iter().all(move |validator| {
                 item.iter()
                     .filter(move |(property, _)| !self.properties.contains_key(*property))
@@ -198,7 +198,7 @@ impl AdditionalPropertiesWithPatternsValidator {
 
 impl Validate for AdditionalPropertiesWithPatternsValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             let errors: Vec<_> = self
                 .validators
                 .iter()
@@ -214,7 +214,7 @@ impl Validate for AdditionalPropertiesWithPatternsValidator {
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             return self.validators.iter().all(move |validator| {
                 item.iter()
                     .filter(move |(property, _)| !self.pattern.is_match(property))
@@ -243,7 +243,7 @@ impl<'a> AdditionalPropertiesWithPatternsFalseValidator {
 
 impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             for (property, _) in item {
                 if !self.pattern.is_match(property) {
                     let property_value = Value::String(property.to_string());
@@ -255,7 +255,7 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             for (property, _) in item {
                 if !self.pattern.is_match(property) {
                     return false;
@@ -283,7 +283,7 @@ impl AdditionalPropertiesWithPatternsNotEmptyValidator {
         pattern: Regex,
         context: &CompilationContext,
     ) -> CompilationResult {
-        if let Value::Object(properties) = properties {
+        if let Some(properties) = properties.as_object() {
             return Ok(Box::new(
                 AdditionalPropertiesWithPatternsNotEmptyValidator {
                     validators: compile_validators(schema, context)?,
@@ -298,7 +298,7 @@ impl AdditionalPropertiesWithPatternsNotEmptyValidator {
 
 impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             let errors: Vec<_> = self
                 .validators
                 .iter()
@@ -317,7 +317,7 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             return self.validators.iter().all(move |validator| {
                 item.iter()
                     .filter(move |(property, _)| {
@@ -341,7 +341,7 @@ pub struct AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
 
 impl AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
     pub(crate) fn compile(properties: &Value, pattern: Regex) -> CompilationResult {
-        if let Value::Object(properties) = properties {
+        if let Some(properties) = properties.as_object() {
             return Ok(Box::new(
                 AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
                     properties: properties.clone(),
@@ -355,7 +355,7 @@ impl AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
 
 impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             for property in item.keys() {
                 if !self.properties.contains_key(property) && !self.pattern.is_match(property) {
                     let property_value = Value::String(property.to_string());
@@ -367,7 +367,7 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             for property in item.keys() {
                 if !self.properties.contains_key(property) && !self.pattern.is_match(property) {
                     return false;
@@ -389,53 +389,51 @@ pub(crate) fn compile(
 ) -> Option<CompilationResult> {
     let properties = parent.get("properties");
     if let Some(patterns) = parent.get("patternProperties") {
-        if let Value::Object(obj) = patterns {
+        if let Some(obj) = patterns.as_object() {
             let pattern = obj.keys().cloned().collect::<Vec<String>>().join("|");
-            return match Regex::new(&pattern) {
-                Ok(re) => {
-                    match schema {
-                        Value::Bool(true) => None, // "additionalProperties" are "true" by default
-                        Value::Bool(false) => match properties {
-                            Some(properties) => Some(
-                                AdditionalPropertiesWithPatternsNotEmptyFalseValidator::compile(
-                                    properties, re,
-                                ),
+            if let Ok(re) = Regex::new(&pattern) {
+                if let Some(boolean) = schema.as_bool() {
+                    if boolean {
+                        None // "additionalProperties" are "true" by default
+                    } else if let Some(properties) = properties {
+                        Some(
+                            AdditionalPropertiesWithPatternsNotEmptyFalseValidator::compile(
+                                properties, re,
                             ),
-                            None => {
-                                Some(AdditionalPropertiesWithPatternsFalseValidator::compile(re))
-                            }
-                        },
-                        _ => match properties {
-                            Some(properties) => {
-                                Some(AdditionalPropertiesWithPatternsNotEmptyValidator::compile(
-                                    schema, properties, re, context,
-                                ))
-                            }
-                            None => Some(AdditionalPropertiesWithPatternsValidator::compile(
-                                schema, re, context,
-                            )),
-                        },
+                        )
+                    } else {
+                        Some(AdditionalPropertiesWithPatternsFalseValidator::compile(re))
                     }
+                } else if let Some(properties) = properties {
+                    Some(AdditionalPropertiesWithPatternsNotEmptyValidator::compile(
+                        schema, properties, re, context,
+                    ))
+                } else {
+                    Some(AdditionalPropertiesWithPatternsValidator::compile(
+                        schema, re, context,
+                    ))
                 }
-                Err(_) => Some(Err(CompilationError::SchemaError)),
-            };
+            } else {
+                Some(Err(CompilationError::SchemaError))
+            }
+        } else {
+            Some(Err(CompilationError::SchemaError))
         }
-        Some(Err(CompilationError::SchemaError))
+    } else if let Some(boolean) = schema.as_bool() {
+        if boolean {
+            None // "additionalProperties" are "true" by default
+        } else if let Some(properties) = properties {
+            Some(AdditionalPropertiesNotEmptyFalseValidator::compile(
+                properties,
+            ))
+        } else {
+            Some(AdditionalPropertiesFalseValidator::compile())
+        }
+    } else if let Some(properties) = properties {
+        Some(AdditionalPropertiesNotEmptyValidator::compile(
+            schema, properties, context,
+        ))
     } else {
-        match schema {
-            Value::Bool(true) => None, // "additionalProperties" are "true" by default
-            Value::Bool(false) => match properties {
-                Some(properties) => Some(AdditionalPropertiesNotEmptyFalseValidator::compile(
-                    properties,
-                )),
-                None => Some(AdditionalPropertiesFalseValidator::compile()),
-            },
-            _ => match properties {
-                Some(properties) => Some(AdditionalPropertiesNotEmptyValidator::compile(
-                    schema, properties, context,
-                )),
-                None => Some(AdditionalPropertiesValidator::compile(schema, context)),
-            },
-        }
+        Some(AdditionalPropertiesValidator::compile(schema, context))
     }
 }

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -30,7 +30,7 @@ impl Validate for AnyOfValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            return error(ValidationError::any_of(instance));
+            error(ValidationError::any_of(instance))
         }
     }
 

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -19,7 +19,7 @@ impl ContainsValidator {
 
 impl Validate for ContainsValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Array(items) = instance {
+        if let Some(items) = instance.as_array() {
             for item in items {
                 if self
                     .validators
@@ -35,7 +35,7 @@ impl Validate for ContainsValidator {
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Array(items) = instance {
+        if let Some(items) = instance.as_array() {
             for item in items {
                 if self
                     .validators

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -12,13 +12,14 @@ pub struct EnumValidator {
 
 impl EnumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Array(items) = schema {
-            return Ok(Box::new(EnumValidator {
+        if let Some(items) = schema.as_array() {
+            Ok(Box::new(EnumValidator {
                 options: schema.clone(),
                 items: items.clone(),
-            }));
+            }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -9,7 +9,7 @@ pub struct ExclusiveMaximumValidator {
     limit: f64,
 }
 
-impl<'a> ExclusiveMaximumValidator {
+impl ExclusiveMaximumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_f64() {
             Ok(Box::new(ExclusiveMaximumValidator { limit }))

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -11,19 +11,17 @@ pub struct ExclusiveMaximumValidator {
 
 impl<'a> ExclusiveMaximumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            return Ok(Box::new(ExclusiveMaximumValidator {
-                limit: limit.as_f64().unwrap(),
-            }));
+        if let Some(limit) = schema.as_f64() {
+            Ok(Box::new(ExclusiveMaximumValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 
 impl Validate for ExclusiveMaximumValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item >= self.limit {
                 return error(ValidationError::exclusive_maximum(instance, self.limit));
             }
@@ -32,8 +30,7 @@ impl Validate for ExclusiveMaximumValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item >= self.limit {
                 return false;
             }

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -9,7 +9,7 @@ pub struct ExclusiveMinimumValidator {
     limit: f64,
 }
 
-impl<'a> ExclusiveMinimumValidator {
+impl ExclusiveMinimumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_f64() {
             return Ok(Box::new(ExclusiveMinimumValidator { limit }));

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -11,8 +11,7 @@ pub struct ExclusiveMinimumValidator {
 
 impl<'a> ExclusiveMinimumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_f64().unwrap();
+        if let Some(limit) = schema.as_f64() {
             return Ok(Box::new(ExclusiveMinimumValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -21,8 +20,7 @@ impl<'a> ExclusiveMinimumValidator {
 
 impl Validate for ExclusiveMinimumValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item <= self.limit {
                 return error(ValidationError::exclusive_minimum(instance, self.limit));
             }
@@ -31,8 +29,7 @@ impl Validate for ExclusiveMinimumValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item <= self.limit {
                 return false;
             }

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -22,7 +22,7 @@ impl FormatValidator {
 
 impl Validate for FormatValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if !(self.check)(item) {
                 return error(ValidationError::format(instance, self.format.clone()));
             }
@@ -31,7 +31,7 @@ impl Validate for FormatValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             return (self.check)(item);
         }
         true

--- a/src/keywords/helpers.rs
+++ b/src/keywords/helpers.rs
@@ -1,8 +1,19 @@
 use serde_json::Value;
 
+fn are_f64_equal(left: f64, right: f64) -> bool {
+    (left - right).abs() < 3. * f64::EPSILON
+}
+
 pub(crate) fn equal(left: &Value, right: &Value) -> bool {
-    match (left, right) {
-        (Value::Number(left), Value::Number(right)) => left.as_f64() == right.as_f64(),
-        (_, _) => left == right,
+    if left == right {
+        true
+    } else if let Some(left_num) = left.as_f64() {
+        if let Some(right_num) = right.as_f64() {
+            are_f64_equal(left_num, right_num)
+        } else {
+            false
+        }
+    } else {
+        false
     }
 }

--- a/src/keywords/if_.rs
+++ b/src/keywords/if_.rs
@@ -64,8 +64,8 @@ pub struct IfElseValidator {
     else_schema: Validators,
 }
 
-impl<'a> IfElseValidator {
-    pub(crate) fn compile(
+impl IfElseValidator {
+    pub(crate) fn compile<'a>(
         schema: &'a Value,
         else_schema: &'a Value,
         context: &CompilationContext,

--- a/src/keywords/legacy/maximum_draft_4.rs
+++ b/src/keywords/legacy/maximum_draft_4.rs
@@ -7,8 +7,12 @@ pub(crate) fn compile(
     schema: &Value,
     context: &CompilationContext,
 ) -> Option<CompilationResult> {
-    match parent.get("exclusiveMaximum") {
-        Some(Value::Bool(true)) => exclusive_maximum::compile(parent, schema, context),
-        _ => maximum::compile(parent, schema, context),
+    if let Some(exclusive_maximum) = parent.get("exclusiveMaximum") {
+        if let Some(value) = exclusive_maximum.as_bool() {
+            if value {
+                return exclusive_maximum::compile(parent, schema, context);
+            }
+        }
     }
+    maximum::compile(parent, schema, context)
 }

--- a/src/keywords/legacy/minimum_draft_4.rs
+++ b/src/keywords/legacy/minimum_draft_4.rs
@@ -7,8 +7,12 @@ pub(crate) fn compile(
     schema: &Value,
     context: &CompilationContext,
 ) -> Option<CompilationResult> {
-    match parent.get("exclusiveMinimum") {
-        Some(Value::Bool(true)) => exclusive_minimum::compile(parent, schema, context),
-        _ => minimum::compile(parent, schema, context),
+    if let Some(exclusive_maximum) = parent.get("exclusiveMinimum") {
+        if let Some(value) = exclusive_maximum.as_bool() {
+            if value {
+                return exclusive_minimum::compile(parent, schema, context);
+            }
+        }
     }
+    minimum::compile(parent, schema, context)
 }

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -4,6 +4,7 @@ use crate::{
     error::{error, no_error, CompilationError, ErrorIterator, PrimitiveType, ValidationError},
 };
 use serde_json::{Map, Number, Value};
+use std::convert::TryFrom;
 
 pub struct MultipleTypesValidator {
     types: Vec<PrimitiveType>,
@@ -14,15 +15,9 @@ impl MultipleTypesValidator {
         let mut types = Vec::with_capacity(items.len());
         for item in items {
             match item {
-                Value::String(string) => match string.as_str() {
-                    "integer" => types.push(PrimitiveType::Integer),
-                    "null" => types.push(PrimitiveType::Null),
-                    "boolean" => types.push(PrimitiveType::Boolean),
-                    "string" => types.push(PrimitiveType::String),
-                    "array" => types.push(PrimitiveType::Array),
-                    "object" => types.push(PrimitiveType::Object),
-                    "number" => types.push(PrimitiveType::Number),
-                    _ => return Err(CompilationError::SchemaError),
+                Value::String(string) => match PrimitiveType::try_from(string.as_str()) {
+                    Ok(primitive_value) => types.push(primitive_value),
+                    Err(_) => return Err(CompilationError::SchemaError),
                 },
                 _ => return Err(CompilationError::SchemaError),
             }

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -11,9 +11,10 @@ pub struct MaxItemsValidator {
 
 impl<'a> MaxItemsValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
-            return Ok(Box::new(MaxItemsValidator { limit }));
+        if let Some(limit) = schema.as_u64() {
+            return Ok(Box::new(MaxItemsValidator {
+                limit: limit as usize,
+            }));
         }
         Err(CompilationError::SchemaError)
     }
@@ -21,7 +22,7 @@ impl<'a> MaxItemsValidator {
 
 impl Validate for MaxItemsValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Array(items) = instance {
+        if let Some(items) = instance.as_array() {
             if items.len() > self.limit {
                 return error(ValidationError::max_items(instance, self.limit));
             }
@@ -30,7 +31,7 @@ impl Validate for MaxItemsValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Array(items) = instance {
+        if let Some(items) = instance.as_array() {
             if items.len() > self.limit {
                 return false;
             }

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -9,7 +9,7 @@ pub struct MaxItemsValidator {
     limit: usize,
 }
 
-impl<'a> MaxItemsValidator {
+impl MaxItemsValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MaxItemsValidator {

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -11,9 +11,10 @@ pub struct MaxLengthValidator {
 
 impl MaxLengthValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
-            return Ok(Box::new(MaxLengthValidator { limit }));
+        if let Some(limit) = schema.as_u64() {
+            return Ok(Box::new(MaxLengthValidator {
+                limit: limit as usize,
+            }));
         }
         Err(CompilationError::SchemaError)
     }
@@ -21,7 +22,7 @@ impl MaxLengthValidator {
 
 impl Validate for MaxLengthValidator {
     fn validate<'a>(&self, _schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if item.chars().count() > self.limit {
                 return error(ValidationError::max_length(instance, self.limit));
             }
@@ -30,7 +31,7 @@ impl Validate for MaxLengthValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if item.chars().count() > self.limit {
                 return false;
             }

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -9,7 +9,7 @@ pub struct MaxPropertiesValidator {
     limit: usize,
 }
 
-impl<'a> MaxPropertiesValidator {
+impl MaxPropertiesValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MaxPropertiesValidator {

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -11,9 +11,10 @@ pub struct MaxPropertiesValidator {
 
 impl<'a> MaxPropertiesValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
-            return Ok(Box::new(MaxPropertiesValidator { limit }));
+        if let Some(limit) = schema.as_u64() {
+            return Ok(Box::new(MaxPropertiesValidator {
+                limit: limit as usize,
+            }));
         }
         Err(CompilationError::SchemaError)
     }
@@ -21,7 +22,7 @@ impl<'a> MaxPropertiesValidator {
 
 impl Validate for MaxPropertiesValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             if item.len() > self.limit {
                 return error(ValidationError::max_properties(instance, self.limit));
             }
@@ -30,7 +31,7 @@ impl Validate for MaxPropertiesValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             if item.len() > self.limit {
                 return false;
             }

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -11,8 +11,7 @@ pub struct MaximumValidator {
 
 impl MaximumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_f64().unwrap();
+        if let Some(limit) = schema.as_f64() {
             return Ok(Box::new(MaximumValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -21,8 +20,7 @@ impl MaximumValidator {
 
 impl Validate for MaximumValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item > self.limit {
                 return error(ValidationError::maximum(instance, self.limit));
             }
@@ -31,8 +29,7 @@ impl Validate for MaximumValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item > self.limit {
                 return false;
             }

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -11,9 +11,10 @@ pub struct MinItemsValidator {
 
 impl MinItemsValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
-            return Ok(Box::new(MinItemsValidator { limit }));
+        if let Some(limit) = schema.as_u64() {
+            return Ok(Box::new(MinItemsValidator {
+                limit: limit as usize,
+            }));
         }
         Err(CompilationError::SchemaError)
     }
@@ -21,7 +22,7 @@ impl MinItemsValidator {
 
 impl Validate for MinItemsValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Array(items) = instance {
+        if let Some(items) = instance.as_array() {
             if items.len() < self.limit {
                 return error(ValidationError::min_items(instance, self.limit));
             }
@@ -30,7 +31,7 @@ impl Validate for MinItemsValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Array(items) = instance {
+        if let Some(items) = instance.as_array() {
             if items.len() < self.limit {
                 return false;
             }

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -11,9 +11,10 @@ pub struct MinLengthValidator {
 
 impl<'a> MinLengthValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
-            return Ok(Box::new(MinLengthValidator { limit }));
+        if let Some(limit) = schema.as_u64() {
+            return Ok(Box::new(MinLengthValidator {
+                limit: limit as usize,
+            }));
         }
         Err(CompilationError::SchemaError)
     }
@@ -21,7 +22,7 @@ impl<'a> MinLengthValidator {
 
 impl Validate for MinLengthValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if item.chars().count() < self.limit {
                 return error(ValidationError::min_length(instance, self.limit));
             }
@@ -30,7 +31,7 @@ impl Validate for MinLengthValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if item.chars().count() < self.limit {
                 return false;
             }

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -9,7 +9,7 @@ pub struct MinLengthValidator {
     limit: usize,
 }
 
-impl<'a> MinLengthValidator {
+impl MinLengthValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MinLengthValidator {

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -11,9 +11,10 @@ pub struct MinPropertiesValidator {
 
 impl<'a> MinPropertiesValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
-            return Ok(Box::new(MinPropertiesValidator { limit }));
+        if let Some(limit) = schema.as_u64() {
+            return Ok(Box::new(MinPropertiesValidator {
+                limit: limit as usize,
+            }));
         }
         Err(CompilationError::SchemaError)
     }
@@ -21,7 +22,7 @@ impl<'a> MinPropertiesValidator {
 
 impl Validate for MinPropertiesValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             if item.len() < self.limit {
                 return error(ValidationError::min_properties(instance, self.limit));
             }
@@ -30,7 +31,7 @@ impl Validate for MinPropertiesValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             if item.len() < self.limit {
                 return false;
             }

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -9,7 +9,7 @@ pub struct MinPropertiesValidator {
     limit: usize,
 }
 
-impl<'a> MinPropertiesValidator {
+impl MinPropertiesValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MinPropertiesValidator {

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -11,8 +11,7 @@ pub struct MinimumValidator {
 
 impl MinimumValidator {
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_f64().unwrap();
+        if let Some(limit) = schema.as_f64() {
             return Ok(Box::new(MinimumValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -21,8 +20,7 @@ impl MinimumValidator {
 
 impl Validate for MinimumValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item < self.limit {
                 return error(ValidationError::minimum(instance, self.limit));
             }
@@ -31,8 +29,7 @@ impl Validate for MinimumValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             if item < self.limit {
                 return false;
             }

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -10,7 +10,7 @@ pub struct MultipleOfFloatValidator {
     multiple_of: f64,
 }
 
-impl<'a> MultipleOfFloatValidator {
+impl MultipleOfFloatValidator {
     pub(crate) fn compile(multiple_of: f64) -> CompilationResult {
         Ok(Box::new(MultipleOfFloatValidator { multiple_of }))
     }
@@ -46,7 +46,7 @@ pub struct MultipleOfIntegerValidator {
     multiple_of: f64,
 }
 
-impl<'a> MultipleOfIntegerValidator {
+impl MultipleOfIntegerValidator {
     pub(crate) fn compile(multiple_of: f64) -> CompilationResult {
         Ok(Box::new(MultipleOfIntegerValidator { multiple_of }))
     }

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -18,8 +18,7 @@ impl<'a> MultipleOfFloatValidator {
 
 impl Validate for MultipleOfFloatValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             let remainder = (item / self.multiple_of) % 1.;
             if !(remainder < EPSILON && remainder < (1. - EPSILON)) {
                 return error(ValidationError::multiple_of(instance, self.multiple_of));
@@ -29,8 +28,7 @@ impl Validate for MultipleOfFloatValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             let remainder = (item / self.multiple_of) % 1.;
             if !(remainder < EPSILON && remainder < (1. - EPSILON)) {
                 return false;
@@ -56,8 +54,7 @@ impl<'a> MultipleOfIntegerValidator {
 
 impl Validate for MultipleOfIntegerValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             let is_multiple = if item.fract() == 0. {
                 (item % self.multiple_of) == 0.
             } else {
@@ -72,8 +69,7 @@ impl Validate for MultipleOfIntegerValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(item) = instance {
-            let item = item.as_f64().unwrap();
+        if let Some(item) = instance.as_f64() {
             let is_multiple = if item.fract() == 0. {
                 (item % self.multiple_of) == 0.
             } else {
@@ -97,8 +93,7 @@ pub(crate) fn compile(
     schema: &Value,
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
-    if let Value::Number(multiple_of) = schema {
-        let multiple_of = multiple_of.as_f64().unwrap();
+    if let Some(multiple_of) = schema.as_f64() {
         return if multiple_of.fract() == 0. {
             Some(MultipleOfIntegerValidator::compile(multiple_of))
         } else {

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -19,22 +19,21 @@ pub struct PatternValidator {
 
 impl PatternValidator {
     pub(crate) fn compile(pattern: &Value) -> CompilationResult {
-        match pattern {
-            Value::String(item) => {
-                let pattern = convert_regex(item)?;
-                Ok(Box::new(PatternValidator {
-                    original: item.clone(),
-                    pattern,
-                }))
-            }
-            _ => Err(CompilationError::SchemaError),
+        if let Some(item) = pattern.as_str() {
+            let pattern = convert_regex(item)?;
+            Ok(Box::new(PatternValidator {
+                original: item.to_string(),
+                pattern,
+            }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
     }
 }
 
 impl Validate for PatternValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if !self.pattern.is_match(item) {
                 return error(ValidationError::pattern(instance, self.original.clone()));
             }
@@ -43,7 +42,7 @@ impl Validate for PatternValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
+        if let Some(item) = instance.as_str() {
             if !self.pattern.is_match(item) {
                 return false;
             }

--- a/src/keywords/pattern_properties.rs
+++ b/src/keywords/pattern_properties.rs
@@ -30,7 +30,7 @@ impl PatternPropertiesValidator {
 
 impl Validate for PatternPropertiesValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             let errors: Vec<_> = self
                 .patterns
                 .iter()
@@ -50,7 +50,7 @@ impl Validate for PatternPropertiesValidator {
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
+        if let Some(item) = instance.as_object() {
             return self.patterns.iter().all(move |(re, validators)| {
                 item.iter()
                     .filter(move |(key, _)| re.is_match(key))

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -3,7 +3,7 @@ use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, PrimitiveType, ValidationError},
 };
-use serde_json::{Map, Number, Value};
+use serde_json::{Map, Value};
 use std::convert::TryFrom;
 
 pub struct MultipleTypesValidator {
@@ -14,12 +14,13 @@ impl MultipleTypesValidator {
     pub(crate) fn compile(items: &[Value]) -> CompilationResult {
         let mut types = Vec::with_capacity(items.len());
         for item in items {
-            match item {
-                Value::String(string) => match PrimitiveType::try_from(string.as_str()) {
+            if let Some(string) = item.as_str() {
+                match PrimitiveType::try_from(string) {
                     Ok(primitive_value) => types.push(primitive_value),
                     Err(_) => return Err(CompilationError::SchemaError),
-                },
-                _ => return Err(CompilationError::SchemaError),
+                }
+            } else {
+                return Err(CompilationError::SchemaError);
             }
         }
         Ok(Box::new(MultipleTypesValidator { types }))
@@ -38,17 +39,11 @@ impl Validate for MultipleTypesValidator {
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+        let instance_primtive_type = PrimitiveType::from(instance);
         for type_ in self.types.iter() {
-            match (type_, instance) {
-                (PrimitiveType::Integer, Value::Number(num)) if is_integer(num) => return true,
-                (PrimitiveType::Null, Value::Null)
-                | (PrimitiveType::Boolean, Value::Bool(_))
-                | (PrimitiveType::String, Value::String(_))
-                | (PrimitiveType::Array, Value::Array(_))
-                | (PrimitiveType::Object, Value::Object(_))
-                | (PrimitiveType::Number, Value::Number(_)) => return true,
-                (_, _) => continue,
-            };
+            if type_ == &instance_primtive_type {
+                return true;
+            }
         }
         false
     }
@@ -249,10 +244,9 @@ impl Validate for IntegerTypeValidator {
     }
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Number(num) = instance {
-            return is_integer(num);
-        }
-        false
+        instance.is_u64()
+            || instance.is_i64()
+            || instance.as_f64().map(|f| f.fract() == 0.).unwrap_or(false)
     }
 
     fn name(&self) -> String {
@@ -260,29 +254,26 @@ impl Validate for IntegerTypeValidator {
     }
 }
 
-fn is_integer(num: &Number) -> bool {
-    num.is_u64() || num.is_i64() || num.as_f64().unwrap().fract() == 0.
-}
-
 pub(crate) fn compile(
     _: &Map<String, Value>,
     schema: &Value,
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
-    match schema {
-        Value::String(item) => compile_single_type(item.as_str()),
-        Value::Array(items) => {
-            if items.len() == 1 {
-                if let Some(Value::String(item)) = items.iter().next() {
-                    compile_single_type(item.as_str())
-                } else {
-                    Some(Err(CompilationError::SchemaError))
-                }
+    if let Some(item) = schema.as_str() {
+        compile_single_type(item)
+    } else if let Some(items) = schema.as_array() {
+        if items.len() == 1 {
+            // Unwrap is safe as we checked that we have exactly one item
+            if let Some(item) = items.iter().next().unwrap().as_str() {
+                compile_single_type(item)
             } else {
-                Some(MultipleTypesValidator::compile(items))
+                Some(Err(CompilationError::SchemaError))
             }
+        } else {
+            Some(MultipleTypesValidator::compile(items))
         }
-        _ => Some(Err(CompilationError::SchemaError)),
+    } else {
+        Some(Err(CompilationError::SchemaError))
     }
 }
 

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -139,7 +139,7 @@ pub fn draft_from_schema(schema: &Value) -> Option<Draft> {
 }
 
 pub fn id_of(draft: Draft, schema: &Value) -> Option<&str> {
-    if let Value::Object(object) = schema {
+    if let Some(object) = schema.as_object() {
         if draft == Draft::Draft4 || draft == Draft::Draft3 {
             object.get("id")
         } else {


### PR DESCRIPTION
The goal of this PR is to decouple (as much as possible) from `serde_json`.
This is mostly needed to simplify the integration of `json-trait-rs` (#30).

I'm publishing this for initial review as it will be the base of the work for testing `json-trait-rs`.

I'm very sorry for the size of the PR ... :(