### PR TITLE
Split Validate methods 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,9 @@ rayon = "1"
 reqwest = { version = ">= 0.10", features = ["blocking", "json"]}
 parking_lot = ">= 0.1"
 num-cmp = ">= 0.1"
+paste = ">= 0.1"
 
 [dev-dependencies]
-paste = ">= 0.1"
 criterion = ">= 0.1"
 draft = {path = "draft"}
 jsonschema-valid = ">= 0.1"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,5 +1,5 @@
 use crate::primitive_type::{PrimitiveType, PrimitiveTypesBitMap};
-use serde_json::Value;
+use serde_json::{Map, Number, Value};
 use std::{
     borrow::Cow,
     error, fmt,
@@ -183,11 +183,66 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::AnyOf,
         }
     }
-    pub(crate) fn constant(instance: &'a Value, expected_value: &Value) -> ValidationError<'a> {
+    pub(crate) fn constant_array(
+        instance: &'a Value,
+        expected_value: &[Value],
+    ) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::Constant {
-                expected_value: expected_value.clone(),
+                expected_value: Value::Array(expected_value.to_vec()),
+            },
+        }
+    }
+    pub(crate) fn constant_boolean(
+        instance: &'a Value,
+        expected_value: bool,
+    ) -> ValidationError<'a> {
+        ValidationError {
+            instance: Cow::Borrowed(instance),
+            kind: ValidationErrorKind::Constant {
+                expected_value: Value::Bool(expected_value),
+            },
+        }
+    }
+    pub(crate) fn constant_null(instance: &'a Value) -> ValidationError<'a> {
+        ValidationError {
+            instance: Cow::Borrowed(instance),
+            kind: ValidationErrorKind::Constant {
+                expected_value: Value::Null,
+            },
+        }
+    }
+    pub(crate) fn constant_number(
+        instance: &'a Value,
+        expected_value: &Number,
+    ) -> ValidationError<'a> {
+        ValidationError {
+            instance: Cow::Borrowed(instance),
+            kind: ValidationErrorKind::Constant {
+                expected_value: Value::Number(expected_value.clone()),
+            },
+        }
+    }
+    pub(crate) fn constant_object(
+        instance: &'a Value,
+        expected_value: &Map<String, Value>,
+    ) -> ValidationError<'a> {
+        ValidationError {
+            instance: Cow::Borrowed(instance),
+            kind: ValidationErrorKind::Constant {
+                expected_value: Value::Object(expected_value.clone()),
+            },
+        }
+    }
+    pub(crate) fn constant_string(
+        instance: &'a Value,
+        expected_value: &str,
+    ) -> ValidationError<'a> {
+        ValidationError {
+            instance: Cow::Borrowed(instance),
+            kind: ValidationErrorKind::Constant {
+                expected_value: Value::String(expected_value.to_string()),
             },
         }
     }

--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::{CompilationError, ErrorIterator, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::{boolean::TrueValidator, format_validators, CompilationResult, Validators},
     validator::Validate,
 };
@@ -37,6 +37,14 @@ impl Validate for AdditionalItemsObjectValidator {
                 .all(move |validator| validator.is_valid(schema, item))
         })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            self.is_valid_array(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_array<'a>(
@@ -57,6 +65,14 @@ impl Validate for AdditionalItemsObjectValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -82,6 +98,14 @@ impl Validate for AdditionalItemsBooleanValidator {
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_array: &[Value]) -> bool {
         instance_array.len() <= self.items_count
+    }
+    #[inline]
+    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_array) = instance {
+            instance_array.len() <= self.items_count
+        } else {
+            true
+        }
     }
 }
 

--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -1,8 +1,8 @@
-use super::{boolean::TrueValidator, CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::format_validators,
+    keywords::{boolean::TrueValidator, format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::format_validators,
+    keywords::{format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use regex::Regex;
 use serde_json::{Map, Value};

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -40,6 +40,14 @@ impl Validate for AdditionalPropertiesValidator {
                 .all(move |value| validator.is_valid(schema, value))
         })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -59,6 +67,14 @@ impl Validate for AdditionalPropertiesValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -87,6 +103,14 @@ impl Validate for AdditionalPropertiesFalseValidator {
         instance_value: &Map<String, Value>,
     ) -> bool {
         instance_value.is_empty()
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
     }
 }
 
@@ -120,6 +144,14 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
             .keys()
             .all(|property| self.properties.contains(property))
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -136,6 +168,14 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
             }
         }
         no_error()
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -181,6 +221,14 @@ impl Validate for AdditionalPropertiesNotEmptyValidator {
                 .all(move |(_, value)| validator.is_valid(schema, value))
         })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -201,6 +249,14 @@ impl Validate for AdditionalPropertiesNotEmptyValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -243,6 +299,14 @@ impl Validate for AdditionalPropertiesWithPatternsValidator {
                 .all(move |(_, value)| validator.is_valid(schema, value))
         })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -263,6 +327,14 @@ impl Validate for AdditionalPropertiesWithPatternsValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -293,6 +365,14 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
             .keys()
             .all(|property| self.pattern.is_match(property))
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -310,6 +390,14 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
                         .into_owned(),
                 )
             })
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -362,6 +450,14 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
                 .all(move |(_, value)| validator.is_valid(schema, value))
         })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -385,6 +481,14 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -422,6 +526,14 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
             .keys()
             .all(|property| self.properties.contains(property) || self.pattern.is_match(property))
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -441,6 +553,14 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
                         .into_owned(),
                 )
             })
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/all_of.rs
+++ b/src/keywords/all_of.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{CompilationError, ErrorIterator},
-    keywords::format_vec_of_validators,
+    keywords::{format_vec_of_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::format_vec_of_validators,
+    keywords::{format_vec_of_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/boolean.rs
+++ b/src/keywords/boolean.rs
@@ -1,29 +1,17 @@
 use crate::{
-    compilation::JSONSchema,
-    error::{error, no_error, ErrorIterator, ValidationError},
-    keywords::CompilationResult,
+    compilation::JSONSchema, error::ValidationError, keywords::CompilationResult,
     validator::Validate,
 };
-use serde_json::Value;
+use serde_json::{Map, Value};
 
 pub struct TrueValidator {}
-
 impl TrueValidator {
     #[inline]
     pub(crate) fn compile() -> CompilationResult {
         Ok(Box::new(TrueValidator {}))
     }
 }
-
 impl Validate for TrueValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, _: &'a Value) -> ErrorIterator<'a> {
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {
-        true
-    }
-
     fn name(&self) -> String {
         "true".to_string()
     }
@@ -39,16 +27,46 @@ impl FalseValidator {
 }
 
 impl Validate for FalseValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        error(ValidationError::false_schema(instance))
-    }
-
-    fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {
-        false
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::false_schema(instance)
     }
 
     fn name(&self) -> String {
         "false".to_string()
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, _: bool) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_object(&self, _: &JSONSchema, _: &Value, _: &Map<String, Value>) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, _: f64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
+        false
     }
 }
 

--- a/src/keywords/boolean.rs
+++ b/src/keywords/boolean.rs
@@ -1,5 +1,7 @@
 use crate::{
-    compilation::JSONSchema, error::ValidationError, keywords::CompilationResult,
+    compilation::JSONSchema,
+    error::{error, no_error, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
     validator::Validate,
 };
 use serde_json::{Map, Value};
@@ -14,6 +16,16 @@ impl TrueValidator {
 impl Validate for TrueValidator {
     fn name(&self) -> String {
         "true".to_string()
+    }
+
+    #[inline]
+    fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {
+        true
+    }
+
+    #[inline]
+    fn validate<'a>(&self, _: &'a JSONSchema, _: &'a Value) -> ErrorIterator<'a> {
+        no_error()
     }
 }
 
@@ -67,6 +79,15 @@ impl Validate for FalseValidator {
     #[inline]
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         false
+    }
+    #[inline]
+    fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {
+        false
+    }
+
+    #[inline]
+    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        error(self.build_validation_error(instance))
     }
 }
 

