### PR TITLE
perf: Replace `Map` with `BTreeSet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - Reuse parsed `DEFAULT_ROOT_URL` in `JSONSchema::compile`.
 - Avoid string allocation during `scope` parsing in `JSONSchema::compile`.
 - Refactor benchmark suite
+- Use `BTreeSet` in `additionalProperties` keyword during compilation to reduce the amount of copied data. [#91](https://github.com/Stranger6667/jsonschema-rs/pull/91)
 
 ## Fixed
 


### PR DESCRIPTION
Since it is not clear when `Vec` will be more efficient & when `HashSet` I think we can start from an easy win and use the same data structure but without copying values. The validation stays the same, but the compilation is noticeable faster (15-20%)