### PR TITLE
chore: Bump JSON-Schema-Test-Suite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ idna = ">= 0.2"
 [dev-dependencies]
 criterion = ">= 0.1"
 mockito = ">= 0"
-json_schema_test_suite = ">= 0"
+json_schema_test_suite = ">= 0.3"
 jsonschema-valid = ">= 0.1"
 valico = "3"
 test-case = "1"

--- a/README.md
+++ b/README.md
@@ -8,9 +8,10 @@
 A JSON Schema validator implementation. It compiles schema into a validation tree to have validation as fast as possible.
 
 Supported drafts:
-- Draft 7
+
+- Draft 7 (except optional `idn-hostname.json` test cases)
 - Draft 6
-- Draft 4 (except optional `bignum.json` test case)
+- Draft 4 (except optional `bignum.json` test cases)
 
 ```toml
 # Cargo.toml
@@ -31,10 +32,10 @@ fn main() {
     if let Err(errors) = result {
         for error in errors {
             println!("Validation error: {}", error)
-        }   
+        }
     }
 }
-``` 
+```
 
 If you only need to know whether document is valid or not (which is faster):
 

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -4,7 +4,7 @@ use jsonschema::{Draft, JSONSchema};
 #[json_schema_test_suite("tests/suite", "draft4", {"optional_bignum_0_0", "optional_bignum_2_0"})]
 #[json_schema_test_suite("tests/suite", "draft6")]
 #[json_schema_test_suite("tests/suite", "draft7", {
-    "optional_format_idn_hostname_0_7",  // https://github.com/Stranger6667/jsonschema-rs/issues/101
+    r"optional_format_idn_hostname_0_\d+",  // https://github.com/Stranger6667/jsonschema-rs/issues/101
 })]
 fn test_draft(_server_address: &str, test_case: TestCase) {
     let draft_version = match test_case.draft_version.as_ref() {


### PR DESCRIPTION
The goal of this PR is to bump again `JSON-Schema-Test-Suite` and bump `json_schema_test_suite` dependency to allow regular expressions in the ignored tests