### PR TITLE
style: Extract Validate::name into ToString trait

### DIFF
--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -28,10 +28,6 @@ impl AdditionalItemsObjectValidator {
     }
 }
 impl Validate for AdditionalItemsObjectValidator {
-    fn name(&self) -> String {
-        format!("additionalItems: {}", format_validators(&self.validators))
-    }
-
     #[inline]
     fn is_valid_array(&self, schema: &JSONSchema, _: &Value, instance_array: &[Value]) -> bool {
         instance_array.iter().skip(self.items_count).all(|item| {
@@ -78,6 +74,11 @@ impl Validate for AdditionalItemsObjectValidator {
         }
     }
 }
+impl ToString for AdditionalItemsObjectValidator {
+    fn to_string(&self) -> String {
+        format!("additionalItems: {}", format_validators(&self.validators))
+    }
+}
 
 pub struct AdditionalItemsBooleanValidator {
     items_count: usize,
@@ -94,10 +95,6 @@ impl Validate for AdditionalItemsBooleanValidator {
         ValidationError::additional_items(instance, self.items_count)
     }
 
-    fn name(&self) -> String {
-        "additionalItems: false".to_string()
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_array: &[Value]) -> bool {
         instance_array.len() <= self.items_count
@@ -109,6 +106,11 @@ impl Validate for AdditionalItemsBooleanValidator {
         } else {
             true
         }
+    }
+}
+impl ToString for AdditionalItemsBooleanValidator {
+    fn to_string(&self) -> String {
+        "additionalItems: false".to_string()
     }
 }
 

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -20,13 +20,6 @@ impl AdditionalPropertiesValidator {
     }
 }
 impl Validate for AdditionalPropertiesValidator {
-    fn name(&self) -> String {
-        format!(
-            "additionalProperties: {}",
-            format_validators(&self.validators)
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -77,6 +70,14 @@ impl Validate for AdditionalPropertiesValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "additionalProperties: {}",
+            format_validators(&self.validators)
+        )
+    }
+}
 
 pub struct AdditionalPropertiesFalseValidator {}
 impl AdditionalPropertiesFalseValidator {
@@ -89,10 +90,6 @@ impl Validate for AdditionalPropertiesFalseValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::false_schema(instance)
-    }
-
-    fn name(&self) -> String {
-        "additionalProperties: false".to_string()
     }
 
     #[inline]
@@ -113,6 +110,11 @@ impl Validate for AdditionalPropertiesFalseValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesFalseValidator {
+    fn to_string(&self) -> String {
+        "additionalProperties: false".to_string()
+    }
+}
 
 pub struct AdditionalPropertiesNotEmptyFalseValidator {
     properties: BTreeSet<String>,
@@ -129,10 +131,6 @@ impl AdditionalPropertiesNotEmptyFalseValidator {
     }
 }
 impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
-    fn name(&self) -> String {
-        "additionalProperties: false".to_string()
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -178,6 +176,11 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesNotEmptyFalseValidator {
+    fn to_string(&self) -> String {
+        "additionalProperties: false".to_string()
+    }
+}
 
 pub struct AdditionalPropertiesNotEmptyValidator {
     validators: Validators,
@@ -200,13 +203,6 @@ impl AdditionalPropertiesNotEmptyValidator {
     }
 }
 impl Validate for AdditionalPropertiesNotEmptyValidator {
-    fn name(&self) -> String {
-        format!(
-            "additionalProperties: {}",
-            format_validators(&self.validators)
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -259,6 +255,14 @@ impl Validate for AdditionalPropertiesNotEmptyValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesNotEmptyValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "additionalProperties: {}",
+            format_validators(&self.validators)
+        )
+    }
+}
 
 pub struct AdditionalPropertiesWithPatternsValidator {
     validators: Validators,
@@ -278,13 +282,6 @@ impl AdditionalPropertiesWithPatternsValidator {
     }
 }
 impl Validate for AdditionalPropertiesWithPatternsValidator {
-    fn name(&self) -> String {
-        format!(
-            "additionalProperties: {}",
-            format_validators(&self.validators)
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -337,6 +334,14 @@ impl Validate for AdditionalPropertiesWithPatternsValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesWithPatternsValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "additionalProperties: {}",
+            format_validators(&self.validators)
+        )
+    }
+}
 
 pub struct AdditionalPropertiesWithPatternsFalseValidator {
     pattern: Regex,
@@ -350,10 +355,6 @@ impl AdditionalPropertiesWithPatternsFalseValidator {
     }
 }
 impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
-    fn name(&self) -> String {
-        "additionalProperties: false".to_string()
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -400,6 +401,11 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesWithPatternsFalseValidator {
+    fn to_string(&self) -> String {
+        "additionalProperties: false".to_string()
+    }
+}
 
 pub struct AdditionalPropertiesWithPatternsNotEmptyValidator {
     validators: Validators,
@@ -427,13 +433,6 @@ impl AdditionalPropertiesWithPatternsNotEmptyValidator {
     }
 }
 impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
-    fn name(&self) -> String {
-        format!(
-            "additionalProperties: {}",
-            format_validators(&self.validators)
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -491,6 +490,14 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
         }
     }
 }
+impl ToString for AdditionalPropertiesWithPatternsNotEmptyValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "additionalProperties: {}",
+            format_validators(&self.validators)
+        )
+    }
+}
 
 pub struct AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
     properties: BTreeSet<String>,