--- a/src/keywords/boolean.rs
+++ b/src/keywords/boolean.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::JSONSchema,
     error::{error, no_error, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::Value;
 

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::ValidationError,
+    error::{error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -67,6 +67,23 @@ impl Validate for ConstArrayValidator {
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         false
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            self.is_valid_array(schema, instance, instance_value)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
 }
 
 struct ConstBooleanValidator {
@@ -120,6 +137,23 @@ impl Validate for ConstBooleanValidator {
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         false
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Bool(instance_value) = instance {
+            self.is_valid_boolean(schema, instance, *instance_value)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Bool(instance_value) = instance {
+            self.validate_boolean(schema, instance, *instance_value)
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
 }
 
 struct ConstNullValidator {}
@@ -170,6 +204,23 @@ impl Validate for ConstNullValidator {
     #[inline]
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         false
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Null = instance {
+            self.is_valid_null(schema, instance, ())
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Null = instance {
+            self.validate_null(schema, instance, ())
+        } else {
+            error(self.build_validation_error(instance))
+        }
     }
 }
 
@@ -243,6 +294,23 @@ impl Validate for ConstNumberValidator {
         #[allow(clippy::cast_precision_loss)]
         self.is_valid_number(schema, instance, instance_value as f64)
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Some(instance_value) = instance.as_f64() {
+            self.is_valid_number(schema, instance, instance_value)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Some(instance_value) = instance.as_f64() {
+            self.validate_number(schema, instance, instance_value)
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
 }
 
 struct ConstObjectValidator {
@@ -310,6 +378,23 @@ impl Validate for ConstObjectValidator {
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         false
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
 }
 
 struct ConstStringValidator {
@@ -364,6 +449,23 @@ impl Validate for ConstStringValidator {
     #[inline]
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         false
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            false
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            error(self.build_validation_error(instance))
+        }
     }
 }
 

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -1,7 +1,7 @@
-use super::{helpers, CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
+    keywords::{helpers, CompilationResult, Validate},
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -4,25 +4,84 @@ use crate::{
     keywords::CompilationResult,
     validator::Validate,
 };
-use serde_json::{Map, Value};
+use serde_json::{Map, Number, Value};
 use std::f64::EPSILON;
 
-pub struct ConstValidator {
-    value: Value,
+struct ConstArrayValidator {
+    value: Vec<Value>,
 }
-
-impl ConstValidator {
+impl ConstArrayValidator {
     #[inline]
-    pub(crate) fn compile(value: &Value) -> CompilationResult {
-        Ok(Box::new(ConstValidator {
-            value: value.clone(),
+    pub(crate) fn compile(value: &[Value]) -> CompilationResult {
+        Ok(Box::new(ConstArrayValidator {
+            value: value.to_vec(),
         }))
     }
 }
-
-impl Validate for ConstValidator {
+impl Validate for ConstArrayValidator {
+    #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
-        ValidationError::constant(instance, &self.value)
+        ValidationError::constant_array(instance, &self.value)
+    }
+
+    fn name(&self) -> String {
+        format!(
+            "const: [{}]",
+            self.value
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
+        self.value == instance_value
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, _: bool) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_object(&self, _: &JSONSchema, _: &Value, _: &Map<String, Value>) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, _: f64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
+        false
+    }
+}
+
+struct ConstBooleanValidator {
+    value: bool,
+}
+impl ConstBooleanValidator {
+    #[inline]
+    pub(crate) fn compile(value: bool) -> CompilationResult {
+        Ok(Box::new(ConstBooleanValidator { value }))
+    }
+}
+impl Validate for ConstBooleanValidator {
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::constant_boolean(instance, self.value)
     }
 
     fn name(&self) -> String {
@@ -30,37 +89,135 @@ impl Validate for ConstValidator {
     }
 
     #[inline]
-    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
-        self.value
-            .as_array()
-            .map_or_else(|| false, |value| value.as_slice() == instance_value)
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
+        false
     }
     #[inline]
     fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, instance_value: bool) -> bool {
-        self.value
-            .as_bool()
-            .map_or_else(|| false, |value| value == instance_value)
-    }
-    #[inline]
-    fn is_valid_object(
-        &self,
-        _: &JSONSchema,
-        _: &Value,
-        instance_value: &Map<String, Value>,
-    ) -> bool {
-        self.value
-            .as_object()
-            .map_or_else(|| false, |value| value == instance_value)
+        self.value == instance_value
     }
     #[inline]
     fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
-        self.value.is_null()
+        false
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, _: f64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_object(&self, _: &JSONSchema, _: &Value, _: &Map<String, Value>) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
+        false
+    }
+}
+
+struct ConstNullValidator {}
+impl ConstNullValidator {
+    #[inline]
+    pub(crate) fn compile() -> CompilationResult {
+        Ok(Box::new(ConstNullValidator {}))
+    }
+}
+impl Validate for ConstNullValidator {
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::constant_null(instance)
+    }
+
+    fn name(&self) -> String {
+        format!("const: {}", Value::Null)
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, _: bool) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, _: f64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_object(&self, _: &JSONSchema, _: &Value, _: &Map<String, Value>) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
+        false
+    }
+}
+
+struct ConstNumberValidator {
+    // This is saved in order to ensure that the error message is not altered by precision loss
+    original_value: Number,
+    value: f64,
+}
+impl ConstNumberValidator {
+    #[inline]
+    pub(crate) fn compile(original_value: &Number) -> CompilationResult {
+        Ok(Box::new(ConstNumberValidator {
+            original_value: original_value.clone(),
+            value: original_value
+                .as_f64()
+                .expect("A JSON number will always be representable as f64"),
+        }))
+    }
+}
+impl Validate for ConstNumberValidator {
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::constant_number(instance, &self.original_value)
+    }
+
+    fn name(&self) -> String {
+        format!("const: {}", self.original_value)
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, _: bool) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        false
     }
     #[inline]
     fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
-        self.value
-            .as_f64()
-            .map_or_else(|| false, |value| (value - instance_value).abs() < EPSILON)
+        (self.value - instance_value).abs() < EPSILON
+    }
+    #[inline]
+    fn is_valid_object(&self, _: &JSONSchema, _: &Value, _: &Map<String, Value>) -> bool {
+        false
     }
     #[inline]
     fn is_valid_signed_integer(
@@ -73,10 +230,8 @@ impl Validate for ConstValidator {
         self.is_valid_number(schema, instance, instance_value as f64)
     }
     #[inline]
-    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
-        self.value
-            .as_str()
-            .map_or_else(|| false, |value| value == instance_value)
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
+        false
     }
     #[inline]
     fn is_valid_unsigned_integer(
@@ -90,11 +245,140 @@ impl Validate for ConstValidator {
     }
 }
 
+struct ConstObjectValidator {
+    value: Map<String, Value>,
+}
+impl ConstObjectValidator {
+    #[inline]
+    pub(crate) fn compile(value: &Map<String, Value>) -> CompilationResult {
+        Ok(Box::new(ConstObjectValidator {
+            value: value.clone(),
+        }))
+    }
+}
+impl Validate for ConstObjectValidator {
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::constant_object(instance, &self.value)
+    }
+
+    fn name(&self) -> String {
+        format!(
+            "const: {{{}}}",
+            self.value
+                .iter()
+                .map(|(key, value)| format!(r#""{}":{}"#, key, value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, _: bool) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, _: f64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        &self.value == instance_value
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
+        false
+    }
+}
+
+struct ConstStringValidator {
+    value: String,
+}
+impl ConstStringValidator {
+    #[inline]
+    pub(crate) fn compile(value: &str) -> CompilationResult {
+        Ok(Box::new(ConstStringValidator {
+            value: value.to_string(),
+        }))
+    }
+}
+impl Validate for ConstStringValidator {
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::constant_string(instance, &self.value)
+    }
+
+    fn name(&self) -> String {
+        format!(r#"const: "{}""#, self.value)
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, _: bool) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, _: f64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_object(&self, _: &JSONSchema, _: &Value, _: &Map<String, Value>) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
+        false
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
+        self.value == instance_value
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
+        false
+    }
+}
+
 #[inline]
 pub fn compile(
     _: &Map<String, Value>,
     schema: &Value,
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
-    Some(ConstValidator::compile(schema))
+    match schema {
+        Value::Array(items) => Some(ConstArrayValidator::compile(items)),
+        Value::Bool(item) => Some(ConstBooleanValidator::compile(*item)),
+        Value::Null => Some(ConstNullValidator::compile()),
+        Value::Number(item) => Some(ConstNumberValidator::compile(item)),
+        Value::Object(map) => Some(ConstObjectValidator::compile(map)),
+        Value::String(string) => Some(ConstStringValidator::compile(string)),
+    }
 }

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -1,9 +1,11 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, ErrorIterator, ValidationError},
-    keywords::{helpers, CompilationResult, Validate},
+    error::ValidationError,
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
+use std::f64::EPSILON;
 
 pub struct ConstValidator {
     value: Value,
@@ -19,22 +21,75 @@ impl ConstValidator {
 }
 
 impl Validate for ConstValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if self.is_valid(schema, instance) {
-            no_error()
-        } else {
-            error(ValidationError::constant(instance, &self.value))
-        }
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        helpers::equal(instance, &self.value)
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::constant(instance, &self.value)
     }
 
     fn name(&self) -> String {
         format!("const: {}", self.value)
     }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
+        self.value
+            .as_array()
+            .map_or_else(|| false, |value| value.as_slice() == instance_value)
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, instance_value: bool) -> bool {
+        self.value
+            .as_bool()
+            .map_or_else(|| false, |value| value == instance_value)
+    }
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        self.value
+            .as_object()
+            .map_or_else(|| false, |value| value == instance_value)
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        self.value.is_null()
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
+        self.value
+            .as_f64()
+            .map_or_else(|| false, |value| (value - instance_value).abs() < EPSILON)
+    }
+    #[inline]
+    fn is_valid_signed_integer(
+        &self,
+        schema: &JSONSchema,
+        instance: &Value,
+        instance_value: i64,
+    ) -> bool {
+        #[allow(clippy::cast_precision_loss)]
+        self.is_valid_number(schema, instance, instance_value as f64)
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
+        self.value
+            .as_str()
+            .map_or_else(|| false, |value| value == instance_value)
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(
+        &self,
+        schema: &JSONSchema,
+        instance: &Value,
+        instance_value: u64,
+    ) -> bool {
+        #[allow(clippy::cast_precision_loss)]
+        self.is_valid_number(schema, instance, instance_value as f64)
+    }
 }
+
 #[inline]
 pub fn compile(
     _: &Map<String, Value>,

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::ValidationError,
+    error::{no_error, ErrorIterator, ValidationError},
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,
 };
@@ -41,6 +41,23 @@ impl Validate for ContainsValidator {
             }
         }
         false
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            self.is_valid_array(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
-    keywords::format_validators,
+    keywords::{format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -1,8 +1,9 @@
 //! Validators for `contentMediaType` and `contentEncoding` keywords.
-use super::{CompilationResult, ErrorIterator, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ValidationError},
+    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{from_str, Map, Value};
 

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -36,6 +36,14 @@ impl Validate for ContentMediaTypeValidator {
     fn is_valid_string(&self, _: &JSONSchema, instance: &Value, instance_value: &str) -> bool {
         (self.func)(instance, instance_value).next().is_none()
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_string<'a>(
@@ -45,6 +53,14 @@ impl Validate for ContentMediaTypeValidator {
         instance_value: &'a str,
     ) -> ErrorIterator<'a> {
         (self.func)(instance, instance_value)
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -76,6 +92,14 @@ impl Validate for ContentEncodingValidator {
     fn is_valid_string(&self, _: &JSONSchema, instance: &Value, instance_value: &str) -> bool {
         (self.func)(instance, instance_value).next().is_none()
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_string<'a>(
@@ -85,6 +109,14 @@ impl Validate for ContentEncodingValidator {
         instance_value: &'a str,
     ) -> ErrorIterator<'a> {
         (self.func)(instance, instance_value)
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -129,6 +161,14 @@ impl Validate for ContentMediaTypeAndEncodingValidator {
             Err(_) => false,
         }
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_string<'a>(
@@ -145,6 +185,14 @@ impl Validate for ContentMediaTypeAndEncodingValidator {
                 Box::new(errors.into_iter())
             }
             Err(e) => error(e),
+        }
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            no_error()
         }
     }
 }

--- a/src/keywords/dependencies.rs
+++ b/src/keywords/dependencies.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::{CompilationError, ErrorIterator},
+    error::{no_error, CompilationError, ErrorIterator},
     keywords::{
         format_key_value_validators, required::RequiredValidator, CompilationResult, Validators,
     },
@@ -54,6 +54,14 @@ impl Validate for DependenciesValidator {
                 })
             })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -75,6 +83,14 @@ impl Validate for DependenciesValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/dependencies.rs
+++ b/src/keywords/dependencies.rs
@@ -1,8 +1,10 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator},
-    keywords::{format_key_value_validators, required::RequiredValidator},
+    keywords::{
+        format_key_value_validators, required::RequiredValidator, CompilationResult, Validators,
+    },
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -1,7 +1,7 @@
-use super::{helpers, CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::{helpers, CompilationResult, Validate},
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -1,10 +1,13 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::{helpers, CompilationResult, Validate},
+    error::{CompilationError, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
+use std::f64::EPSILON;
 
+#[derive(Debug)]
 pub struct EnumValidator {
     options: Value,
     items: Vec<Value>,
@@ -24,15 +27,9 @@ impl EnumValidator {
 }
 
 impl Validate for EnumValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
-            return error(ValidationError::enumeration(instance, &self.options));
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        self.items.iter().any(|item| helpers::equal(instance, item))
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::enumeration(instance, &self.options)
     }
 
     fn name(&self) -> String {
@@ -44,6 +41,77 @@ impl Validate for EnumValidator {
                 .collect::<Vec<String>>()
                 .join(", ")
         )
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
+        self.items.iter().any(|item| {
+            if let Value::Array(value) = item {
+                value.as_slice() == instance_value
+            } else {
+                false
+            }
+        })
+    }
+    #[inline]
+    fn is_valid_boolean(&self, _: &JSONSchema, _: &Value, instance_value: bool) -> bool {
+        self.items.iter().any(|item| {
+            if let Value::Bool(value) = item {
+                *value == instance_value
+            } else {
+                false
+            }
+        })
+    }
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        self.items.iter().any(|item| {
+            if let Value::Object(value) = item {
+                value == instance_value
+            } else {
+                false
+            }
+        })
+    }
+    #[inline]
+    fn is_valid_null(&self, _: &JSONSchema, _: &Value, _: ()) -> bool {
+        self.items.iter().any(Value::is_null)
+    }
+    #[inline]
+    fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
+        self.items.iter().any(|item| {
+            item.as_f64()
+                .map_or_else(|| false, |value| (value - instance_value).abs() < EPSILON)
+        })
+    }
+    #[inline]
+    fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, instance_value: i64) -> bool {
+        self.items.iter().any(|item| {
+            item.as_i64()
+                .map_or_else(|| false, |value| value == instance_value)
+        })
+    }
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
+        self.items.iter().any(|item| {
+            if let Value::String(value) = item {
+                value == instance_value
+            } else {
+                false
+            }
+        })
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, instance_value: u64) -> bool {
+        self.items.iter().any(|item| {
+            item.as_u64()
+                .map_or_else(|| false, |value| value == instance_value)
+        })
     }
 }
 

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use num_cmp::NumCmp;
 use serde_json::{Map, Value};

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -20,37 +20,36 @@ pub struct ExclusiveMaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
-                schema: &'a JSONSchema,
-                instance: &'a Value,
-            ) -> ErrorIterator<'a> {
-                if self.is_valid(schema, instance) {
-                    no_error()
-                } else {
-                    error(ValidationError::exclusive_maximum(
-                        instance,
-                        self.limit as f64,
-                    )) // do not cast
-                }
-            }
-
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-                if let Value::Number(item) = instance {
-                    return if let Some(item) = item.as_u64() {
-                        NumCmp::num_lt(item, self.limit)
-                    } else if let Some(item) = item.as_i64() {
-                        NumCmp::num_lt(item, self.limit)
-                    } else {
-                        let item = item.as_f64().expect("Always valid");
-                        NumCmp::num_lt(item, self.limit)
-                    };
-                }
-                true
+            fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+                #[allow(trivial_numeric_casts)]
+                ValidationError::exclusive_maximum(instance, self.limit as f64)
             }
 
             fn name(&self) -> String {
                 format!("exclusiveMaximum: {}", self.limit)
+            }
+
+            #[inline]
+            fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
+                NumCmp::num_lt(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid_signed_integer(
+                &self,
+                _: &JSONSchema,
+                _: &Value,
+                instance_value: i64,
+            ) -> bool {
+                NumCmp::num_lt(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid_unsigned_integer(
+                &self,
+                _: &JSONSchema,
+                _: &Value,
+                instance_value: u64,
+            ) -> bool {
+                NumCmp::num_lt(instance_value, self.limit)
             }
         }
     };

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use num_cmp::NumCmp;
 use serde_json::{Map, Value};

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -20,37 +20,36 @@ pub struct ExclusiveMinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
-                schema: &'a JSONSchema,
-                instance: &'a Value,
-            ) -> ErrorIterator<'a> {
-                if self.is_valid(schema, instance) {
-                    no_error()
-                } else {
-                    error(ValidationError::exclusive_minimum(
-                        instance,
-                        self.limit as f64,
-                    )) // do not cast
-                }
-            }
-
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-                if let Value::Number(item) = instance {
-                    return if let Some(item) = item.as_u64() {
-                        NumCmp::num_gt(item, self.limit)
-                    } else if let Some(item) = item.as_i64() {
-                        NumCmp::num_gt(item, self.limit)
-                    } else {
-                        let item = item.as_f64().expect("Always valid");
-                        NumCmp::num_gt(item, self.limit)
-                    };
-                }
-                true
+            fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+                #[allow(trivial_numeric_casts)]
+                ValidationError::exclusive_minimum(instance, self.limit as f64)
             }
 
             fn name(&self) -> String {
                 format!("exclusiveMinimum: {}", self.limit)
+            }
+
+            #[inline]
+            fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
+                NumCmp::num_gt(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid_signed_integer(
+                &self,
+                _: &JSONSchema,
+                _: &Value,
+                instance_value: i64,
+            ) -> bool {
+                NumCmp::num_gt(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid_unsigned_integer(
+                &self,
+                _: &JSONSchema,
+                _: &Value,
+                instance_value: u64,
+            ) -> bool {
+                NumCmp::num_gt(instance_value, self.limit)
             }
         }
     };

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -20,6 +20,7 @@ pub struct ExclusiveMinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
+            #[inline]
             fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
                 #[allow(trivial_numeric_casts)]
                 ValidationError::exclusive_minimum(instance, self.limit as f64)
@@ -50,6 +51,43 @@ macro_rules! validate {
                 instance_value: u64,
             ) -> bool {
                 NumCmp::num_gt(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+                if let Some(instance_value) = instance.as_u64() {
+                    self.is_valid_unsigned_integer(schema, instance, instance_value)
+                } else if let Some(instance_value) = instance.as_i64() {
+                    self.is_valid_signed_integer(schema, instance, instance_value)
+                } else if let Some(instance_value) = instance.as_f64() {
+                    self.is_valid_number(schema, instance, instance_value)
+                } else {
+                    true
+                }
+            }
+
+            #[inline]
+            fn validate<'a>(
+                &self,
+                schema: &'a JSONSchema,
+                instance: &'a Value,
+            ) -> ErrorIterator<'a> {
+                if let Value::Number(instance_number) = instance {
+                    if let Some(instance_unsigned_integer) = instance_number.as_u64() {
+                        self.validate_unsigned_integer(schema, instance, instance_unsigned_integer)
+                    } else if let Some(instance_signed_integer) = instance_number.as_i64() {
+                        self.validate_signed_integer(schema, instance, instance_signed_integer)
+                    } else {
+                        self.validate_number(
+                            schema,
+                            instance,
+                            instance_number
+                                .as_f64()
+                                .expect("A JSON number will always be representabe as f64"),
+                        )
+                    }
+                } else {
+                    no_error()
+                }
             }
         }
     };

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -1,7 +1,7 @@
 //! Validator for `format` keyword.
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -58,6 +58,23 @@ macro_rules! string_format_validator {
             #[inline]
             fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_string: &str) -> bool {
                 $check(instance_string)
+            }
+            #[inline]
+            fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+                if let Value::String(instance_string) = instance {
+                    self.is_valid_string(schema, instance, instance_string)
+                } else {
+                    true
+                }
+            }
+
+            #[inline]
+            fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+                if let Value::String(instance_value) = instance {
+                    self.validate_string(schema, instance, instance_value)
+                } else {
+                    no_error()
+                }
             }
         );
     };

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -1,8 +1,9 @@
 //! Validator for `format` keyword.
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use chrono::{DateTime, NaiveDate};
 use regex::Regex;
