### PR TITLE
fix: Possible truncation & panic 

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -83,21 +83,21 @@ pub enum ValidationErrorKind {
     /// `ref` value is not valid.
     InvalidReference { reference: String },
     /// Too many items in an array.
-    MaxItems { limit: usize },
+    MaxItems { limit: u64 },
     /// Value is too large.
     Maximum { limit: f64 },
     /// String is too long.
-    MaxLength { limit: usize },
+    MaxLength { limit: u64 },
     /// Too many properties in an object.
-    MaxProperties { limit: usize },
+    MaxProperties { limit: u64 },
     /// Too few items in an array.
-    MinItems { limit: usize },
+    MinItems { limit: u64 },
     /// Value is too small.
     Minimum { limit: f64 },
     /// String is too short.
-    MinLength { limit: usize },
+    MinLength { limit: u64 },
     /// Not enough properties in an object.
-    MinProperties { limit: usize },
+    MinProperties { limit: u64 },
     /// When some number is not a multiple of another number.
     MultipleOf { multiple_of: f64 },
     /// Negated schema failed validation.
@@ -244,7 +244,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::InvalidReference { reference },
         }
     }
-    pub(crate) fn max_items(instance: &'a Value, limit: usize) -> ValidationError<'a> {
+    pub(crate) fn max_items(instance: &'a Value, limit: u64) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::MaxItems { limit },
@@ -256,19 +256,19 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Maximum { limit },
         }
     }
-    pub(crate) fn max_length(instance: &'a Value, limit: usize) -> ValidationError<'a> {
+    pub(crate) fn max_length(instance: &'a Value, limit: u64) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::MaxLength { limit },
         }
     }
-    pub(crate) fn max_properties(instance: &'a Value, limit: usize) -> ValidationError<'a> {
+    pub(crate) fn max_properties(instance: &'a Value, limit: u64) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::MaxProperties { limit },
         }
     }
-    pub(crate) fn min_items(instance: &'a Value, limit: usize) -> ValidationError<'a> {
+    pub(crate) fn min_items(instance: &'a Value, limit: u64) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::MinItems { limit },
@@ -280,13 +280,13 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Minimum { limit },
         }
     }
-    pub(crate) fn min_length(instance: &'a Value, limit: usize) -> ValidationError<'a> {
+    pub(crate) fn min_length(instance: &'a Value, limit: u64) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::MinLength { limit },
         }
     }
-    pub(crate) fn min_properties(instance: &'a Value, limit: usize) -> ValidationError<'a> {
+    pub(crate) fn min_properties(instance: &'a Value, limit: u64) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::MinProperties { limit },

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -6,14 +6,13 @@ use crate::{
 use serde_json::{Map, Value};
 
 pub struct MaxItemsValidator {
-    limit: usize,
+    limit: u64,
 }
 
 impl MaxItemsValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
+        if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MaxItemsValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -23,7 +22,7 @@ impl MaxItemsValidator {
 impl Validate for MaxItemsValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
-            if items.len() > self.limit {
+            if (items.len() as u64) > self.limit {
                 return error(ValidationError::max_items(instance, self.limit));
             }
         }
@@ -32,7 +31,7 @@ impl Validate for MaxItemsValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
-            if items.len() > self.limit {
+            if (items.len() as u64) > self.limit {
                 return false;
             }
         }

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -6,14 +6,13 @@ use crate::{
 use serde_json::{Map, Value};
 
 pub struct MaxLengthValidator {
-    limit: usize,
+    limit: u64,
 }
 
 impl MaxLengthValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
+        if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MaxLengthValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -23,7 +22,7 @@ impl MaxLengthValidator {
 impl Validate for MaxLengthValidator {
     fn validate<'a>(&self, _schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
-            if item.chars().count() > self.limit {
+            if (item.chars().count() as u64) > self.limit {
                 return error(ValidationError::max_length(instance, self.limit));
             }
         }
@@ -32,7 +31,7 @@ impl Validate for MaxLengthValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            if item.chars().count() > self.limit {
+            if (item.chars().count() as u64) > self.limit {
                 return false;
             }
         }

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -6,14 +6,13 @@ use crate::{
 use serde_json::{Map, Value};
 
 pub struct MaxPropertiesValidator {
-    limit: usize,
+    limit: u64,
 }
 
 impl MaxPropertiesValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
+        if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MaxPropertiesValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -23,7 +22,7 @@ impl MaxPropertiesValidator {
 impl Validate for MaxPropertiesValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
-            if item.len() > self.limit {
+            if (item.len() as u64) > self.limit {
                 return error(ValidationError::max_properties(instance, self.limit));
             }
         }
@@ -32,7 +31,7 @@ impl Validate for MaxPropertiesValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
-            if item.len() > self.limit {
+            if (item.len() as u64) > self.limit {
                 return false;
             }
         }

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -6,14 +6,13 @@ use crate::{
 use serde_json::{Map, Value};
 
 pub struct MinItemsValidator {
-    limit: usize,
+    limit: u64,
 }
 
 impl MinItemsValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
+        if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MinItemsValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -23,7 +22,7 @@ impl MinItemsValidator {
 impl Validate for MinItemsValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
-            if items.len() < self.limit {
+            if (items.len() as u64) < self.limit {
                 return error(ValidationError::min_items(instance, self.limit));
             }
         }
@@ -32,7 +31,7 @@ impl Validate for MinItemsValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
-            if items.len() < self.limit {
+            if (items.len() as u64) < self.limit {
                 return false;
             }
         }

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -6,14 +6,13 @@ use crate::{
 use serde_json::{Map, Value};
 
 pub struct MinLengthValidator {
-    limit: usize,
+    limit: u64,
 }
 
 impl MinLengthValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
+        if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MinLengthValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -23,7 +22,7 @@ impl MinLengthValidator {
 impl Validate for MinLengthValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
-            if item.chars().count() < self.limit {
+            if (item.chars().count() as u64) < self.limit {
                 return error(ValidationError::min_length(instance, self.limit));
             }
         }
@@ -32,7 +31,7 @@ impl Validate for MinLengthValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            if item.chars().count() < self.limit {
+            if (item.chars().count() as u64) < self.limit {
                 return false;
             }
         }

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -6,14 +6,13 @@ use crate::{
 use serde_json::{Map, Value};
 
 pub struct MinPropertiesValidator {
-    limit: usize,
+    limit: u64,
 }
 
 impl MinPropertiesValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
-        if let Value::Number(limit) = schema {
-            let limit = limit.as_u64().unwrap() as usize;
+        if let Some(limit) = schema.as_u64() {
             return Ok(Box::new(MinPropertiesValidator { limit }));
         }
         Err(CompilationError::SchemaError)
@@ -23,7 +22,7 @@ impl MinPropertiesValidator {
 impl Validate for MinPropertiesValidator {
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
-            if item.len() < self.limit {
+            if (item.len() as u64) < self.limit {
                 return error(ValidationError::min_properties(instance, self.limit));
             }
         }
@@ -32,7 +31,7 @@ impl Validate for MinPropertiesValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
-            if item.len() < self.limit {
+            if (item.len() as u64) < self.limit {
                 return false;
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,8 @@
     clippy::match_same_arms,
     clippy::needless_borrow,
     clippy::print_stdout,
-    clippy::integer_arithmetic
+    clippy::integer_arithmetic,
+    clippy::cast_possible_truncation
 )]
 mod compilation;
 mod error;


### PR DESCRIPTION
In `maxItems`, `maxLength`, `maxProperties`, `minItems`, `minLength` and `minProperties` validators

A test is problematic since it will require a large object + 32-bit system to build & test

fixes #64 