@@ -511,10 +518,6 @@ impl AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
     }
 }
 impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
-    fn name(&self) -> String {
-        "additionalProperties: false".to_string()
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -561,6 +564,11 @@ impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
+    fn to_string(&self) -> String {
+        "additionalProperties: false".to_string()
     }
 }
 

--- a/src/keywords/all_of.rs
+++ b/src/keywords/all_of.rs
@@ -71,10 +71,6 @@ macro_rules! all_of_impl_validate {
 }
 
 impl Validate for AllOfValidator {
-    fn name(&self) -> String {
-        format!("allOf: [{}]", format_vec_of_validators(&self.schemas))
-    }
-
     all_of_impl_is_valid!(array, &[Value]);
     all_of_impl_is_valid!(boolean, bool);
     all_of_impl_is_valid!(null, ());
@@ -92,6 +88,11 @@ impl Validate for AllOfValidator {
     all_of_impl_validate!(signed_integer, i64);
     all_of_impl_validate!(string, &'a str);
     all_of_impl_validate!(unsigned_integer, u64);
+}
+impl ToString for AllOfValidator {
+    fn to_string(&self) -> String {
+        format!("allOf: [{}]", format_vec_of_validators(&self.schemas))
+    }
 }
 
 #[inline]

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -51,10 +51,6 @@ impl Validate for AnyOfValidator {
         ValidationError::any_of(instance)
     }
 
-    fn name(&self) -> String {
-        format!("anyOf: [{}]", format_vec_of_validators(&self.schemas))
-    }
-
     any_of_impl_is_valid!(array, &[Value]);
     any_of_impl_is_valid!(boolean, bool);
     any_of_impl_is_valid!(null, ());
@@ -63,6 +59,11 @@ impl Validate for AnyOfValidator {
     any_of_impl_is_valid!(signed_integer, i64);
     any_of_impl_is_valid!(string, &str);
     any_of_impl_is_valid!(unsigned_integer, u64);
+}
+impl ToString for AnyOfValidator {
+    fn to_string(&self) -> String {
+        format!("anyOf: [{}]", format_vec_of_validators(&self.schemas))
+    }
 }
 
 #[inline]

--- a/src/keywords/boolean.rs
+++ b/src/keywords/boolean.rs
@@ -14,10 +14,6 @@ impl TrueValidator {
     }
 }
 impl Validate for TrueValidator {
-    fn name(&self) -> String {
-        "true".to_string()
-    }
-
     #[inline]
     fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {
         true
@@ -28,24 +24,23 @@ impl Validate for TrueValidator {
         no_error()
     }
 }
+impl ToString for TrueValidator {
+    fn to_string(&self) -> String {
+        "true".to_string()
+    }
+}
 
 pub struct FalseValidator {}
-
 impl FalseValidator {
     #[inline]
     pub(crate) fn compile() -> CompilationResult {
         Ok(Box::new(FalseValidator {}))
     }
 }
-
 impl Validate for FalseValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::false_schema(instance)
-    }
-
-    fn name(&self) -> String {
-        "false".to_string()
     }
 
     #[inline]
@@ -88,6 +83,11 @@ impl Validate for FalseValidator {
     #[inline]
     fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
         error(self.build_validation_error(instance))
+    }
+}
+impl ToString for FalseValidator {
+    fn to_string(&self) -> String {
+        "false".to_string()
     }
 }
 

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -24,17 +24,6 @@ impl Validate for ConstArrayValidator {
         ValidationError::constant_array(instance, &self.value)
     }
 
-    fn name(&self) -> String {
-        format!(
-            "const: [{}]",
-            self.value
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         self.value == instance_value
@@ -85,6 +74,18 @@ impl Validate for ConstArrayValidator {
         }
     }
 }
+impl ToString for ConstArrayValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "const: [{}]",
+            self.value
+                .iter()
+                .map(ToString::to_string)
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
 
 struct ConstBooleanValidator {
     value: bool,
@@ -99,10 +100,6 @@ impl Validate for ConstBooleanValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::constant_boolean(instance, self.value)
-    }
-
-    fn name(&self) -> String {
-        format!("const: {}", self.value)
     }
 
     #[inline]
@@ -155,6 +152,11 @@ impl Validate for ConstBooleanValidator {
         }
     }
 }
+impl ToString for ConstBooleanValidator {
+    fn to_string(&self) -> String {
+        format!("const: {}", self.value)
+    }
+}
 
 struct ConstNullValidator {}
 impl ConstNullValidator {
@@ -167,10 +169,6 @@ impl Validate for ConstNullValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::constant_null(instance)
-    }
-
-    fn name(&self) -> String {
-        format!("const: {}", Value::Null)
     }
 
     #[inline]
@@ -223,6 +221,11 @@ impl Validate for ConstNullValidator {
         }
     }
 }
+impl ToString for ConstNullValidator {
+    fn to_string(&self) -> String {
+        format!("const: {}", Value::Null)
+    }
+}
 
 struct ConstNumberValidator {
     // This is saved in order to ensure that the error message is not altered by precision loss
@@ -244,10 +247,6 @@ impl Validate for ConstNumberValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::constant_number(instance, &self.original_value)
-    }
-
-    fn name(&self) -> String {
-        format!("const: {}", self.original_value)
     }
 
     #[inline]