@@ -298,7 +299,7 @@ pub fn compile(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use crate::compilation::JSONSchema;
     use serde_json::json;
 
     #[test]

--- a/src/keywords/helpers.rs
+++ b/src/keywords/helpers.rs
@@ -1,8 +1,0 @@
-use serde_json::Value;
-
-pub fn equal(left: &Value, right: &Value) -> bool {
-    match (left, right) {
-        (Value::Number(left), Value::Number(right)) => left.as_f64() == right.as_f64(),
-        (_, _) => left == right,
-    }
-}

--- a/src/keywords/if_.rs
+++ b/src/keywords/if_.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator},
-    keywords::format_validators,
+    keywords::{format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/items.rs
+++ b/src/keywords/items.rs
@@ -1,8 +1,10 @@
-use super::{boolean::TrueValidator, CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator},
-    keywords::{format_validators, format_vec_of_validators},
+    keywords::{
+        boolean::TrueValidator, format_validators, format_vec_of_validators, CompilationResult,
+        Validate, Validators,
+    },
 };
 use rayon::prelude::*;
 use serde_json::{Map, Value};

--- a/src/keywords/items.rs
+++ b/src/keywords/items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::ErrorIterator,
+    error::{no_error, ErrorIterator},
     keywords::{
         boolean::TrueValidator, format_validators, format_vec_of_validators, CompilationResult,
         Validators,
@@ -40,6 +40,14 @@ impl Validate for ItemsArrayValidator {
                     .all(move |validator| validator.is_valid(schema, item))
             })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            self.is_valid_array(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_array<'a>(
@@ -60,6 +68,14 @@ impl Validate for ItemsArrayValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 
@@ -94,6 +110,14 @@ impl Validate for ItemsObjectValidator {
             })
         }
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            self.is_valid_array(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_array<'a>(
@@ -123,6 +147,14 @@ impl Validate for ItemsObjectValidator {
                 .collect()
         };
         Box::new(errors.into_iter())
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/legacy/maximum_draft_4.rs
+++ b/src/keywords/legacy/maximum_draft_4.rs
@@ -1,5 +1,7 @@
-use super::super::{exclusive_maximum, maximum, CompilationResult};
-use crate::compilation::CompilationContext;
+use crate::{
+    compilation::CompilationContext,
+    keywords::{exclusive_maximum, maximum, CompilationResult},
+};
 use serde_json::{Map, Value};
 
 #[inline]

--- a/src/keywords/legacy/minimum_draft_4.rs
+++ b/src/keywords/legacy/minimum_draft_4.rs
@@ -1,5 +1,7 @@
-use super::super::{exclusive_minimum, minimum, CompilationResult};
-use crate::compilation::CompilationContext;
+use crate::{
+    compilation::CompilationContext,
+    keywords::{exclusive_minimum, minimum, CompilationResult},
+};
 use serde_json::{Map, Value};
 
 #[inline]

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -1,7 +1,7 @@
-use super::super::{type_, CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::{type_, CompilationResult, Validate},
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
 };
 use serde_json::{Map, Number, Value};

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -33,6 +33,23 @@ impl Validate for MaxItemsValidator {
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         instance_value.len() as u64 <= self.limit
+    }
+    #[inline]
+    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            instance_value.len() as u64 <= self.limit
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -21,26 +21,18 @@ impl MaxItemsValidator {
 }
 
 impl Validate for MaxItemsValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Array(items) = instance {
-            if (items.len() as u64) > self.limit {
-                return error(ValidationError::max_items(instance, self.limit));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Array(items) = instance {
-            if (items.len() as u64) > self.limit {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::max_items(instance, self.limit)
     }
 
     fn name(&self) -> String {
         format!("maxItems: {}", self.limit)
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
+        instance_value.len() as u64 <= self.limit
     }
 }
 

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -21,28 +21,21 @@ impl MaxLengthValidator {
 }
 
 impl Validate for MaxLengthValidator {
-    fn validate<'a>(&self, _schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
-            if (item.chars().count() as u64) > self.limit {
-                return error(ValidationError::max_length(instance, self.limit));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
-            if (item.chars().count() as u64) > self.limit {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::max_length(instance, self.limit)
     }
 
     fn name(&self) -> String {
         format!("maxLength: {}", self.limit)
     }
+
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
+        instance_value.chars().count() as u64 <= self.limit
+    }
 }
+
 #[inline]
 pub fn compile(
     _: &Map<String, Value>,

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -33,6 +33,23 @@ impl Validate for MaxLengthValidator {
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
         instance_value.chars().count() as u64 <= self.limit
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -38,6 +38,23 @@ impl Validate for MaxPropertiesValidator {
         instance_value: &Map<String, Value>,
     ) -> bool {
         (instance_value.len() as u64) <= self.limit
+    }
+    #[inline]
+    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            instance_value.len() as u64 <= self.limit
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -21,26 +21,23 @@ impl MaxPropertiesValidator {
 }
 
 impl Validate for MaxPropertiesValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
-            if (item.len() as u64) > self.limit {
-                return error(ValidationError::max_properties(instance, self.limit));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
-            if (item.len() as u64) > self.limit {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::max_properties(instance, self.limit)
     }
 
     fn name(&self) -> String {
         format!("maxProperties: {}", self.limit)
+    }
+
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        (instance_value.len() as u64) <= self.limit
     }
 }
 

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use num_cmp::NumCmp;
 use serde_json::{Map, Value};

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -20,6 +20,7 @@ pub struct MaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
+            #[inline]
             fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
                 #[allow(trivial_numeric_casts)]
                 ValidationError::maximum(instance, self.limit as f64)
@@ -50,6 +51,43 @@ macro_rules! validate {
                 instance_value: u64,
             ) -> bool {
                 NumCmp::num_le(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+                if let Some(instance_value) = instance.as_u64() {
+                    self.is_valid_unsigned_integer(schema, instance, instance_value)
+                } else if let Some(instance_value) = instance.as_i64() {
+                    self.is_valid_signed_integer(schema, instance, instance_value)
+                } else if let Some(instance_value) = instance.as_f64() {
+                    self.is_valid_number(schema, instance, instance_value)
+                } else {
+                    true
+                }
+            }
+
+            #[inline]
+            fn validate<'a>(
+                &self,
+                schema: &'a JSONSchema,
+                instance: &'a Value,
+            ) -> ErrorIterator<'a> {
+                if let Value::Number(instance_number) = instance {
+                    if let Some(instance_unsigned_integer) = instance_number.as_u64() {
+                        self.validate_unsigned_integer(schema, instance, instance_unsigned_integer)
+                    } else if let Some(instance_signed_integer) = instance_number.as_i64() {
+                        self.validate_signed_integer(schema, instance, instance_signed_integer)
+                    } else {
+                        self.validate_number(
+                            schema,
+                            instance,
+                            instance_number
+                                .as_f64()
+                                .expect("A JSON number will always be representabe as f64"),
+                        )
+                    }
+                } else {
+                    no_error()
+                }
             }
         }
     };

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -20,34 +20,36 @@ pub struct MaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
-                schema: &'a JSONSchema,
-                instance: &'a Value,
-            ) -> ErrorIterator<'a> {
-                if self.is_valid(schema, instance) {
-                    no_error()
-                } else {
-                    error(ValidationError::maximum(instance, self.limit as f64)) // do not cast
-                }
-            }
-
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-                if let Value::Number(item) = instance {
-                    return if let Some(item) = item.as_u64() {
-                        !NumCmp::num_gt(item, self.limit)
-                    } else if let Some(item) = item.as_i64() {
-                        !NumCmp::num_gt(item, self.limit)
-                    } else {
-                        let item = item.as_f64().expect("Always valid");
-                        !NumCmp::num_gt(item, self.limit)
-                    };
-                }
-                true
+            fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+                #[allow(trivial_numeric_casts)]
+                ValidationError::maximum(instance, self.limit as f64)
             }
 
             fn name(&self) -> String {
                 format!("maximum: {}", self.limit)
+            }
+
+            #[inline]
+            fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
+                NumCmp::num_le(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid_signed_integer(
+                &self,
+                _: &JSONSchema,
+                _: &Value,
+                instance_value: i64,
+            ) -> bool {
+                NumCmp::num_le(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid_unsigned_integer(
+                &self,
+                _: &JSONSchema,
+                _: &Value,
+                instance_value: u64,
+            ) -> bool {
+                NumCmp::num_le(instance_value, self.limit)
             }
         }
     };

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -21,28 +21,21 @@ impl MinItemsValidator {
 }
 
 impl Validate for MinItemsValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Array(items) = instance {
-            if (items.len() as u64) < self.limit {
-                return error(ValidationError::min_items(instance, self.limit));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Array(items) = instance {
-            if (items.len() as u64) < self.limit {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::min_items(instance, self.limit)
     }
 
     fn name(&self) -> String {
         format!("minItems: {}", self.limit)
     }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
+        instance_value.len() as u64 >= self.limit
+    }
 }
+
 #[inline]
 pub fn compile(
     _: &Map<String, Value>,

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -33,6 +33,23 @@ impl Validate for MinItemsValidator {
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         instance_value.len() as u64 >= self.limit
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Array(instance_value) = instance {
+            self.is_valid_array(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Array(instance_value) = instance {
+            self.validate_array(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -33,6 +33,23 @@ impl Validate for MinLengthValidator {
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
         instance_value.chars().count() as u64 >= self.limit
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -21,26 +21,18 @@ impl MinLengthValidator {
 }
 
 impl Validate for MinLengthValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
-            if (item.chars().count() as u64) < self.limit {
-                return error(ValidationError::min_length(instance, self.limit));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
-            if (item.chars().count() as u64) < self.limit {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::min_length(instance, self.limit)
     }
 
     fn name(&self) -> String {
         format!("minLength: {}", self.limit)
+    }
+
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
+        instance_value.chars().count() as u64 >= self.limit
     }
 }
 

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -38,6 +38,23 @@ impl Validate for MinPropertiesValidator {
         instance_value: &Map<String, Value>,
     ) -> bool {
         instance_value.len() as u64 >= self.limit
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -21,26 +21,23 @@ impl MinPropertiesValidator {
 }
 
 impl Validate for MinPropertiesValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
-            if (item.len() as u64) < self.limit {
-                return error(ValidationError::min_properties(instance, self.limit));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
-            if (item.len() as u64) < self.limit {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::min_properties(instance, self.limit)
     }
 
     fn name(&self) -> String {
         format!("minProperties: {}", self.limit)
+    }
+
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        instance_value.len() as u64 >= self.limit
     }
 }
 

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use num_cmp::NumCmp;
 use serde_json::{Map, Value};

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -20,6 +20,7 @@ pub struct MinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
+            #[inline]
             fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
                 #[allow(trivial_numeric_casts)]
                 ValidationError::minimum(instance, self.limit as f64)
@@ -50,6 +51,43 @@ macro_rules! validate {
                 instance_value: u64,
             ) -> bool {
                 NumCmp::num_ge(instance_value, self.limit)
+            }
+            #[inline]
+            fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+                if let Some(instance_value) = instance.as_u64() {
+                    self.is_valid_unsigned_integer(schema, instance, instance_value)
+                } else if let Some(instance_value) = instance.as_i64() {
+                    self.is_valid_signed_integer(schema, instance, instance_value)
+                } else if let Some(instance_value) = instance.as_f64() {
+                    self.is_valid_number(schema, instance, instance_value)
+                } else {
+                    true
+                }
+            }
+
+            #[inline]
+            fn validate<'a>(
+                &self,
+                schema: &'a JSONSchema,
+                instance: &'a Value,
+            ) -> ErrorIterator<'a> {
+                if let Value::Number(instance_number) = instance {
+                    if let Some(instance_unsigned_integer) = instance_number.as_u64() {
+                        self.validate_unsigned_integer(schema, instance, instance_unsigned_integer)
+                    } else if let Some(instance_signed_integer) = instance_number.as_i64() {
+                        self.validate_signed_integer(schema, instance, instance_signed_integer)
+                    } else {
+                        self.validate_number(
+                            schema,
+                            instance,
+                            instance_number
+                                .as_f64()
+                                .expect("A JSON number will always be representabe as f64"),
+                        )
+                    }
+                } else {
+                    no_error()
+                }
             }
         }
     };

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -34,26 +34,7 @@ pub mod ref_;
 pub mod required;
 pub mod type_;
 pub mod unique_items;
-use crate::{compilation::JSONSchema, error, error::ErrorIterator};
-use serde_json::Value;
-use std::fmt::{Debug, Error, Formatter};
-
-pub trait Validate: Send + Sync {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a>;
-    // The same as above, but does not construct ErrorIterator.
-    // It is faster for cases when the result is not needed (like anyOf), since errors are
-    // not constructed
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool;
-    fn name(&self) -> String {
-        "<validator>".to_string()
-    }
-}
-
-impl Debug for dyn Validate + Send + Sync {
-    fn fmt(&self, f: &mut Formatter<'_>) -> Result<(), Error> {
-        f.write_str(&self.name())
-    }
-}
+use crate::{error, validator::Validate};
 
 pub type CompilationResult = Result<BoxedValidator, error::CompilationError>;
 pub type BoxedValidator = Box<dyn Validate + Send + Sync>;
@@ -100,7 +81,7 @@ fn format_key_value_validators(validators: &[(String, Validators)]) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::JSONSchema;
+    use crate::compilation::JSONSchema;
     use serde_json::{json, Value};
     use test_case::test_case;
 

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -11,7 +11,6 @@ pub mod enum_;
 pub mod exclusive_maximum;
 pub mod exclusive_minimum;
 pub mod format;
-pub mod helpers;
 pub mod if_;
 pub mod items;
 pub mod legacy;
@@ -196,7 +195,13 @@ mod tests {
     #[test_case(json!({"uniqueItems": true}), json!([1, 1]), r#"'[1,1]' has non-unique elements"#)]
     fn error_message(schema: Value, instance: Value, expected: &str) {
         let compiled = JSONSchema::compile(&schema, None).unwrap();
-        let errors: Vec<_> = compiled.validate(&instance).unwrap_err().collect();
+        let errors: Vec<_> = compiled
+            .validate(&instance)
+            .expect_err(&format!(
+                "Validation error is expected. Schema=`{:?}` Instance=`{:?}`",
+                schema, instance
+            ))
+            .collect();
         assert_eq!(errors[0].to_string(), expected);
     }
 

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 use std::f64::EPSILON;

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -53,6 +53,23 @@ impl Validate for MultipleOfFloatValidator {
         #[allow(clippy::cast_precision_loss)]
         self.is_valid_number(schema, instance, instance_value as f64)
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Some(instance_value) = instance.as_f64() {
+            self.is_valid_number(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Some(instance_value) = instance.as_f64() {
+            self.validate_number(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
+    }
 }
 
 pub struct MultipleOfIntegerValidator {
@@ -104,6 +121,23 @@ impl Validate for MultipleOfIntegerValidator {
     ) -> bool {
         #[allow(clippy::cast_precision_loss)]
         self.is_valid_number(schema, instance, instance_value as f64)
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Some(instance_value) = instance.as_f64() {
+            self.is_valid_number(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Some(instance_value) = instance.as_f64() {
+            self.validate_number(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/not.rs
+++ b/src/keywords/not.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
-    keywords::format_validators,
+    keywords::{format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/not.rs
+++ b/src/keywords/not.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,
 };
@@ -22,25 +22,42 @@ impl NotValidator {
     }
 }
 
-impl Validate for NotValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if self.is_valid(schema, instance) {
-            no_error()
-        } else {
-            error(ValidationError::not(instance, self.original.clone()))
+macro_rules! not_impl_is_valid {
+    ($method_suffix:tt, $instance_type: ty) => {
+        paste::item! {
+            #[inline]
+            fn [<is_valid_ $method_suffix>](
+                &self,
+                schema: &JSONSchema,
+                instance: &Value,
+                instance_value: $instance_type,
+            ) -> bool {
+                !self
+                .validators
+                .iter()
+                .all(|validator| validator.[<is_valid_ $method_suffix>](schema, instance, instance_value))
+            }
         }
-    }
-
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        !self
-            .validators
-            .iter()
-            .all(|validator| validator.is_valid(schema, instance))
+    };
+}
+impl Validate for NotValidator {
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::not(instance, self.original.clone())
     }
 
     fn name(&self) -> String {
         format!("not: {}", format_validators(&self.validators))
     }
+
+    not_impl_is_valid!(array, &[Value]);
+    not_impl_is_valid!(boolean, bool);
+    not_impl_is_valid!(null, ());
+    not_impl_is_valid!(number, f64);
+    not_impl_is_valid!(object, &Map<String, Value>);
+    not_impl_is_valid!(signed_integer, i64);
+    not_impl_is_valid!(string, &str);
+    not_impl_is_valid!(unsigned_integer, u64);
 }
 
 #[inline]

--- a/src/keywords/one_of.rs
+++ b/src/keywords/one_of.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::format_vec_of_validators,
+    keywords::{format_vec_of_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/one_of.rs
+++ b/src/keywords/one_of.rs
@@ -22,61 +22,90 @@ impl OneOfValidator {
         }
         Err(CompilationError::SchemaError)
     }
-
-    fn get_first_valid(&self, schema: &JSONSchema, instance: &Value) -> Option<usize> {
-        let mut first_valid_idx = None;
-        for (idx, validators) in self.schemas.iter().enumerate() {
-            if validators
-                .iter()
-                .all(|validator| validator.is_valid(schema, instance))
-            {
-                first_valid_idx = Some(idx);
-                break;
-            }
-        }
-        first_valid_idx
-    }
-
-    #[allow(clippy::integer_arithmetic)]
-    fn are_others_valid(&self, schema: &JSONSchema, instance: &Value, idx: usize) -> bool {
-        // `idx + 1` will not overflow, because the maximum possible value there is `usize::MAX - 1`
-        // For example we have `usize::MAX` schemas and only the last one is valid, then
-        // in `get_first_valid` we enumerate from `0`, and on the last index will be `usize::MAX - 1`
-        for validators in self.schemas.iter().skip(idx + 1) {
-            if validators
-                .iter()
-                .all(|validator| validator.is_valid(schema, instance))
-            {
-                return true;
-            }
-        }
-        false
-    }
 }
 
-impl Validate for OneOfValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        let first_valid_idx = self.get_first_valid(schema, instance);
-        if let Some(idx) = first_valid_idx {
-            if self.are_others_valid(schema, instance, idx) {
-                return error(ValidationError::one_of_multiple_valid(instance));
+macro_rules! one_of_impl_is_valid {
+    ($method_suffix:tt, $instance_type: ty) => {
+        paste::item! {
+            #[inline]
+            fn [<is_valid_ $method_suffix>](
+                &self,
+                schema: &JSONSchema,
+                instance: &Value,
+                instance_value: $instance_type,
+            ) -> bool {
+                let mut valid_schema_iterator = self.schemas
+                    .iter()
+                    .filter(|validators| {
+                        validators
+                            .iter()
+                            .all(|validator| validator.[<is_valid_ $method_suffix>](schema, instance, instance_value))
+                    });
+
+                if valid_schema_iterator.next().is_some() {
+                    // If one schema is valid we need to ensure that there are no other valid schemas
+                    valid_schema_iterator.next().is_none()
+                } else {
+                    false
+                }
             }
-            no_error()
-        } else {
-            error(ValidationError::one_of_not_valid(instance))
         }
-    }
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        let first_valid_idx = self.get_first_valid(schema, instance);
-        if let Some(idx) = first_valid_idx {
-            !self.are_others_valid(schema, instance, idx)
-        } else {
-            false
+    };
+}
+macro_rules! one_of_impl_validate {
+    ($method_suffix:tt, $instance_type: ty) => {
+        paste::item! {
+            #[inline]
+            fn [<validate_ $method_suffix>]<'a>(
+                &self,
+                schema: &'a JSONSchema,
+                instance: &'a Value,
+                instance_value: $instance_type,
+            ) -> ErrorIterator<'a> {
+                let mut valid_schema_iterator = self.schemas
+                    .iter()
+                    .filter(|validators| {
+                        validators
+                            .iter()
+                            .all(|validator| validator.[<is_valid_ $method_suffix>](schema, instance, instance_value))
+                    });
+
+                if valid_schema_iterator.next().is_some() {
+                    // If one schema is valid we need to ensure that there are no other valid schemas
+                    if valid_schema_iterator.next().is_none() {
+                        no_error()
+                    } else {
+                        error(ValidationError::one_of_multiple_valid(instance))
+                    }
+                } else {
+                    error(ValidationError::one_of_not_valid(instance))
+                }
+            }
         }
-    }
+    };
+}
+impl Validate for OneOfValidator {
     fn name(&self) -> String {
         format!("oneOf: [{}]", format_vec_of_validators(&self.schemas))
     }
+
+    one_of_impl_is_valid!(array, &[Value]);
+    one_of_impl_is_valid!(boolean, bool);
+    one_of_impl_is_valid!(null, ());
+    one_of_impl_is_valid!(number, f64);
+    one_of_impl_is_valid!(object, &Map<String, Value>);
+    one_of_impl_is_valid!(signed_integer, i64);
+    one_of_impl_is_valid!(string, &str);
+    one_of_impl_is_valid!(unsigned_integer, u64);
+
+    one_of_impl_validate!(array, &[Value]);
+    one_of_impl_validate!(boolean, bool);
+    one_of_impl_validate!(null, ());
+    one_of_impl_validate!(number, f64);
+    one_of_impl_validate!(object, &Map<String, Value>);
+    one_of_impl_validate!(signed_integer, i64);
+    one_of_impl_validate!(string, &str);
+    one_of_impl_validate!(unsigned_integer, u64);
 }
 
 #[inline]

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -9,7 +9,7 @@ use serde_json::{Map, Value};
 
 use std::ops::Index;
 
-lazy_static! {
+lazy_static::lazy_static! {
     static ref CONTROL_GROUPS_RE: Regex = Regex::new(r"\\c[A-Za-z]").expect("Is a valid regex");
 }
 
@@ -35,26 +35,18 @@ impl PatternValidator {
 }
 
 impl Validate for PatternValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::String(item) = instance {
-            if !self.pattern.is_match(item) {
-                return error(ValidationError::pattern(instance, self.original.clone()));
-            }
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::String(item) = instance {
-            if !self.pattern.is_match(item) {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::pattern(instance, self.original.clone())
     }
 
     fn name(&self) -> String {
         format!("pattern: {}", self.pattern)
+    }
+
+    #[inline]
+    fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
+        self.pattern.is_match(instance_value)
     }
 }
 

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{CompilationError, ValidationError},
+    error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -47,6 +47,23 @@ impl Validate for PatternValidator {
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
         self.pattern.is_match(instance_value)
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::String(instance_value) = instance {
+            self.is_valid_string(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
+
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::String(instance_value) = instance {
+            self.validate_string(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use regex::{Captures, Regex};
 use serde_json::{Map, Value};

--- a/src/keywords/pattern_properties.rs
+++ b/src/keywords/pattern_properties.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator},
-    keywords::format_validators,
+    keywords::{format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use regex::Regex;
 use serde_json::{Map, Value};

--- a/src/keywords/properties.rs
+++ b/src/keywords/properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::{CompilationError, ErrorIterator},
+    error::{no_error, CompilationError, ErrorIterator},
     keywords::{format_key_value_validators, CompilationResult, Validators},
     validator::Validate,
 };
@@ -49,6 +49,14 @@ impl Validate for PropertiesValidator {
             })
         })
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -73,6 +81,14 @@ impl Validate for PropertiesValidator {
                 .collect::<Vec<_>>()
                 .into_iter(),
         )
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/properties.rs
+++ b/src/keywords/properties.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
-    error::{no_error, CompilationError, ErrorIterator},
+    error::{CompilationError, ErrorIterator},
     keywords::{format_key_value_validators, CompilationResult, Validators},
     validator::Validate,
 };
@@ -27,43 +27,51 @@ impl PropertiesValidator {
 }
 
 impl Validate for PropertiesValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
-            let errors: Vec<_> = self
-                .properties
-                .iter()
-                .flat_map(move |(name, validators)| {
-                    let option = item.get(name);
-                    option.into_iter().flat_map(move |item| {
-                        validators
-                            .iter()
-                            .flat_map(move |validator| validator.validate(schema, item))
-                    })
-                })
-                .collect();
-            return Box::new(errors.into_iter());
-        }
-        no_error()
-    }
-
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
-            return self.properties.iter().all(move |(name, validators)| {
-                let option = item.get(name);
-                option.into_iter().all(move |item| {
-                    validators
-                        .iter()
-                        .all(move |validator| validator.is_valid(schema, item))
-                })
-            });
-        }
-        true
-    }
-
     fn name(&self) -> String {
         format!(
             "properties: {{{}}}",
             format_key_value_validators(&self.properties)
+        )
+    }
+
+    #[inline]
+    fn is_valid_object(
+        &self,
+        schema: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        self.properties.iter().all(|(name, validators)| {
+            instance_value.get(name).into_iter().all(|sub_value| {
+                validators
+                    .iter()
+                    .all(|validator| validator.is_valid(schema, sub_value))
+            })
+        })
+    }
+
+    #[inline]
+    fn validate_object<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        _: &'a Value,
+        instance_value: &'a Map<String, Value>,
+    ) -> ErrorIterator<'a> {
+        Box::new(
+            self.properties
+                .iter()
+                .flat_map(move |(name, validators)| {
+                    instance_value
+                        .get(name)
+                        .into_iter()
+                        .flat_map(move |sub_value| {
+                            validators
+                                .iter()
+                                .flat_map(move |validator| validator.validate(schema, sub_value))
+                        })
+                })
+                .collect::<Vec<_>>()
+                .into_iter(),
         )
     }
 }

--- a/src/keywords/properties.rs
+++ b/src/keywords/properties.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator},
-    keywords::format_key_value_validators,
+    keywords::{format_key_value_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/property_names.rs
+++ b/src/keywords/property_names.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate, Validators};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
-    keywords::format_validators,
+    keywords::{format_validators, CompilationResult, Validators},
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 use std::borrow::Borrow;

--- a/src/keywords/ref_.rs
+++ b/src/keywords/ref_.rs
@@ -5,7 +5,7 @@ use crate::{
     validator::Validate,
 };
 use parking_lot::RwLock;
-use serde_json::Value;
+use serde_json::{Map, Value};
 use url::Url;
 
 pub struct RefValidator {
@@ -29,6 +29,7 @@ impl RefValidator {
     }
 
     /// Ensure that validators are built and built once.
+    #[inline]
     fn ensure_validators<'a>(&self, schema: &'a JSONSchema) -> Result<(), ValidationError<'a>> {
         if self.validators.read().is_none() {
             let (scope, resolved) =
@@ -45,40 +46,85 @@ impl RefValidator {
     }
 }
 
+macro_rules! ref_impl_is_valid {
+    ($method_suffix:tt, $instance_type: ty) => {
+        paste::item! {
+            #[inline]
+            fn [<is_valid_ $method_suffix>](
+                &self,
+                schema: &JSONSchema,
+                instance: &Value,
+                instance_value: $instance_type,
+            ) -> bool {
+                if self.ensure_validators(schema).is_err() {
+                    false
+                } else {
+                    self.validators
+                        .read()
+                        .as_ref()
+                        .expect("ensure_validators guarantees the presence of the validators")
+                        .iter()
+                        .all(move |validator| {
+                            validator.[<is_valid_ $method_suffix>](schema, instance, instance_value)
+                        })
+                }
+            }
+        }
+    };
+}
+macro_rules! ref_impl_validate {
+    ($method_suffix:tt, $instance_type: ty) => {
+        paste::item! {
+            #[inline]
+            fn [<validate_ $method_suffix>]<'a>(
+                &self,
+                schema: &'a JSONSchema,
+                instance: &'a Value,
+                instance_value: $instance_type,
+            ) -> ErrorIterator<'a> {
+                if let Err(err) = self.ensure_validators(schema) {
+                    error(err)
+                } else {
+                    Box::new(
+                        self.validators
+                            .read()
+                            .as_ref()
+                            .expect("ensure_validators guarantees the presence of the validators")
+                            .iter()
+                            .flat_map(move |validator| {
+                                validator.[<validate_ $method_suffix>](schema, instance, instance_value)
+                            })
+                            .collect::<Vec<_>>()
+                            .into_iter(),
+                    )
+                }
+            }
+        }
+    };
+}
+
 impl Validate for RefValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Err(err) = self.ensure_validators(schema) {
-            error(err)
-        } else {
-            Box::new(
-                self.validators
-                    .read()
-                    .as_ref()
-                    .expect("ensure_validators guarantees the presence of the validators")
-                    .iter()
-                    .flat_map(move |validator| validator.validate(schema, instance))
-                    .collect::<Vec<_>>()
-                    .into_iter(),
-            )
-        }
-    }
-
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        if self.ensure_validators(schema).is_err() {
-            false
-        } else {
-            self.validators
-                .read()
-                .as_ref()
-                .expect("ensure_validators guarantees the presence of the validators")
-                .iter()
-                .all(move |validator| validator.is_valid(schema, instance))
-        }
-    }
-
     fn name(&self) -> String {
         format!("$ref: {}", self.reference)
     }
