### PR TITLE
fix: `items` allows the presence of boolean schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Enable Link-Time Optimizations and set `codegen-units` to 1. [#104](https://github.com/Stranger6667/jsonschema-rs/issues/104)
+- fix: `items` allows the presence of boolean schemas. [#115](https://github.com/Stranger6667/jsonschema-rs/pull/115)
 
 ## [0.3.0] - 2020-06-08
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -15,9 +15,9 @@
     clippy::option_map_unwrap_or
 )]
 use jsonschema::Draft;
-use pyo3::prelude::*;
-use pyo3::types::PyAny;
-use pyo3::{create_exception, exceptions, wrap_pyfunction, PyObjectProtocol};
+use pyo3::{
+    create_exception, exceptions, prelude::*, types::PyAny, wrap_pyfunction, PyObjectProtocol,
+};
 use serde_json::Value;
 
 mod ser;

--- a/python/src/ser.rs
+++ b/python/src/ser.rs
@@ -1,10 +1,8 @@
-use pyo3::exceptions;
-use pyo3::ffi::*;
-use pyo3::prelude::*;
-use pyo3::types::PyAny;
-use pyo3::AsPyPointer;
-use serde::ser::{self, Serialize, SerializeMap, SerializeSeq};
-use serde::Serializer;
+use pyo3::{exceptions, ffi::*, prelude::*, types::PyAny, AsPyPointer};
+use serde::{
+    ser::{self, Serialize, SerializeMap, SerializeSeq},
+    Serializer,
+};
 
 use crate::{string, types};
 use std::ffi::CStr;

--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -1,7 +1,10 @@
 use crate::{
     compilation::{compile_validators, CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::{boolean::TrueValidator, format_validators, CompilationResult, Validators},
+    keywords::{
+        boolean::{FalseValidator, TrueValidator},
+        format_validators, CompilationResult, Validators,
+    },
     validator::Validate,
 };
 use serde_json::{Map, Value};
@@ -131,6 +134,13 @@ pub fn compile(
                         Some(AdditionalItemsBooleanValidator::compile(items_count))
                     }
                     _ => None,
+                }
+            }
+            Value::Bool(value) => {
+                if *value {
+                    Some(TrueValidator::compile())
+                } else {
+                    Some(FalseValidator::compile())
                 }
             }
             _ => Some(Err(CompilationError::SchemaError)),

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -241,6 +241,7 @@ mod tests {
     }
 
     #[test_case(json!({"additionalProperties": false}), json!({}))]
+    #[test_case(json!({"additionalItems": false, "items": true}), json!([]))]
     fn is_valid(schema: Value, instance: Value) {
         let data = json!(instance);
         let compiled = JSONSchema::compile(&schema, None).unwrap();


### PR DESCRIPTION
While working on https://github.com/macisamuele/jsonschema-equivalent I've noticed that having boolean schemas into `items` keyword result into an invalid schema, when instead it should be considered valid.

Example:
```json
{
    "additionalItems": false,
    "items": true
}
```
is considered an invalid schema but according to the [draft (section 6.4.1)](https://tools.ietf.org/html/draft-handrews-json-schema-validation-01#section-6.4.1)
> The value of "items" MUST be either a valid JSON Schema or an array of valid JSON Schemas.

and `true` or `false` are valid JSON Schemas.


The goal of this PR is to fix this.

PS: I'm aware that the example schema is unlikely to be composed by humans as it really is as restrictive as `true` schema, but it is still a possible valid schema.