@@ -312,6 +311,11 @@ impl Validate for ConstNumberValidator {
         }
     }
 }
+impl ToString for ConstNumberValidator {
+    fn to_string(&self) -> String {
+        format!("const: {}", self.original_value)
+    }
+}
 
 struct ConstObjectValidator {
     value: Map<String, Value>,
@@ -328,17 +332,6 @@ impl Validate for ConstObjectValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::constant_object(instance, &self.value)
-    }
-
-    fn name(&self) -> String {
-        format!(
-            "const: {{{}}}",
-            self.value
-                .iter()
-                .map(|(key, value)| format!(r#""{}":{}"#, key, value))
-                .collect::<Vec<_>>()
-                .join(", ")
-        )
     }
 
     #[inline]
@@ -396,6 +389,18 @@ impl Validate for ConstObjectValidator {
         }
     }
 }
+impl ToString for ConstObjectValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "const: {{{}}}",
+            self.value
+                .iter()
+                .map(|(key, value)| format!(r#""{}":{}"#, key, value))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
 
 struct ConstStringValidator {
     value: String,
@@ -412,10 +417,6 @@ impl Validate for ConstStringValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::constant_string(instance, &self.value)
-    }
-
-    fn name(&self) -> String {
-        format!(r#"const: "{}""#, self.value)
     }
 
     #[inline]
@@ -466,6 +467,11 @@ impl Validate for ConstStringValidator {
         } else {
             error(self.build_validation_error(instance))
         }
+    }
+}
+impl ToString for ConstStringValidator {
+    fn to_string(&self) -> String {
+        format!(r#"const: "{}""#, self.value)
     }
 }
 

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -25,10 +25,6 @@ impl Validate for ContainsValidator {
         ValidationError::contains(instance)
     }
 
-    fn name(&self) -> String {
-        format!("contains: {}", format_validators(&self.validators))
-    }
-
     #[inline]
     fn is_valid_array(&self, schema: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         for item in instance_value {
@@ -58,6 +54,11 @@ impl Validate for ContainsValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for ContainsValidator {
+    fn to_string(&self) -> String {
+        format!("contains: {}", format_validators(&self.validators))
     }
 }
 

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -28,10 +28,6 @@ impl ContentMediaTypeValidator {
 
 /// Validator delegates validation to the stored function.
 impl Validate for ContentMediaTypeValidator {
-    fn name(&self) -> String {
-        format!("contentMediaType: {}", self.media_type)
-    }
-
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, instance: &Value, instance_value: &str) -> bool {
         (self.func)(instance, instance_value).next().is_none()
@@ -61,6 +57,11 @@ impl Validate for ContentMediaTypeValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for ContentMediaTypeValidator {
+    fn to_string(&self) -> String {
+        format!("contentMediaType: {}", self.media_type)
     }
 }
 
@@ -84,10 +85,6 @@ impl ContentEncodingValidator {
 }
 
 impl Validate for ContentEncodingValidator {
-    fn name(&self) -> String {
-        format!("contentEncoding: {}", self.encoding)
-    }
-
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, instance: &Value, instance_value: &str) -> bool {
         (self.func)(instance, instance_value).next().is_none()
@@ -117,6 +114,11 @@ impl Validate for ContentEncodingValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for ContentEncodingValidator {
+    fn to_string(&self) -> String {
+        format!("contentEncoding: {}", self.encoding)
     }
 }
 
@@ -147,13 +149,6 @@ impl ContentMediaTypeAndEncodingValidator {
 
 /// Decode the input value & check media type
 impl Validate for ContentMediaTypeAndEncodingValidator {
-    fn name(&self) -> String {
-        format!(
-            "{{contentMediaType: {}, contentEncoding: {}}}",
-            self.media_type, self.encoding
-        )
-    }
-
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, instance: &Value, instance_value: &str) -> bool {
         match (self.converter)(instance, instance_value) {
@@ -194,6 +189,14 @@ impl Validate for ContentMediaTypeAndEncodingValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for ContentMediaTypeAndEncodingValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "{{contentMediaType: {}, contentEncoding: {}}}",
+            self.media_type, self.encoding
+        )
     }
 }
 

--- a/src/keywords/dependencies.rs
+++ b/src/keywords/dependencies.rs
@@ -31,13 +31,6 @@ impl DependenciesValidator {
 }
 
 impl Validate for DependenciesValidator {
-    fn name(&self) -> String {
-        format!(
-            "dependencies: {{{}}}",
-            format_key_value_validators(&self.dependencies)
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -91,6 +84,14 @@ impl Validate for DependenciesValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for DependenciesValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "dependencies: {{{}}}",
+            format_key_value_validators(&self.dependencies)
+        )
     }
 }
 

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -32,17 +32,6 @@ impl Validate for EnumValidator {
         ValidationError::enumeration(instance, &self.options)
     }
 
-    fn name(&self) -> String {
-        format!(
-            "enum: [{}]",
-            self.items
-                .iter()
-                .map(Value::to_string)
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         self.items.iter().any(|item| {
@@ -112,6 +101,18 @@ impl Validate for EnumValidator {
             item.as_u64()
                 .map_or_else(|| false, |value| value == instance_value)
         })
+    }
+}
+impl ToString for EnumValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "enum: [{}]",
+            self.items
+                .iter()
+                .map(Value::to_string)
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -26,10 +26,6 @@ macro_rules! validate {
                 ValidationError::exclusive_maximum(instance, self.limit as f64)
             }
 
-            fn name(&self) -> String {
-                format!("exclusiveMaximum: {}", self.limit)
-            }
-
             #[inline]
             fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
                 NumCmp::num_lt(instance_value, self.limit)
@@ -88,6 +84,11 @@ macro_rules! validate {
                 } else {
                     no_error()
                 }
+            }
+        }
+        impl ToString for $validator {
+            fn to_string(&self) -> String {
+                format!("exclusiveMaximum: {}", self.limit)
             }
         }
     };

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -26,10 +26,6 @@ macro_rules! validate {
                 ValidationError::exclusive_minimum(instance, self.limit as f64)
             }
 
-            fn name(&self) -> String {
-                format!("exclusiveMinimum: {}", self.limit)
-            }
-
             #[inline]
             fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
                 NumCmp::num_gt(instance_value, self.limit)
@@ -88,6 +84,11 @@ macro_rules! validate {
                 } else {
                     no_error()
                 }
+            }
+        }
+        impl ToString for $validator {
+            fn to_string(&self) -> String {
+                format!("exclusiveMinimum: {}", self.limit)
             }
         }
     };

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -30,30 +30,32 @@ lazy_static::lazy_static! {
 }
 
 macro_rules! generic_format_validator {
-    ($name:ident, $format_name:tt => $($validate_components_extra:tt)*) => {
-        struct $name {}
-        impl $name {
+    ($validator:ident, $format_name:tt => $($validate_components_extra:tt)*) => {
+        struct $validator {}
+        impl $validator {
             pub(crate) fn compile() -> CompilationResult {
-                Ok(Box::new($name {}))
+                Ok(Box::new($validator {}))
             }
         }
-        impl Validate for $name {
+        impl Validate for $validator {
             #[inline]
             fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
                 ValidationError::format(instance, $format_name)
             }
-            fn name(&self) -> String {
+            $($validate_components_extra)*
+        }
+        impl ToString for $validator {
+            fn to_string(&self) -> String {
                 concat!("format: ", $format_name).to_string()
             }
-            $($validate_components_extra)*
         }
     };
 }
 
 macro_rules! string_format_validator {
-    ($name:ident, $format_name:tt, $check:expr) => {
+    ($validator:ident, $format_name:tt, $check:expr) => {
         generic_format_validator!(
-            $name,
+            $validator,
             $format_name =>
             #[inline]
             fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_string: &str) -> bool {

--- a/src/keywords/if_.rs
+++ b/src/keywords/if_.rs
@@ -82,14 +82,6 @@ macro_rules! if_then_impl_validate {
 }
 
 impl Validate for IfThenValidator {
-    fn name(&self) -> String {
-        format!(
-            "if: {}, then: {}",
-            format_validators(&self.schema),
-            format_validators(&self.then_schema)
-        )
-    }
-
     if_then_impl_is_valid!(array, &[Value]);
     if_then_impl_is_valid!(boolean, bool);
     if_then_impl_is_valid!(null, ());
@@ -107,6 +99,15 @@ impl Validate for IfThenValidator {
     if_then_impl_validate!(signed_integer, i64);
     if_then_impl_validate!(string, &'a str);
     if_then_impl_validate!(unsigned_integer, u64);
+}
+impl ToString for IfThenValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "if: {}, then: {}",
+            format_validators(&self.schema),
+            format_validators(&self.then_schema)
+        )
+    }
 }
 
 pub struct IfElseValidator {
@@ -185,14 +186,6 @@ macro_rules! if_else_impl_validate {
 }
 
 impl Validate for IfElseValidator {
-    fn name(&self) -> String {
-        format!(
-            "if: {}, else: {}",
-            format_validators(&self.schema),
-            format_validators(&self.else_schema)
-        )
-    }
-
     if_else_impl_is_valid!(array, &[Value]);
     if_else_impl_is_valid!(boolean, bool);
     if_else_impl_is_valid!(null, ());
@@ -210,6 +203,15 @@ impl Validate for IfElseValidator {
     if_else_impl_validate!(signed_integer, i64);
     if_else_impl_validate!(string, &'a str);
     if_else_impl_validate!(unsigned_integer, u64);
+}
+impl ToString for IfElseValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "if: {}, else: {}",
+            format_validators(&self.schema),
+            format_validators(&self.else_schema)
+        )
+    }
 }
 
 pub struct IfThenElseValidator {
@@ -300,15 +302,6 @@ macro_rules! if_then_else_impl_validate {
 }
 
 impl Validate for IfThenElseValidator {
-    fn name(&self) -> String {
-        format!(
-            "if: {}, then: {}, else: {}",
-            format_validators(&self.schema),
-            format_validators(&self.then_schema),
-            format_validators(&self.else_schema)
-        )
-    }
-
     if_then_else_impl_is_valid!(array, &[Value]);
     if_then_else_impl_is_valid!(boolean, bool);
     if_then_else_impl_is_valid!(null, ());
@@ -326,6 +319,16 @@ impl Validate for IfThenElseValidator {
     if_then_else_impl_validate!(signed_integer, i64);
     if_then_else_impl_validate!(string, &'a str);
     if_then_else_impl_validate!(unsigned_integer, u64);
+}
+impl ToString for IfThenElseValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "if: {}, then: {}, else: {}",
+            format_validators(&self.schema),
+            format_validators(&self.then_schema),
+            format_validators(&self.else_schema)
+        )
+    }
 }
 
 #[inline]

--- a/src/keywords/items.rs
+++ b/src/keywords/items.rs
@@ -25,10 +25,6 @@ impl ItemsArrayValidator {
     }
 }
 impl Validate for ItemsArrayValidator {
-    fn name(&self) -> String {
-        format!("items: [{}]", format_vec_of_validators(&self.items))
-    }
-
     #[inline]
     fn is_valid_array(&self, schema: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         instance_value
@@ -78,6 +74,11 @@ impl Validate for ItemsArrayValidator {
         }
     }
 }
+impl ToString for ItemsArrayValidator {
+    fn to_string(&self) -> String {
+        format!("items: [{}]", format_vec_of_validators(&self.items))
+    }
+}
 
 pub struct ItemsObjectValidator {
     validators: Validators,
@@ -90,10 +91,6 @@ impl ItemsObjectValidator {
     }
 }
 impl Validate for ItemsObjectValidator {
-    fn name(&self) -> String {
-        format!("items: {}", format_validators(&self.validators))
-    }
-
     #[inline]
     fn is_valid_array(&self, schema: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         if instance_value.len() > 8 {
@@ -155,6 +152,11 @@ impl Validate for ItemsObjectValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for ItemsObjectValidator {
+    fn to_string(&self) -> String {
+        format!("items: {}", format_validators(&self.validators))
     }
 }
 

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -38,17 +38,6 @@ impl Validate for MultipleTypesValidator {
         ValidationError::multiple_type_error(instance, self.types)
     }
 
-    fn name(&self) -> String {
-        format!(
-            "type: [{}]",
-            self.types
-                .into_iter()
-                .map(|type_| format!("{}", type_))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
         self.types.contains_type(PrimitiveType::Array)
@@ -82,7 +71,18 @@ impl Validate for MultipleTypesValidator {
         self.types.contains_type(PrimitiveType::Integer)
     }
 }
-
+impl ToString for MultipleTypesValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "type: [{}]",
+            self.types
+                .into_iter()
+                .map(|type_| format!("{}", type_))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
 pub struct IntegerTypeValidator {}
 
 impl IntegerTypeValidator {
@@ -96,10 +96,6 @@ impl Validate for IntegerTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Integer)
-    }
-
-    fn name(&self) -> String {
-        "type: integer".to_string()
     }
 
     #[inline]
@@ -146,6 +142,11 @@ impl Validate for IntegerTypeValidator {
         } else {
             error(self.build_validation_error(instance))
         }
+    }
+}
+impl ToString for IntegerTypeValidator {
+    fn to_string(&self) -> String {
+        "type: integer".to_string()
     }
 }
 

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -26,10 +26,6 @@ impl Validate for MaxItemsValidator {
         ValidationError::max_items(instance, self.limit)
     }
 
-    fn name(&self) -> String {
-        format!("maxItems: {}", self.limit)
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         instance_value.len() as u64 <= self.limit
@@ -50,6 +46,11 @@ impl Validate for MaxItemsValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MaxItemsValidator {
+    fn to_string(&self) -> String {
+        format!("maxItems: {}", self.limit)
     }
 }
 

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -26,10 +26,6 @@ impl Validate for MaxLengthValidator {
         ValidationError::max_length(instance, self.limit)
     }
 
-    fn name(&self) -> String {
-        format!("maxLength: {}", self.limit)
-    }
-
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
         instance_value.chars().count() as u64 <= self.limit
@@ -50,6 +46,11 @@ impl Validate for MaxLengthValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MaxLengthValidator {
+    fn to_string(&self) -> String {
+        format!("maxLength: {}", self.limit)
     }
 }
 

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -26,10 +26,6 @@ impl Validate for MaxPropertiesValidator {
         ValidationError::max_properties(instance, self.limit)
     }
 
-    fn name(&self) -> String {
-        format!("maxProperties: {}", self.limit)
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -55,6 +51,11 @@ impl Validate for MaxPropertiesValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MaxPropertiesValidator {
+    fn to_string(&self) -> String {
+        format!("maxProperties: {}", self.limit)
     }
 }
 

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -26,10 +26,6 @@ macro_rules! validate {
                 ValidationError::maximum(instance, self.limit as f64)
             }
 
-            fn name(&self) -> String {
-                format!("maximum: {}", self.limit)
-            }
-
             #[inline]
             fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
                 NumCmp::num_le(instance_value, self.limit)
@@ -88,6 +84,11 @@ macro_rules! validate {
                 } else {
                     no_error()
                 }
+            }
+        }
+        impl ToString for $validator {
+            fn to_string(&self) -> String {
+                format!("maximum: {}", self.limit)
             }
         }
     };

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -26,10 +26,6 @@ impl Validate for MinItemsValidator {
         ValidationError::min_items(instance, self.limit)
     }
 
-    fn name(&self) -> String {
-        format!("minItems: {}", self.limit)
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         instance_value.len() as u64 >= self.limit
@@ -50,6 +46,11 @@ impl Validate for MinItemsValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MinItemsValidator {
+    fn to_string(&self) -> String {
+        format!("minItems: {}", self.limit)
     }
 }
 

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -26,10 +26,6 @@ impl Validate for MinLengthValidator {
         ValidationError::min_length(instance, self.limit)
     }
 
-    fn name(&self) -> String {
-        format!("minLength: {}", self.limit)
-    }
-
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
         instance_value.chars().count() as u64 >= self.limit
@@ -50,6 +46,11 @@ impl Validate for MinLengthValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MinLengthValidator {
+    fn to_string(&self) -> String {
+        format!("minLength: {}", self.limit)
     }
 }
 

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -26,10 +26,6 @@ impl Validate for MinPropertiesValidator {
         ValidationError::min_properties(instance, self.limit)
     }
 
-    fn name(&self) -> String {
-        format!("minProperties: {}", self.limit)
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -55,6 +51,11 @@ impl Validate for MinPropertiesValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MinPropertiesValidator {
+    fn to_string(&self) -> String {
+        format!("minProperties: {}", self.limit)
     }
 }
 

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -26,10 +26,6 @@ macro_rules! validate {
                 ValidationError::minimum(instance, self.limit as f64)
             }
 
-            fn name(&self) -> String {
-                format!("minimum: {}", self.limit)
-            }
-
             #[inline]
             fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
                 NumCmp::num_ge(instance_value, self.limit)
@@ -88,6 +84,11 @@ macro_rules! validate {
                 } else {
                     no_error()
                 }
+            }
+        }
+        impl ToString for $validator {
+            fn to_string(&self) -> String {
+                format!("minimum: {}", self.limit)
             }
         }
     };

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -43,7 +43,7 @@ fn format_validators(validators: &[BoxedValidator]) -> String {
     match validators.len() {
         0 => "{}".to_string(),
         1 => {
-            let name = validators[0].name();
+            let name = validators[0].to_string();
             match name.as_str() {
                 // boolean validators are represented as is, without brackets because if they
                 // occur in a vector, then the schema is not a key/value mapping

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -24,10 +24,6 @@ impl Validate for MultipleOfFloatValidator {
         ValidationError::multiple_of(instance, self.multiple_of)
     }
 
-    fn name(&self) -> String {
-        format!("multipleOf: {}", self.multiple_of)
-    }
-
     #[inline]
     fn is_valid_number(&self, _: &JSONSchema, _: &Value, instance_value: f64) -> bool {
         let remainder = (instance_value / self.multiple_of) % 1.;
@@ -71,6 +67,11 @@ impl Validate for MultipleOfFloatValidator {
         }
     }
 }
+impl ToString for MultipleOfFloatValidator {
+    fn to_string(&self) -> String {
+        format!("multipleOf: {}", self.multiple_of)
+    }
+}
 
 pub struct MultipleOfIntegerValidator {
     multiple_of: f64,
@@ -87,10 +88,6 @@ impl Validate for MultipleOfIntegerValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::multiple_of(instance, self.multiple_of)
-    }
-
-    fn name(&self) -> String {
-        format!("multipleOf: {}", self.multiple_of)
     }
 
     #[inline]
@@ -138,6 +135,11 @@ impl Validate for MultipleOfIntegerValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for MultipleOfIntegerValidator {
+    fn to_string(&self) -> String {
+        format!("multipleOf: {}", self.multiple_of)
     }
 }
 

--- a/src/keywords/not.rs
+++ b/src/keywords/not.rs
@@ -46,10 +46,6 @@ impl Validate for NotValidator {
         ValidationError::not(instance, self.original.clone())
     }
 
-    fn name(&self) -> String {
-        format!("not: {}", format_validators(&self.validators))
-    }
-
     not_impl_is_valid!(array, &[Value]);
     not_impl_is_valid!(boolean, bool);
     not_impl_is_valid!(null, ());
@@ -58,6 +54,11 @@ impl Validate for NotValidator {
     not_impl_is_valid!(signed_integer, i64);
     not_impl_is_valid!(string, &str);
     not_impl_is_valid!(unsigned_integer, u64);
+}
+impl ToString for NotValidator {
+    fn to_string(&self) -> String {
+        format!("not: {}", format_validators(&self.validators))
+    }
 }
 
 #[inline]

--- a/src/keywords/one_of.rs
+++ b/src/keywords/one_of.rs
@@ -85,10 +85,6 @@ macro_rules! one_of_impl_validate {
     };
 }
 impl Validate for OneOfValidator {
-    fn name(&self) -> String {
-        format!("oneOf: [{}]", format_vec_of_validators(&self.schemas))
-    }
-
     one_of_impl_is_valid!(array, &[Value]);
     one_of_impl_is_valid!(boolean, bool);
     one_of_impl_is_valid!(null, ());
@@ -106,6 +102,11 @@ impl Validate for OneOfValidator {
     one_of_impl_validate!(signed_integer, i64);
     one_of_impl_validate!(string, &str);
     one_of_impl_validate!(unsigned_integer, u64);
+}
+impl ToString for OneOfValidator {
+    fn to_string(&self) -> String {
+        format!("oneOf: [{}]", format_vec_of_validators(&self.schemas))
+    }
 }
 
 #[inline]

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -40,10 +40,6 @@ impl Validate for PatternValidator {
         ValidationError::pattern(instance, self.original.clone())
     }
 
-    fn name(&self) -> String {
-        format!("pattern: {}", self.pattern)
-    }
-
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, instance_value: &str) -> bool {
         self.pattern.is_match(instance_value)
@@ -64,6 +60,11 @@ impl Validate for PatternValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for PatternValidator {
+    fn to_string(&self) -> String {
+        format!("pattern: {}", self.pattern)
     }
 }
 

--- a/src/keywords/pattern_properties.rs
+++ b/src/keywords/pattern_properties.rs
@@ -29,17 +29,6 @@ impl PatternPropertiesValidator {
 }
 
 impl Validate for PatternPropertiesValidator {
-    fn name(&self) -> String {
-        format!(
-            "patternProperties: {{{}}}",
-            self.patterns
-                .iter()
-                .map(|(key, validators)| { format!("{}: {}", key, format_validators(validators)) })
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -98,6 +87,18 @@ impl Validate for PatternPropertiesValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for PatternPropertiesValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "patternProperties: {{{}}}",
+            self.patterns
+                .iter()
+                .map(|(key, validators)| { format!("{}: {}", key, format_validators(validators)) })
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
     }
 }
 

--- a/src/keywords/properties.rs
+++ b/src/keywords/properties.rs
@@ -27,13 +27,6 @@ impl PropertiesValidator {
 }
 
 impl Validate for PropertiesValidator {
-    fn name(&self) -> String {
-        format!(
-            "properties: {{{}}}",
-            format_key_value_validators(&self.properties)
-        )
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -89,6 +82,14 @@ impl Validate for PropertiesValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for PropertiesValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "properties: {{{}}}",
+            format_key_value_validators(&self.properties)
+        )
     }
 }
 

--- a/src/keywords/property_names.rs
+++ b/src/keywords/property_names.rs
@@ -20,10 +20,6 @@ impl PropertyNamesObjectValidator {
 }
 
 impl Validate for PropertyNamesObjectValidator {
-    fn name(&self) -> String {
-        format!("propertyNames: {}", format_validators(&self.validators))
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -79,6 +75,11 @@ impl Validate for PropertyNamesObjectValidator {
         }
     }
 }
+impl ToString for PropertyNamesObjectValidator {
+    fn to_string(&self) -> String {
+        format!("propertyNames: {}", format_validators(&self.validators))
+    }
+}
 
 pub struct PropertyNamesBooleanValidator {}
 
@@ -93,10 +94,6 @@ impl Validate for PropertyNamesBooleanValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::false_schema(instance)
-    }
-
-    fn name(&self) -> String {
-        "propertyNames: false".to_string()
     }
 
     #[inline]
@@ -115,6 +112,11 @@ impl Validate for PropertyNamesBooleanValidator {
         } else {
             true
         }
+    }
+}
+impl ToString for PropertyNamesBooleanValidator {
+    fn to_string(&self) -> String {
+        "propertyNames: false".to_string()
     }
 }
 

--- a/src/keywords/ref_.rs
+++ b/src/keywords/ref_.rs
@@ -104,10 +104,6 @@ macro_rules! ref_impl_validate {
 }
 
 impl Validate for RefValidator {
-    fn name(&self) -> String {
-        format!("$ref: {}", self.reference)
-    }
-
     ref_impl_is_valid!(array, &[Value]);
     ref_impl_is_valid!(boolean, bool);
     ref_impl_is_valid!(null, ());
@@ -125,6 +121,11 @@ impl Validate for RefValidator {
     ref_impl_validate!(signed_integer, i64);
     ref_impl_validate!(string, &'a str);
     ref_impl_validate!(unsigned_integer, u64);
+}
+impl ToString for RefValidator {
+    fn to_string(&self) -> String {
+        format!("$ref: {}", self.reference)
+    }
 }
 
 #[inline]

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -30,10 +30,6 @@ impl RequiredValidator {
 }
 
 impl Validate for RequiredValidator {
-    fn name(&self) -> String {
-        format!("required: [{}]", self.required.join(", "))
-    }
-
     #[inline]
     fn is_valid_object(
         &self,
@@ -75,6 +71,11 @@ impl Validate for RequiredValidator {
         } else {
             no_error()
         }
+    }
+}
+impl ToString for RequiredValidator {
+    fn to_string(&self) -> String {
+        format!("required: [{}]", self.required.join(", "))
     }
 }
 

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -38,17 +38,6 @@ impl Validate for MultipleTypesValidator {
         ValidationError::multiple_type_error(instance, self.types)
     }
 
-    fn name(&self) -> String {
-        format!(
-            "type: [{}]",
-            self.types
-                .into_iter()
-                .map(|type_| format!("{}", type_))
-                .collect::<Vec<String>>()
-                .join(", ")
-        )
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, _: &[Value]) -> bool {
         self.types.contains_type(PrimitiveType::Array)
@@ -83,6 +72,18 @@ impl Validate for MultipleTypesValidator {
         self.types.contains_type(PrimitiveType::Integer)
     }
 }
+impl ToString for MultipleTypesValidator {
+    fn to_string(&self) -> String {
+        format!(
+            "type: [{}]",
+            self.types
+                .into_iter()
+                .map(|type_| format!("{}", type_))
+                .collect::<Vec<String>>()
+                .join(", ")
+        )
+    }
+}
 
 pub struct NullTypeValidator {}
 
@@ -97,10 +98,6 @@ impl Validate for NullTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Null)
-    }
-
-    fn name(&self) -> String {
-        "type: null".to_string()
     }
 
     #[inline]
@@ -149,6 +146,11 @@ impl Validate for NullTypeValidator {
         }
     }
 }
+impl ToString for NullTypeValidator {
+    fn to_string(&self) -> String {
+        "type: null".to_string()
+    }
+}
 
 pub struct BooleanTypeValidator {}
 
@@ -163,10 +165,6 @@ impl Validate for BooleanTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Boolean)
-    }
-
-    fn name(&self) -> String {
-        "type: boolean".to_string()
     }
 
     #[inline]
@@ -215,6 +213,11 @@ impl Validate for BooleanTypeValidator {
         }
     }
 }