+
+    ref_impl_is_valid!(array, &[Value]);
+    ref_impl_is_valid!(boolean, bool);
+    ref_impl_is_valid!(null, ());
+    ref_impl_is_valid!(number, f64);
+    ref_impl_is_valid!(object, &Map<String, Value>);
+    ref_impl_is_valid!(signed_integer, i64);
+    ref_impl_is_valid!(string, &str);
+    ref_impl_is_valid!(unsigned_integer, u64);
+
+    ref_impl_validate!(array, &'a [Value]);
+    ref_impl_validate!(boolean, bool);
+    ref_impl_validate!(null, ());
+    ref_impl_validate!(number, f64);
+    ref_impl_validate!(object, &'a Map<String, Value>);
+    ref_impl_validate!(signed_integer, i64);
+    ref_impl_validate!(string, &'a str);
+    ref_impl_validate!(unsigned_integer, u64);
 }
 
 #[inline]

--- a/src/keywords/ref_.rs
+++ b/src/keywords/ref_.rs
@@ -1,8 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{error, ErrorIterator, ValidationError},
-    keywords::Validators,
+    keywords::{CompilationResult, Validators},
+    validator::Validate,
 };
 use parking_lot::RwLock;
 use serde_json::Value;

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -45,6 +45,14 @@ impl Validate for RequiredValidator {
             .iter()
             .all(|property_name| instance_value.contains_key(property_name))
     }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        if let Value::Object(instance_value) = instance {
+            self.is_valid_object(schema, instance, instance_value)
+        } else {
+            true
+        }
+    }
 
     #[inline]
     fn validate_object<'a>(
