### PR TITLE
chore: Cargo fmt & clippy

### DIFF
--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -36,23 +36,20 @@ impl Validate for MultipleTypesValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::multiple_type_error(
-                instance,
-                self.types,
-            ))
+            error(ValidationError::multiple_type_error(instance, self.types))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         match instance {
-            Value::Array(_) => self.types.contains_type(&PrimitiveType::Array),
-            Value::Bool(_) => self.types.contains_type(&PrimitiveType::Boolean),
-            Value::Null => self.types.contains_type(&PrimitiveType::Null),
+            Value::Array(_) => self.types.contains_type(PrimitiveType::Array),
+            Value::Bool(_) => self.types.contains_type(PrimitiveType::Boolean),
+            Value::Null => self.types.contains_type(PrimitiveType::Null),
             Value::Number(num) => {
-                self.types.contains_type(&PrimitiveType::Number)
-                    || (self.types.contains_type(&PrimitiveType::Integer) && is_integer(num))
+                self.types.contains_type(PrimitiveType::Number)
+                    || (self.types.contains_type(PrimitiveType::Integer) && is_integer(num))
             }
-            Value::Object(_) => self.types.contains_type(&PrimitiveType::Object),
-            Value::String(_) => self.types.contains_type(&PrimitiveType::String),
+            Value::Object(_) => self.types.contains_type(PrimitiveType::Object),
+            Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
 
@@ -60,7 +57,8 @@ impl Validate for MultipleTypesValidator {
         format!(
             "type: [{}]",
             self.types
-                .into_iter().map(|type_| format!("{}", type_))
+                .into_iter()
+                .map(|type_| format!("{}", type_))
                 .collect::<Vec<String>>()
                 .join(", ")
         )

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -36,23 +36,20 @@ impl Validate for MultipleTypesValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::multiple_type_error(
-                instance,
-                self.types,
-            ))
+            error(ValidationError::multiple_type_error(instance, self.types))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         match instance {
-            Value::Array(_) => self.types.contains_type(&PrimitiveType::Array),
-            Value::Bool(_) => self.types.contains_type(&PrimitiveType::Boolean),
-            Value::Null => self.types.contains_type(&PrimitiveType::Null),
+            Value::Array(_) => self.types.contains_type(PrimitiveType::Array),
+            Value::Bool(_) => self.types.contains_type(PrimitiveType::Boolean),
+            Value::Null => self.types.contains_type(PrimitiveType::Null),
             Value::Number(num) => {
-                self.types.contains_type(&PrimitiveType::Number)
-                    || (self.types.contains_type(&PrimitiveType::Integer) && is_integer(num))
+                self.types.contains_type(PrimitiveType::Number)
+                    || (self.types.contains_type(PrimitiveType::Integer) && is_integer(num))
             }
-            Value::Object(_) => self.types.contains_type(&PrimitiveType::Object),
-            Value::String(_) => self.types.contains_type(&PrimitiveType::String),
+            Value::Object(_) => self.types.contains_type(PrimitiveType::Object),
+            Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,8 @@
     clippy::result_map_unwrap_or_else,
     clippy::option_unwrap_used,
     clippy::option_map_unwrap_or_else,
-    clippy::option_map_unwrap_or
+    clippy::option_map_unwrap_or,
+    clippy::trivially_copy_pass_by_ref
 )]
 mod compilation;
 mod error;

--- a/src/primitive_type.rs
+++ b/src/primitive_type.rs
@@ -46,29 +46,29 @@ impl TryFrom<&str> for PrimitiveType {
 }
 
 #[inline(always)]
-fn primitive_type_to_bit_map_representation(primitive_type: &PrimitiveType) -> u8 {
+fn primitive_type_to_bit_map_representation(primitive_type: PrimitiveType) -> u8 {
     match primitive_type {
-        PrimitiveType::Array   => 1,
+        PrimitiveType::Array => 1,
         PrimitiveType::Boolean => 2,
         PrimitiveType::Integer => 4,
-        PrimitiveType::Null    => 8,
-        PrimitiveType::Number  => 16,
-        PrimitiveType::Object  => 32,
-        PrimitiveType::String  => 64,
+        PrimitiveType::Null => 8,
+        PrimitiveType::Number => 16,
+        PrimitiveType::Object => 32,
+        PrimitiveType::String => 64,
     }
 }
 
 #[inline(always)]
 fn bit_map_representation_primitive_type(bit_representation: u8) -> PrimitiveType {
     match bit_representation {
-        1  => PrimitiveType::Array,
-        2  => PrimitiveType::Boolean,
-        4  => PrimitiveType::Integer,
-        8  => PrimitiveType::Null,
+        1 => PrimitiveType::Array,
+        2 => PrimitiveType::Boolean,
+        4 => PrimitiveType::Integer,
+        8 => PrimitiveType::Null,
         16 => PrimitiveType::Number,
         32 => PrimitiveType::Object,
         64 => PrimitiveType::String,
-        _ => unreachable!("This shoud never be possible")
+        _ => unreachable!("This shoud never be possible"),
     }
 }
 
@@ -82,20 +82,20 @@ impl PrimitiveTypesBitMap {
     }
 
     #[inline]
-    pub(crate) fn add_type(mut self, primitive_type: &PrimitiveType) -> Self {
+    pub(crate) fn add_type(mut self, primitive_type: PrimitiveType) -> Self {
         self.inner |= primitive_type_to_bit_map_representation(primitive_type);
         self
     }
 
     #[inline(always)]
-    pub(crate) fn contains_type(&self, primitive_type: &PrimitiveType) -> bool {
+    pub(crate) fn contains_type(self, primitive_type: PrimitiveType) -> bool {
         primitive_type_to_bit_map_representation(primitive_type) & self.inner != 0
     }
 }
 impl BitOrAssign<PrimitiveType> for PrimitiveTypesBitMap {
     #[inline]
     fn bitor_assign(&mut self, rhs: PrimitiveType) {
-        *self = self.add_type(&rhs);
+        *self = self.add_type(rhs);
     }
 }
 impl IntoIterator for PrimitiveTypesBitMap {
@@ -104,7 +104,7 @@ impl IntoIterator for PrimitiveTypesBitMap {
     fn into_iter(self) -> Self::IntoIter {
         PrimitiveTypesBitMapIterator {
             range: 1..7,
-            bit_map: self
+            bit_map: self,
         }
     }
 }
@@ -125,12 +125,13 @@ pub struct PrimitiveTypesBitMapIterator {
 }
 impl Iterator for PrimitiveTypesBitMapIterator {
     type Item = PrimitiveType;
+    #[allow(clippy::integer_arithmetic)]
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(value) = self.range.next() {
-                let bit_value = 1<<value;
+                let bit_value = 1 << value;
                 if self.bit_map.inner & bit_value != 0 {
-                    return Some(bit_map_representation_primitive_type(bit_value))
+                    return Some(bit_map_representation_primitive_type(bit_value));
                 }
             } else {
                 return None;


### PR DESCRIPTION
`PrimitiveType` is 1 byte, `&PrimitiveType` is 8 bytes.
It would be more efficient if passed by value