### PR TITLE
feat: Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 Cargo.lock
 .idea
+*.so

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,9 @@ keywords = ["jsonschema", "validation"]
 exclude = ["tests"]
 categories = ["web-programming"]
 
+[workspace]
+members = ["python"]
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "jsonschema-python"
+version = "0.1.0"
+authors = ["Dmitry Dygalo <dadygalo@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+name = "jsonschema_rs"
+crate-type = ["cdylib"]
+
+[dependencies]
+serde_json = "1.0"
+serde = "1.0"
+
+[dependencies.jsonschema]
+path = "../"
+
+[dependencies.pyo3]
+version = "0.9.1"
+features = ["extension-module"]

--- a/python/bench.py
+++ b/python/bench.py
@@ -1,0 +1,77 @@
+import json
+import timeit
+from textwrap import dedent
+import fastjsonschema
+
+
+def load_json(filename):
+    with open(filename) as fd:
+        return json.load(fd)
+
+
+BIG_SCHEMA = load_json("../benches/canada_schema.json")
+BIG_INSTANCE = load_json("../benches/canada.json")
+SMALL_SCHEMA = load_json("../benches/small_schema.json")
+SMALL_INSTANCE_VALID = [9, 'hello', [1, 'a', True], {'a': 'a', 'b': 'b', 'd': 'd'}, 42, 3]
+
+# Compiled fastjsonschema validators
+fast_validate_big = fastjsonschema.compile(BIG_SCHEMA)
+fast_validate_small = fastjsonschema.compile(SMALL_SCHEMA)
+
+
+ITERATIONS_BIG = 10
+ITERATIONS_SMALL = 10000
+setup = dedent("""
+    import json
+    import jsonschema_rs
+    import jsonschema
+    from __main__ import (
+        BIG_SCHEMA, 
+        BIG_INSTANCE, 
+        SMALL_SCHEMA,
+        SMALL_INSTANCE_VALID,
+        fast_validate_small,
+        fast_validate_big,
+    )
+""")
+
+
+def run(code, name, number):
+    result = timeit.timeit(code, setup, number=number)
+    print(f"{name} => {result:.5f}")
+
+
+def bench_object(schema, instance, number, type_):
+    code = f"jsonschema_rs.is_valid({schema}, {instance})"
+    run(code, f"{type_}: object", number)
+
+
+def bench_jsonschema(schema, instance, number, type_):
+    code = f"jsonschema.validate({instance}, {schema})"
+    run(code, f"{type_}: jsonschema", number)
+
+
+def bench_fastjsonschema_small(instance, number, type_):
+    code = f"fast_validate_small({instance})"
+    run(code, f"{type_}: fast jsonschema", number)
+
+
+def bench_fastjsonschema_big(instance, number, type_):
+    code = f"fast_validate_big({instance})"
+    run(code, f"{type_}: fast jsonschema", number)
+
+
+def bench_object_noop(schema, instance, number, type_):
+    code = f"jsonschema_rs.is_valid_noop({schema}, {instance})"
+    run(code, f"{type_}: object noop", number)
+
+
+if __name__ == '__main__':
+    bench_object("SMALL_SCHEMA", "SMALL_INSTANCE_VALID", ITERATIONS_SMALL, "Small")
+    bench_object_noop("SMALL_SCHEMA", "SMALL_INSTANCE_VALID", ITERATIONS_SMALL, "Small")
+    bench_jsonschema("SMALL_SCHEMA", "SMALL_INSTANCE_VALID", ITERATIONS_SMALL, "Small")
+    bench_fastjsonschema_small("SMALL_INSTANCE_VALID", ITERATIONS_SMALL, "Small")
+    bench_object("BIG_SCHEMA", "BIG_INSTANCE", ITERATIONS_BIG, "Big  ")
+    bench_object_noop("BIG_SCHEMA", "BIG_INSTANCE", ITERATIONS_BIG, "Big  ")
+    bench_jsonschema("BIG_SCHEMA", "BIG_INSTANCE", ITERATIONS_BIG, "Big  ")
+    bench_fastjsonschema_big("BIG_INSTANCE", ITERATIONS_BIG, "Big  ")

--- a/python/jsonschema_rs/__init__.py
+++ b/python/jsonschema_rs/__init__.py
@@ -1,0 +1,1 @@
+from .jsonschema_rs import *

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -1,0 +1,112 @@
+use jsonschema;
+use pyo3::prelude::*;
+use pyo3::types::{PyAny, PyDict, PyFloat, PyList, PyTuple};
+use pyo3::wrap_pyfunction;
+use pyo3::Python;
+use serde::ser::{self, Serialize, SerializeMap, SerializeSeq};
+use serde::Serializer;
+
+struct ValueWrapper<'a> {
+    obj: &'a PyAny,
+}
+
+/// Convert a Python value to serde_json::Value
+impl<'a> Serialize for ValueWrapper<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        macro_rules! cast {
+            ($f:expr) => {
+                if let Ok(val) = PyTryFrom::try_from(self.obj) {
+                    return $f(val);
+                }
+            };
+        }
+        macro_rules! extract {
+            ($t:ty) => {
+                if let Ok(val) = <$t as FromPyObject>::extract(self.obj) {
+                    return val.serialize(serializer);
+                }
+            };
+        }
+
+        cast!(|x: &PyList| {
+            let mut seq = serializer.serialize_seq(Some(x.len()))?;
+            for element in x {
+                seq.serialize_element(&ValueWrapper { obj: element })?
+            }
+            seq.end()
+        });
+        cast!(|x: &PyTuple| {
+            let mut seq = serializer.serialize_seq(Some(x.len()))?;
+            for element in x {
+                seq.serialize_element(&ValueWrapper { obj: element })?
+            }
+            seq.end()
+        });
+        cast!(|x: &PyDict| {
+            let mut map = serializer.serialize_map(Some(x.len()))?;
+            for (key, value) in x {
+                if key.is_none() {
+                    map.serialize_key("null")?;
+                } else if let Ok(key) = key.extract::<bool>() {
+                    map.serialize_key(if key { "true" } else { "false" })?;
+                } else if let Ok(key) = key.str() {
+                    let key = key.to_string().unwrap();
+                    map.serialize_key(&key)?;
+                } else {
+                    return Err(ser::Error::custom(format_args!(
+                        "Dictionary key is not a string: {:?}",
+                        key
+                    )));
+                }
+                map.serialize_value(&ValueWrapper { obj: value })?;
+            }
+            map.end()
+        });
+        extract!(String);
+        extract!(bool);
+        extract!(i64);
+        cast!(|x: &PyFloat| {
+            let v = x.value();
+            if !v.is_finite() {
+                return Err(ser::Error::custom(format!("Can't represent {} as JSON", v)));
+            }
+            v.serialize(serializer)
+        });
+        if self.obj.is_none() {
+            return serializer.serialize_unit();
+        }
+        match self.obj.repr() {
+            Ok(repr) => Err(ser::Error::custom(format_args!(
+                "Can't convert to JSON: {}",
+                repr,
+            ))),
+            Err(_) => Err(ser::Error::custom(format_args!(
+                "Type is not JSON serializable: {}",
+                self.obj.get_type().name().into_owned(),
+            ))),
+        }
+    }
+}
+
+#[pyfunction]
+fn is_valid(schema: &'static PyAny, instance: &'static PyAny) -> PyResult<bool> {
+    let schema = serde_json::to_value(ValueWrapper { obj: schema }).unwrap();
+    let instance = serde_json::to_value(ValueWrapper { obj: instance }).unwrap();
+    Ok(jsonschema::is_valid(&schema, &instance))
+}
+
+#[pyfunction]
+fn is_valid_noop(_schema: &'static PyAny, _instance: &'static PyAny) -> PyResult<bool> {
+    // To measure call overhead
+    Ok(true)
+}
+
+#[pymodule]
+fn jsonschema_rs(_py: Python, m: &PyModule) -> PyResult<()> {
+    m.add_wrapped(wrap_pyfunction!(is_valid))?;
+    m.add_wrapped(wrap_pyfunction!(is_valid_noop))?;
+    Ok(())
+}

--- a/python/tests-py/test_jsonschema.py
+++ b/python/tests-py/test_jsonschema.py
@@ -1,0 +1,1 @@
+from jsonschema_rs import is_valid


### PR DESCRIPTION
The approach is based on the newtype pattern. Mostly for comparison with other approaches

The current `bench.py` results:

```
Small: object => 0.15071
Small: object noop => 0.00184
Small: jsonschema => 10.08766
Small: fast jsonschema => 0.05551
Big  : object => 0.32992
Big  : object noop => 0.00000
Big  : jsonschema => 20.27972
Big  : fast jsonschema => 5.88524
```

`fastjsonschema` is 3 times faster on small inputs, but on big inputs, this integration is faster than `fastjsonschema` in ~17.8 times. In comparison with `jsonschema` it is ~60x faster.

The goal is to beat `fastjsonschema` on any inputs, then there will be more reasons to use this library as a replacement