### PR TITLE
$ref keyword caches built validators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ base64 = "0.12.0"
 chrono = "0.4.10"
 rayon = "1.3.0"
 reqwest = { version = "0.10.4", features = ["blocking", "json"]}
+parking_lot = "0.10.2"
 
 [dev-dependencies]
 paste = "0.1"

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -36,10 +36,7 @@ impl Validate for MultipleTypesValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::multiple_type_error(
-                instance,
-                self.types,
-            ))
+            error(ValidationError::multiple_type_error(instance, self.types))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
@@ -60,7 +57,8 @@ impl Validate for MultipleTypesValidator {
         format!(
             "type: [{}]",
             self.types
-                .into_iter().map(|type_| format!("{}", type_))
+                .into_iter()
+                .map(|type_| format!("{}", type_))
                 .collect::<Vec<String>>()
                 .join(", ")
         )

--- a/src/keywords/ref_.rs
+++ b/src/keywords/ref_.rs
@@ -1,60 +1,78 @@
 use super::{CompilationResult, Validate};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::{error, ErrorIterator},
+    error::{error, ErrorIterator, ValidationError},
+    keywords::Validators,
 };
+use parking_lot::RwLock;
 use serde_json::Value;
 use url::Url;
 
 pub struct RefValidator {
     reference: Url,
+    /// Precomputed validators.
+    /// They are behind a RwLock as is not possible to compute them
+    /// at compile time without risking infinite loops of references
+    /// and at the same time during validation we iterate over shared
+    /// references (&self) and not owned references (&mut self).
+    validators: RwLock<Option<Validators>>,
 }
 
 impl RefValidator {
     #[inline]
     pub(crate) fn compile(reference: &str, context: &CompilationContext) -> CompilationResult {
         let reference = context.build_url(reference)?;
-        Ok(Box::new(RefValidator { reference }))
+        Ok(Box::new(RefValidator {
+            reference,
+            validators: RwLock::new(None),
+        }))
+    }
+
+    /// Ensure that validators are built and built once.
+    fn ensure_validators<'a>(&self, schema: &'a JSONSchema) -> Result<(), ValidationError<'a>> {
+        if self.validators.read().is_none() {
+            let (scope, resolved) =
+                schema
+                    .resolver
+                    .resolve_fragment(schema.draft, &self.reference, schema.schema)?;
+            let context = CompilationContext::new(scope, schema.draft);
+            let validators = compile_validators(&resolved, &context)?;
+
+            // Inject the validators into self.validators
+            *self.validators.write() = Some(validators);
+        }
+        Ok(())
     }
 }
 
 impl Validate for RefValidator {
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        match schema
-            .resolver
-            .resolve_fragment(schema.draft, &self.reference, schema.schema)
-        {
-            Ok((scope, resolved)) => {
-                let context = CompilationContext::new(scope, schema.draft);
-                match compile_validators(&resolved, &context) {
-                    Ok(validators) => Box::new(
-                        validators
-                            .into_iter()
-                            .flat_map(move |validator| validator.validate(schema, instance)),
-                    ),
-                    Err(e) => error(e.into()),
-                }
-            }
-            Err(e) => error(e),
+        if let Err(err) = self.ensure_validators(schema) {
+            error(err)
+        } else {
+            Box::new(
+                self.validators
+                    .read()
+                    .as_ref()
+                    .expect("ensure_validators guarantees the presence of the validators")
+                    .iter()
+                    .flat_map(move |validator| validator.validate(schema, instance))
+                    .collect::<Vec<_>>()
+                    .into_iter(),
+            )
         }
     }
 
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        match schema
-            .resolver
-            .resolve_fragment(schema.draft, &self.reference, schema.schema)
-        {
-            Ok((scope, resolved)) => {
-                let context = CompilationContext::new(scope, schema.draft);
-                match compile_validators(&resolved, &context) {
-                    Ok(validators) => validators
-                        .into_iter()
-                        .all(move |validator| validator.is_valid(schema, instance)),
-
-                    Err(_) => false,
-                }
-            }
-            Err(_) => false,
+        if self.ensure_validators(schema).is_err() {
+            false
+        } else {
+            self.validators
+                .read()
+                .as_ref()
+                .expect("ensure_validators guarantees the presence of the validators")
+                .iter()
+                .all(move |validator| validator.is_valid(schema, instance))
         }
     }
 

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -36,10 +36,7 @@ impl Validate for MultipleTypesValidator {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::multiple_type_error(
-                instance,
-                self.types,
-            ))
+            error(ValidationError::multiple_type_error(instance, self.types))
         }
     }
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {

--- a/src/primitive_type.rs
+++ b/src/primitive_type.rs
@@ -48,27 +48,27 @@ impl TryFrom<&str> for PrimitiveType {
 #[inline(always)]
 fn primitive_type_to_bit_map_representation(primitive_type: &PrimitiveType) -> u8 {
     match primitive_type {
-        PrimitiveType::Array   => 1,
+        PrimitiveType::Array => 1,
         PrimitiveType::Boolean => 2,
         PrimitiveType::Integer => 4,
-        PrimitiveType::Null    => 8,
-        PrimitiveType::Number  => 16,
-        PrimitiveType::Object  => 32,
-        PrimitiveType::String  => 64,
+        PrimitiveType::Null => 8,
+        PrimitiveType::Number => 16,
+        PrimitiveType::Object => 32,
+        PrimitiveType::String => 64,
     }
 }
 
 #[inline(always)]
 fn bit_map_representation_primitive_type(bit_representation: u8) -> PrimitiveType {
     match bit_representation {
-        1  => PrimitiveType::Array,
-        2  => PrimitiveType::Boolean,
-        4  => PrimitiveType::Integer,
-        8  => PrimitiveType::Null,
+        1 => PrimitiveType::Array,
+        2 => PrimitiveType::Boolean,
+        4 => PrimitiveType::Integer,
+        8 => PrimitiveType::Null,
         16 => PrimitiveType::Number,
         32 => PrimitiveType::Object,
         64 => PrimitiveType::String,
-        _ => unreachable!("This shoud never be possible")
+        _ => unreachable!("This shoud never be possible"),
     }
 }
 
@@ -104,7 +104,7 @@ impl IntoIterator for PrimitiveTypesBitMap {
     fn into_iter(self) -> Self::IntoIter {
         PrimitiveTypesBitMapIterator {
             range: 1..7,
-            bit_map: self
+            bit_map: self,
         }
     }
 }
@@ -128,9 +128,9 @@ impl Iterator for PrimitiveTypesBitMapIterator {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             if let Some(value) = self.range.next() {
-                let bit_value = 1<<value;
+                let bit_value = 1 << value;
                 if self.bit_map.inner & bit_value != 0 {
-                    return Some(bit_map_representation_primitive_type(bit_value))
+                    return Some(bit_map_representation_primitive_type(bit_value));
                 }
             } else {
                 return None;


### PR DESCRIPTION
The goal of this PR is to reduce validation penalty performance while interacting with `$ref`s.

At the current state every time we're trying to validate such object we're actually re-building all the validators (which is essentially the compile part of the process).

I've tried to move validators build logic (currently in `RefValidator::ensure_validators`) into the compilation process, but it get's though due to potential circular dependencies with references.
In order to reduce the code changes and keep performances in consideration I'm opting for storing the validators behind a `RwLock`.
The decision of using it is mostly related to the fact that respect a `Mutex` it does have similar performances but at the same time allows multiple readers (in our case multiple parallel validations).

Performance improvements are over well 45% improvement for validation. Raw data in [here](https://gist.github.com/macisamuele/07ca443be23b62789e4b98d99cd928c8)

PS. once again this was spotted while working on [maci-split-validators](https://github.com/macisamuele/jsonschema-rs/tree/maci-split-validators) 😎 