+impl ToString for BooleanTypeValidator {
+    fn to_string(&self) -> String {
+        "type: boolean".to_string()
+    }
+}
 
 pub struct StringTypeValidator {}
 
@@ -229,10 +232,6 @@ impl Validate for StringTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::String)
-    }
-
-    fn name(&self) -> String {
-        "type: string".to_string()
     }
 
     #[inline]
@@ -281,6 +280,11 @@ impl Validate for StringTypeValidator {
         }
     }
 }
+impl ToString for StringTypeValidator {
+    fn to_string(&self) -> String {
+        "type: string".to_string()
+    }
+}
 
 pub struct ArrayTypeValidator {}
 
@@ -295,10 +299,6 @@ impl Validate for ArrayTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Array)
-    }
-
-    fn name(&self) -> String {
-        "type: array".to_string()
     }
 
     #[inline]
@@ -347,6 +347,11 @@ impl Validate for ArrayTypeValidator {
         }
     }
 }
+impl ToString for ArrayTypeValidator {
+    fn to_string(&self) -> String {
+        "type: array".to_string()
+    }
+}
 
 pub struct ObjectTypeValidator {}
 
@@ -361,10 +366,6 @@ impl Validate for ObjectTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Object)
-    }
-
-    fn name(&self) -> String {
-        "type: object".to_string()
     }
 
     #[inline]
