### PR TITLE
Create perf-helpers subproject to help in running code profiling

### DIFF
--- a/perf-helpers/.gitignore
+++ b/perf-helpers/.gitignore
@@ -1,0 +1,3 @@
+/Cargo.lock
+/target
+/trace.svg

--- a/perf-helpers/Cargo.toml
+++ b/perf-helpers/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "perf_helpers"
+version = "0.1.0"
+authors = ["Samuele Maci <macisamuele@gmail.com>"]
+edition = "2018"
+publish = false
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[dependencies]
+jsonschema = { path = "../" }
+serde_json = "1"
+
+[profile.release]
+debug = true

--- a/perf-helpers/run
+++ b/perf-helpers/run
@@ -1,0 +1,31 @@
+#!/bin/sh
+set -euo pipefail
+CURDIR=$(pwd)
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+if [ $# -lt 2 ]; then
+    echo "Usage: $0 <schema path> <instance path> [<number of iterations>]" > /dev/stderr
+    exit 1
+fi
+
+export SCHEMA_PATH="$(realpath $1)"
+export INSTANCE_PATH="$(realpath $2)"
+export NUMBER_OF_ITERATIONS="${3:-1234}"
+
+# Ensure that flamegraph is installed
+cargo flamegraph -h > /dev/null || cargo install flamegraph
+
+# Clear files before starting
+rm -rf trace.svg
+
+# Move into perf-helpers package
+pushd ${DIR}
+
+# Ensure that a new build is re-issued as the content of the
+# files and/or CLI arguments (env variables) might change
+cargo clean --release --package perf_helpers
+
+cargo flamegraph --root --output ${CURDIR}/trace.svg
+
+# Exits perf-helpers
+popd

--- a/perf-helpers/src/main.rs
+++ b/perf-helpers/src/main.rs
@@ -1,0 +1,24 @@
+use jsonschema::JSONSchema;
+use serde_json::{from_str, Error, Value};
+
+/// This executable is supposed to be used via ../run sh scrpt
+/// The script does trigger the build of the binary and is responsible
+/// injects for injecting the needed environmental variables
+fn main() -> Result<(), Error> {
+    let schema: Value = from_str(include_str!(env!("SCHEMA_PATH")))?;
+    let instance: Value = from_str(include_str!(env!("INSTANCE_PATH")))?;
+    let number_of_iterations: usize = env!("NUMBER_OF_ITERATIONS")
+        .parse()
+        .expect("NUMBER_OF_ITERATIONS is expected to be a positive integer");
+
+    eprintln!("Schema {}", schema);
+    eprintln!("Instance {}", instance);
+    eprintln!("Number of Iterations {}", number_of_iterations);
+
+    let compiled = JSONSchema::compile(&schema, None).unwrap();
+    for _ in 0..number_of_iterations {
+        compiled.is_valid(&instance);
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
The goal of this PR is to streamline the process of getting obtaining a flamegraph to focus optimisation efforts (as described on https://github.com/Stranger6667/jsonschema-rs/issues/91#issuecomment-633236132)

The `cargo-flamegraph` crate allows to run a binary with `perf`/`dtrace` (depending on the platform) and producing a SVG file containing the flamegraph.

In order to obtain it we need to have debug symbols in the release build (and the subproject takes care of that).

In order to make the tool easier to use I've ensured that `perf-helpers/src/main.rs` retrieves the schema and instance JSON representation at compile time, such that testing different combinations requires to modify the command to run instead of the file to compile.

The way of using it is
```sh
./perf-helpers/run ${schema_path} ${instance_path} [${number_of_iterations}]
```
The output file will be available on the directory from where you've run the script