### PR TITLE
chore: Use `to_string` instead of `format!`

### DIFF
--- a/src/compilation.rs
+++ b/src/compilation.rs
@@ -231,11 +231,11 @@ mod tests {
         let errors: Vec<ValidationError> = result.unwrap_err().collect();
         assert_eq!(errors.len(), 2);
         assert_eq!(
-            format!("{}", errors[0]),
+            errors[0].to_string(),
             r#"{"a":3} has less than 2 properties"#
         );
         assert_eq!(
-            format!("{}", errors[1]),
+            errors[1].to_string(),
             r#"'"a"' is shorter than 3 characters"#
         );
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -589,8 +589,7 @@ mod tests {
     fn single_type_error() {
         let instance = json!(42);
         let err = ValidationError::single_type_error(&instance, PrimitiveType::String);
-        let repr = format!("{}", err);
-        assert_eq!(repr, "'42' is not of type 'string'")
+        assert_eq!(err.to_string(), "'42' is not of type 'string'")
     }
 
     #[test]
@@ -600,7 +599,6 @@ mod tests {
             &instance,
             vec![PrimitiveType::String, PrimitiveType::Number].into(),
         );
-        let repr = format!("{}", err);
-        assert_eq!(repr, "'42' is not of types 'number', 'string'")
+        assert_eq!(err.to_string(), "'42' is not of types 'number', 'string'")
     }
 }

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -40,7 +40,7 @@ impl Validate for EnumValidator {
             "enum: [{}]",
             self.items
                 .iter()
-                .map(|item| format!("{}", item))
+                .map(Value::to_string)
                 .collect::<Vec<String>>()
                 .join(", ")
         )

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -216,7 +216,7 @@ mod tests {
     fn error_message(schema: Value, instance: Value, expected: &str) {
         let compiled = JSONSchema::compile(&schema, None).unwrap();
         let errors: Vec<_> = compiled.validate(&instance).unwrap_err().collect();
-        assert_eq!(format!("{}", errors[0]), expected);
+        assert_eq!(errors[0].to_string(), expected);
     }
 
     // Extra cases not covered by JSON test suite


### PR DESCRIPTION
It makes it a bit more readable