@@ -413,6 +414,11 @@ impl Validate for ObjectTypeValidator {
         }
     }
 }
+impl ToString for ObjectTypeValidator {
+    fn to_string(&self) -> String {
+        "type: object".to_string()
+    }
+}
 
 pub struct NumberTypeValidator {}
 
@@ -427,10 +433,6 @@ impl Validate for NumberTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Number)
-    }
-
-    fn name(&self) -> String {
-        "type: number".to_string()
     }
 
     #[inline]
@@ -471,7 +473,11 @@ impl Validate for NumberTypeValidator {
         }
     }
 }
-
+impl ToString for NumberTypeValidator {
+    fn to_string(&self) -> String {
+        "type: number".to_string()
+    }
+}
 pub struct IntegerTypeValidator {}
 
 impl IntegerTypeValidator {
@@ -485,10 +491,6 @@ impl Validate for IntegerTypeValidator {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
         ValidationError::single_type_error(instance, PrimitiveType::Integer)
-    }
-
-    fn name(&self) -> String {
-        "type: integer".to_string()
     }
 
     #[inline]
@@ -538,6 +540,11 @@ impl Validate for IntegerTypeValidator {
         } else {
             error(self.build_validation_error(instance))
         }
+    }
+}
+impl ToString for IntegerTypeValidator {
+    fn to_string(&self) -> String {
+        "type: integer".to_string()
     }
 }
 

