### PR TITLE
Bump json schema test suite

### DIFF
--- a/python/tests-py/test_suite.py
+++ b/python/tests-py/test_suite.py
@@ -8,7 +8,11 @@ import jsonschema_rs
 
 IS_WINDOWS = sys.platform == "win32"
 SUPPORTED_DRAFTS = (4, 6, 7)
-NOT_SUPPORTED_CASES = {4: ("bignum.json",), 6: ("bignum.json",), 7: ("bignum.json",)}
+NOT_SUPPORTED_CASES = {
+    4: ("bignum.json",),
+    6: ("bignum.json",),
+    7: ("bignum.json", "idn-hostname.json"),  # https://github.com/Stranger6667/jsonschema-rs/issues/101
+}
 
 
 def load_file(path):

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -77,8 +77,14 @@ fn convert_regex(pattern: &str) -> Result<Regex, regex::Error> {
             .replace(r"\D", "[^0-9]")
             .replace(r"\w", "[A-Za-z]")
             .replace(r"\W", "[^A-Za-z]")
-            .replace(r"\s", "[ \t\n\r\x0b\x0c]")
-            .replace(r"\S", "[^ \t\n\r\x0b\x0c]"),
+            .replace(
+                r"\s",
+                "[ \t\n\r\u{000b}\u{000c}\u{2003}\u{feff}\u{2029}\u{00a0}]",
+            )
+            .replace(
+                r"\S",
+                "[^ \t\n\r\u{000b}\u{000c}\u{2003}\u{feff}\u{2029}\u{00a0}]",
+            ),
     )
 }
 

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -1,5 +1,12 @@
 use draft::test_draft;
 
-test_draft!("tests/suite/tests/draft4/", {"optional_bignum_0_0", "optional_bignum_2_0"});
+test_draft!("tests/suite/tests/draft4/", {
+    "optional_bignum_0_0",
+    "optional_bignum_2_0",
+});
 test_draft!("tests/suite/tests/draft6/");
-test_draft!("tests/suite/tests/draft7/");
+test_draft!("tests/suite/tests/draft7/", {
+    "optional_format_idn_hostname_0_11", // https://github.com/Stranger6667/jsonschema-rs/issues/101
+    "optional_format_idn_hostname_0_6",  // https://github.com/Stranger6667/jsonschema-rs/issues/101
+    "optional_format_idn_hostname_0_7",  // https://github.com/Stranger6667/jsonschema-rs/issues/101
+});


### PR DESCRIPTION
The goal of this PR is to bump json-schema-test-suite.

NOTE: Tests of `resolver` needed to be updated in order to make them independent from the external testing suite (and so making easier future bumps)
I "just" copied the schema resulting from `load` without trying to simplify it to contain only the information useful for the test.