### PR TITLE
fix: Add `idna` dependency to improve idn-hostname format correctness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ reqwest = { version = ">= 0.10", features = ["blocking", "json"]}
 parking_lot = ">= 0.1"
 num-cmp = ">= 0.1"
 paste = ">= 0.1"
+idna = ">= 0.2"
 
 [dev-dependencies]
 criterion = ">= 0.1"

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -98,6 +98,10 @@ fn is_valid_hostname(string: &str) -> bool {
             .any(|c| !(c.is_alphanumeric() || c == '-' || c == '.'))
         || string.split('.').any(|part| part.chars().count() > 63))
 }
+#[inline]
+fn is_valid_idn_hostname(string: &str) -> bool {
+    is_valid_hostname(string) && idna::domain_to_unicode(string).1.is_ok()
+}
 
 string_format_validator!(DateValidator, "date", |instance_string| {
     NaiveDate::parse_from_str(instance_string, "%Y-%m-%d").is_ok()
@@ -108,7 +112,7 @@ string_format_validator!(DateTimeValidator, "date-time", |instance_string| {
 string_format_validator!(EmailValidator, "email", is_valid_email);
 string_format_validator!(IDNEmailValidator, "idn-email", is_valid_email);
 string_format_validator!(HostnameValidator, "hostname", is_valid_hostname);
-string_format_validator!(IDNHostnameValidator, "idn-hostname", is_valid_hostname);
+string_format_validator!(IDNHostnameValidator, "idn-hostname", is_valid_idn_hostname);
 string_format_validator!(IpV4Validator, "ipv4", |instance_string| {
     if let Ok(IpAddr::V4(_)) = IpAddr::from_str(instance_string) {
         true

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -4,8 +4,6 @@ use jsonschema::{Draft, JSONSchema};
 #[json_schema_test_suite("tests/suite", "draft4", {"optional_bignum_0_0", "optional_bignum_2_0"})]
 #[json_schema_test_suite("tests/suite", "draft6")]
 #[json_schema_test_suite("tests/suite", "draft7", {
-    "optional_format_idn_hostname_0_11", // https://github.com/Stranger6667/jsonschema-rs/issues/101
-    "optional_format_idn_hostname_0_6",  // https://github.com/Stranger6667/jsonschema-rs/issues/101
     "optional_format_idn_hostname_0_7",  // https://github.com/Stranger6667/jsonschema-rs/issues/101
 })]
 fn test_draft(_server_address: &str, test_case: TestCase) {


### PR DESCRIPTION
The goal of this PR, as visible on the description, is to improve the correctness of `idn-hostname` format.

Checking around I found no perfect rust library that does this validation and implementing the whole RFC seems really out of scope.
Among the different available libraries (idna, unic-idna, unic-idna-punicode) `idna` seems the most maintained and accurate (allows us to remove two of the three optional ignored tests).
