### PR TITLE
style: A rust library should not pin exact versions (use bounds instead)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,24 +14,24 @@ categories = ["web-programming"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-serde_json = "1.0.48"
-url = "2.1.1"
-lazy_static = "1.4.0"
-percent-encoding = "2.1.0"
-regex = "1.3.4"
-base64 = "0.12.0"
-chrono = "0.4.10"
-rayon = "1.3.0"
-reqwest = { version = "0.10.4", features = ["blocking", "json"]}
-parking_lot = "0.10.2"
+serde_json = "1"
+url = "2"
+lazy_static = "1"
+percent-encoding = "2"
+regex = "1"
+base64 = ">= 0.2"
+chrono = ">= 0.2"
+rayon = "1"
+reqwest = { version = ">= 0.10", features = ["blocking", "json"]}
+parking_lot = ">= 0.1"
 
 [dev-dependencies]
-paste = "0.1"
-criterion = "0.3.1"
+paste = ">= 0.1"
+criterion = ">= 0.1"
 draft = {path = "draft"}
-jsonschema-valid = "0.4.0"
-valico = "3.2.0"
-test-case = "1.0.0"
+jsonschema-valid = ">= 0.1"
+valico = "3"
+test-case = "1"
 
 [[bench]]
 name = "jsonschema"

--- a/draft/Cargo.toml
+++ b/draft/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 proc-macro = true
 
 [dependencies]
-serde_json = "1.0.48"
-heck = "0.3.1"
-quote = "1.0.5"
-syn = "1.0.21"
-proc-macro2 = "1.0.12"
+serde_json = "1"
+heck = ">= 0.1"
+quote = "1"
+syn = "1"
+proc-macro2 = "1"


### PR DESCRIPTION
Currently the library does define very tight dependencies and this is not common in libraries.
Libraries should be able to use any version of the dependencies that are compatible with the code.

Think about the case of: we're depending on `serde-json==1.0.48` and new versions are released (let's say `1.0.53`) and the new version does fix some bug or enhance performances.
With the current `Cargo.toml` definition users of `jsonschema` library will not have benefits of the `serde-json` improvements and even worst they might end-up with binaries that are embedding multiple version of the `serder-json` library.

For this reason we should describe what are the minimum versions required for the code to compile and perform properly (maybe we depend on an higher version due to bug fixes rather than exposed features).

If this library will be used to build binary applications they will be responsible for defining the exact list of used versions (via `Cargo.lock`) and if this library will be used as static library for FFI applications (ie. Python binding) then the project defining the static library will be responsible for pinning the dependencies.

Some reading is on https://doc.rust-lang.org/cargo/faq.html#why-do-binaries-have-cargolock-in-version-control-but-not-libraries