### PR TITLE
fix: Ensure that formats are applied only to correspondent drafts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - ECMAScript regex support
+- Formats should be associated to Draft versions (ie. `idn-hostname` is not defined on draft 4 and draft 6)
 
 ## [0.3.1] - 2020-06-21
 


### PR DESCRIPTION
The goal of this PR is to ensure that we have better association between formats and draft version.

Some formats are not available on all the supported drafts and by not managing this case we might end up validating foreign formats according to the drafts (ie. `idn-hostname` is not defined on draft 4 and draft 6).

This is an initial proposal, a more long-term solution (if we do expect many more drafts showing up) might be defining an order between drafts (`PartialOrd` trait) and ensure that certain formats are available only for a range of `Draft`s.
I've not implemented anything similar for now as the *exceptions* are not many (at least for now)