### PR TITLE
fix: Handle errors during conversion to `Value` instead of using `unwrap`

### DIFF
--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - ECMAScript regex support
 - Formats should be associated to Draft versions (ie. `idn-hostname` is not defined on draft 4 and draft 6)
+- Handle errors during conversion to `Value` instead of using `unwrap` in `JSONSchema::is_valid` and `JSONSchema::validate`. [#127](https://github.com/Stranger6667/jsonschema-rs/issues/127)
 
 ## [0.3.3] - 2020-06-22
 

--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -122,9 +122,9 @@ impl JSONSchema {
     ///
     /// The output is a boolean value, that indicates whether the instance is valid or not.
     #[text_signature = "(instance)"]
-    fn is_valid(&self, instance: &PyAny) -> bool {
-        let instance = ser::to_value(instance).unwrap();
-        self.schema.is_valid(&instance)
+    fn is_valid(&self, instance: &PyAny) -> PyResult<bool> {
+        let instance = ser::to_value(instance)?;
+        Ok(self.schema.is_valid(&instance))
     }
 
     /// validate(instance)
@@ -139,7 +139,7 @@ impl JSONSchema {
     /// If the input instance is invalid, only the first occurred error is raised.
     #[text_signature = "(instance)"]
     fn validate(&self, instance: &PyAny) -> PyResult<()> {
-        let instance = ser::to_value(instance).unwrap();
+        let instance = ser::to_value(instance)?;
         let result = self.schema.validate(&instance);
         let error = if let Some(mut errors) = result.err() {
             // If we have `Err` case, then the iterator is not empty

--- a/python/tests-py/test_jsonschema.py
+++ b/python/tests-py/test_jsonschema.py
@@ -83,3 +83,10 @@ def test_maximum(maximum):
 def test_multiple_of(multiple_of):
     with suppress(SystemError):
         assert is_valid({"multipleOf": multiple_of}, multiple_of * 3)
+
+
+@pytest.mark.parametrize("method", ("is_valid", "validate"))
+def test_invalid_value(method):
+    schema = JSONSchema({"minimum": 42})
+    with pytest.raises(ValueError, match="Unsupported type: 'object'"):
+        getattr(schema, method)(object())


### PR DESCRIPTION
Fixes #127 