### PR TITLE
chore: Convert gitmodule to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "tests/suite"]
 	path = tests/suite
-	url = git@github.com:json-schema-org/JSON-Schema-Test-Suite.git
+	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite.git


### PR DESCRIPTION
I just noticed this issue, while compiling a fork of your crate without TLS because I want to statically link it with musl. If you don't want to include this, that's fine from my side but it might make it easier for others to depend on git versions of your crate & forks.