--- a/src/keywords/unique_items.rs
+++ b/src/keywords/unique_items.rs
@@ -74,10 +74,6 @@ impl Validate for UniqueItemsValidator {
         ValidationError::unique_items(instance)
     }
 
-    fn name(&self) -> String {
-        "uniqueItems: true".to_string()
-    }
-
     #[inline]
     fn is_valid_array(&self, _: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
         is_unique(instance_value)
@@ -100,7 +96,11 @@ impl Validate for UniqueItemsValidator {
         }
     }
 }
-
+impl ToString for UniqueItemsValidator {
+    fn to_string(&self) -> String {
+        "uniqueItems: true".to_string()
+    }
+}
 #[inline]
 pub fn compile(
     _: &Map<String, Value>,

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -5,12 +5,11 @@ use crate::{
 use serde_json::{Map, Value};
 use std::fmt;
 
-pub trait Validate: Send + Sync {
+pub trait Validate: Send + Sync + ToString {
     #[inline]
     fn build_validation_error<'a>(&self, instance: &'a Value) -> ValidationError<'a> {
-        ValidationError::unexpected(instance, &self.name())
+        ValidationError::unexpected(instance, &self.to_string())
     }
-    fn name(&self) -> String;
 
     #[inline]
     fn is_valid_array(
@@ -250,6 +249,6 @@ pub trait Validate: Send + Sync {
 
 impl fmt::Debug for dyn Validate + Send + Sync {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.name())
+        f.write_str(&self.to_string())
     }
 }


### PR DESCRIPTION
`Validate::name` does represent the concept of *transform the validator to a string readable by humans*.
The goal of this PR is to use the more canonical `ToString::to_string` for this ;)


I do expect python tests to fail as in #117 and they should be green once #118 is merged (or at least the fix is ported in).