@@ -59,6 +67,14 @@ impl Validate for RequiredValidator {
             }
         }
         no_error()
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        if let Value::Object(instance_value) = instance {
+            self.validate_object(schema, instance, instance_value)
+        } else {
+            no_error()
+        }
     }
 }
 

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -30,29 +30,35 @@ impl RequiredValidator {
 }
 
 impl Validate for RequiredValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if let Value::Object(item) = instance {
-            for property_name in &self.required {
-                if !item.contains_key(property_name) {
-                    return error(ValidationError::required(instance, property_name.clone()));
-                }
+    fn name(&self) -> String {
+        format!("required: [{}]", self.required.join(", "))
+    }
+
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _: &JSONSchema,
+        _: &Value,
+        instance_value: &Map<String, Value>,
+    ) -> bool {
+        self.required
+            .iter()
+            .all(|property_name| instance_value.contains_key(property_name))
+    }
+
+    #[inline]
+    fn validate_object<'a>(
+        &self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: &'a Map<String, Value>,
+    ) -> ErrorIterator<'a> {
+        for property_name in &self.required {
+            if !instance_value.contains_key(property_name) {
+                return error(ValidationError::required(instance, property_name.clone()));
             }
         }
         no_error()
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Object(item) = instance {
-            return self
-                .required
-                .iter()
-                .all(|property_name| item.contains_key(property_name));
-        }
-        true
-    }
-
-    fn name(&self) -> String {
-        format!("required: [{}]", self.required.join(", "))
     }
 }
 

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -1,8 +1,9 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
+    validator::Validate,
 };
 use serde_json::{Map, Number, Value};
 use std::convert::TryFrom;

--- a/src/keywords/unique_items.rs
+++ b/src/keywords/unique_items.rs
@@ -1,6 +1,6 @@
 use crate::{
     compilation::{CompilationContext, JSONSchema},
-    error::{error, no_error, ErrorIterator, ValidationError},
+    error::ValidationError,
     keywords::CompilationResult,
     validator::Validate,
 };
@@ -68,25 +68,18 @@ impl UniqueItemsValidator {
 }
 
 impl Validate for UniqueItemsValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if self.is_valid(schema, instance) {
-            no_error()
-        } else {
-            error(ValidationError::unique_items(instance))
-        }
-    }
-
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
-        if let Value::Array(items) = instance {
-            if !is_unique(items) {
-                return false;
-            }
-        }
-        true
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::unique_items(instance)
     }
 
     fn name(&self) -> String {
         "uniqueItems: true".to_string()
+    }
+
+    #[inline]
+    fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
+        is_unique(instance_value)
     }
 }
 

--- a/src/keywords/unique_items.rs
+++ b/src/keywords/unique_items.rs
@@ -1,7 +1,8 @@
-use super::{CompilationResult, Validate};
 use crate::{
     compilation::{CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    validator::Validate,
 };
 use serde_json::{Map, Value};
 use std::{

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,6 +57,7 @@ mod keywords;
 mod primitive_type;
 mod resolver;
 mod schemas;
+mod validator;
 pub use compilation::JSONSchema;
 pub use error::{CompilationError, ErrorIterator, ValidationError};
 pub use schemas::Draft;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@
     missing_docs,
     missing_debug_implementations,
     trivial_casts,
+    trivial_numeric_casts,
     unused_extern_crates,
     unused_import_braces,
     unused_qualifications,
@@ -63,9 +64,6 @@ pub use error::{CompilationError, ErrorIterator, ValidationError};
 pub use schemas::Draft;
 use serde_json::Value;
 
-#[macro_use]
-extern crate lazy_static;
-
 /// Validates `instance` against `schema`. Draft version is detected automatically.
 /// ```rust
 /// use jsonschema::is_valid;
@@ -76,6 +74,7 @@ extern crate lazy_static;
 /// let instance = json!("foo");
 /// assert!(is_valid(&schema, &instance));
 /// ```
+#[must_use]
 #[inline]
 pub fn is_valid(schema: &Value, instance: &Value) -> bool {
     let compiled = JSONSchema::compile(schema, None).expect("Invalid schema");

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -48,7 +48,9 @@ impl<'a> Resolver<'a> {
                         let document: Value = response.json()?;
                         Ok(Cow::Owned(document))
                     }
-                    scheme => Err(ValidationError::unknown_reference_scheme(scheme.to_owned())),
+                    http_scheme => Err(ValidationError::unknown_reference_scheme(
+                        http_scheme.to_owned(),
+                    )),
                 },
             },
         }
@@ -217,7 +219,7 @@ mod tests {
         Resolver::new(
             Draft::Draft7,
             &Url::parse("json-schema:///").unwrap(),
-            &schema,
+            schema,
         )
         .unwrap()
     }

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,14 +1,251 @@
-use crate::{compilation::JSONSchema, error::ErrorIterator};
-use serde_json::Value;
+use crate::{
+    compilation::JSONSchema,
+    error::{error, no_error, ErrorIterator, ValidationError},
+};
+use serde_json::{Map, Value};
 use std::fmt;
 
 pub trait Validate: Send + Sync {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a>;
-    // The same as above, but does not construct ErrorIterator.
-    // It is faster for cases when the result is not needed (like anyOf), since errors are
-    // not constructed
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool;
+    #[inline]
+    fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
+        ValidationError::unexpected(instance, &self.name())
+    }
     fn name(&self) -> String;
+
+    #[inline]
+    fn is_valid_array(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: &[Value],
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_boolean(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: bool,
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_object(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: &Map<String, Value>,
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_null(&self, _schema: &JSONSchema, _instance: &Value, _instance_value: ()) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_number(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: f64,
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_signed_integer(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: i64,
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_string(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: &str,
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid_unsigned_integer(
+        &self,
+        _schema: &JSONSchema,
+        _instance: &Value,
+        _instance_value: u64,
+    ) -> bool {
+        true
+    }
+    #[inline]
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+        match instance {
+            Value::Array(instance_array) => self.is_valid_array(schema, instance, instance_array),
+            Value::Bool(instance_boolean) => {
+                self.is_valid_boolean(schema, instance, *instance_boolean)
+            }
+            Value::Null => self.is_valid_null(schema, instance, ()),
+            Value::Number(instance_number) => {
+                if let Some(instance_unsigned_integer) = instance_number.as_u64() {
+                    self.is_valid_unsigned_integer(schema, instance, instance_unsigned_integer)
+                } else if let Some(instance_signed_integer) = instance_number.as_i64() {
+                    self.is_valid_signed_integer(schema, instance, instance_signed_integer)
+                } else {
+                    self.is_valid_number(
+                        schema,
+                        instance,
+                        instance_number
+                            .as_f64()
+                            .expect("A JSON number will always be representabe as f64"),
+                    )
+                }
+            }
+            Value::Object(instance_object) => {
+                self.is_valid_object(schema, instance, instance_object)
+            }
+            Value::String(instance_string) => {
+                self.is_valid_string(schema, instance, instance_string)
+            }
+        }
+    }
+
+    #[inline]
+    fn validate_array<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: &'a [Value],
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_array(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_boolean<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: bool,
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_boolean(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_object<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: &'a Map<String, Value>,
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_object(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_null<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        _: (),
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_null(schema, instance, ()) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_number<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: f64,
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_number(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_signed_integer<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: i64,
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_signed_integer(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_string<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: &'a str,
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_string(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate_unsigned_integer<'a>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        instance_value: u64,
+    ) -> ErrorIterator<'a> {
+        if self.is_valid_unsigned_integer(schema, instance, instance_value) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
+        }
+    }
+    #[inline]
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        match instance {
+            Value::Array(instance_array) => self.validate_array(schema, instance, instance_array),
+            Value::Bool(instance_boolean) => {
+                self.validate_boolean(schema, instance, *instance_boolean)
+            }
+            Value::Null => self.validate_null(schema, instance, ()),
+            Value::Number(instance_number) => {
+                if let Some(instance_unsigned_integer) = instance_number.as_u64() {
+                    self.validate_unsigned_integer(schema, instance, instance_unsigned_integer)
+                } else if let Some(instance_signed_integer) = instance_number.as_i64() {
+                    self.validate_signed_integer(schema, instance, instance_signed_integer)
+                } else {
+                    self.validate_number(
+                        schema,
+                        instance,
+                        instance_number
+                            .as_f64()
+                            .expect("A JSON number will always be representable as f64"),
+                    )
+                }
+            }
+            Value::Object(instance_object) => {
+                self.validate_object(schema, instance, instance_object)
+            }
+            Value::String(instance_string) => {
+                self.validate_string(schema, instance, instance_string)
+            }
+        }
+    }
 }
 
 impl fmt::Debug for dyn Validate + Send + Sync {

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1,0 +1,18 @@
+use crate::{compilation::JSONSchema, error::ErrorIterator};
+use serde_json::Value;
+use std::fmt;
+
+pub trait Validate: Send + Sync {
+    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a>;
+    // The same as above, but does not construct ErrorIterator.
+    // It is faster for cases when the result is not needed (like anyOf), since errors are
+    // not constructed
+    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool;
+    fn name(&self) -> String;
+}
+
+impl fmt::Debug for dyn Validate + Send + Sync {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.name())
+    }
+}


### PR DESCRIPTION
This PR is related to #63 even if it is not fully addressing it yet.

Disclaimer: this is huge (and sorry in advance for that).

The concept of the PR is to have the a single point (or as limited as possible) where we do interact with `serde_json::Value::as_*` methods (or the logically equivalent pattern matching).

In order to achieve so the `Validate` trait needs to define a set of `is_valid_*` and `validate_*` methods.
By default (this is mostly done to reduce code verbosity if possible) the trait defines:
 *  `is_valid_*` as always returning true (essentially the `TrueValidator`)
 * `validate_*` methods do use the result of the matching `is_valid_*` to decide if they have to return `no_error` or a specific error (built via `Validate:: build_validation_error`)
 * `build_validation_error` to generate a `ValidationError` for the current instance (meant to reduce duplication and ensure that default implementation of `validate_*` makes sense)

Something to notice here is that I've not yet checked for benchmark results (that's one of the reason for the last commit in this PR) but I might eventually expect some small regression as all the code that has been created does not really have any inlining (not considering to do it now considering the huge size) but at the same time we should have some lifting from reduced interaction with `Value::as_*` methods

If tests are green (and they should) it would be mergeable, but considering the size and the few tricks and twists of few validators I would highly recommend a proper review.
