### PR TITLE
Customizable media type and content encoding

### DIFF
--- a/python/src/lib.rs
+++ b/python/src/lib.rs
@@ -44,19 +44,15 @@ impl From<JSONSchemaError> for PyErr {
     }
 }
 
-fn get_draft(draft: Option<u8>) -> PyResult<Draft> {
-    if let Some(value) = draft {
-        match value {
-            DRAFT4 => Ok(jsonschema::Draft::Draft4),
-            DRAFT6 => Ok(jsonschema::Draft::Draft6),
-            DRAFT7 => Ok(jsonschema::Draft::Draft7),
-            _ => Err(exceptions::ValueError::py_err(format!(
-                "Unknown draft: {}",
-                value
-            ))),
-        }
-    } else {
-        Ok(jsonschema::Draft::default())
+fn get_draft(draft: u8) -> PyResult<Draft> {
+    match draft {
+        DRAFT4 => Ok(jsonschema::Draft::Draft4),
+        DRAFT6 => Ok(jsonschema::Draft::Draft6),
+        DRAFT7 => Ok(jsonschema::Draft::Draft7),
+        _ => Err(exceptions::ValueError::py_err(format!(
+            "Unknown draft: {}",
+            draft
+        ))),
     }
 }
 
@@ -72,11 +68,14 @@ fn get_draft(draft: Option<u8>) -> PyResult<Draft> {
 #[pyfunction]
 #[text_signature = "(schema, instance, draft=None)"]
 fn is_valid(schema: &PyAny, instance: &PyAny, draft: Option<u8>) -> PyResult<bool> {
-    let draft = get_draft(draft).map(Some)?;
     let schema = ser::to_value(schema)?;
     let instance = ser::to_value(instance)?;
-    let compiled =
-        jsonschema::JSONSchema::compile(&schema, draft).map_err(JSONSchemaError::Compilation)?;
+    let mut config = jsonschema::CompilationConfig::default();
+    if let Some(raw_draft_version) = draft {
+        config.set_draft(get_draft(raw_draft_version)?);
+    }
+    let compiled = jsonschema::JSONSchema::compile(&schema, Some(config))
+        .map_err(JSONSchemaError::Compilation)?;
     Ok(compiled.is_valid(&instance))
 }
 
@@ -100,13 +99,16 @@ struct JSONSchema {
 impl JSONSchema {
     #[new]
     fn new(schema: &PyAny, draft: Option<u8>) -> PyResult<Self> {
-        let draft = get_draft(draft).map(Some)?;
         let raw_schema = ser::to_value(schema)?;
+        let mut config = jsonschema::CompilationConfig::default();
+        if let Some(raw_draft_version) = draft {
+            config.set_draft(get_draft(raw_draft_version)?);
+        }
         // Currently, it is the simplest way to pass a reference to `JSONSchema`
         // It is cleaned up in the `Drop` implementation
         let schema: &'static Value = Box::leak(Box::new(raw_schema));
         Ok(JSONSchema {
-            schema: jsonschema::JSONSchema::compile(schema, draft)
+            schema: jsonschema::JSONSchema::compile(schema, Some(config))
                 .map_err(JSONSchemaError::Compilation)?,
             raw_schema: schema,
         })

--- a/src/compilation/config.rs
+++ b/src/compilation/config.rs
@@ -1,10 +1,15 @@
-use crate::schemas;
+use crate::{
+    content_media_type::{ContentMediaTypeCheckType, DEFAULT_CONTENT_MEDIA_TYPE_CHECKS},
+    schemas,
+};
 use serde_json::Value;
+use std::{collections::HashMap, fmt};
 
 #[allow(missing_docs)]
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Default)]
 pub struct CompilationConfig {
     pub(crate) draft: Option<schemas::Draft>,
+    content_media_type_checks: HashMap<String, Option<ContentMediaTypeCheckType>>,
 }
 
 #[allow(missing_docs)]
@@ -24,5 +29,40 @@ impl CompilationConfig {
     pub fn set_draft(&mut self, draft: schemas::Draft) -> &mut Self {
         self.draft = Some(draft);
         self
+    }
+
+    pub(crate) fn content_media_type_check(
+        &self,
+        media_type: &str,
+    ) -> Option<ContentMediaTypeCheckType> {
+        if let Some(value) = self.content_media_type_checks.get(media_type) {
+            *value
+        } else if let Some(value) = DEFAULT_CONTENT_MEDIA_TYPE_CHECKS.get(media_type) {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn add_content_media_type_check<IS: Into<String>>(
+        &mut self,
+        media_type: IS,
+        media_type_check: Option<ContentMediaTypeCheckType>,
+    ) -> &mut Self {
+        self.content_media_type_checks
+            .insert(media_type.into(), media_type_check);
+        self
+    }
+}
+
+impl fmt::Debug for CompilationConfig {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt.debug_struct("CompilationConfig")
+            .field("draft", &self.draft)
+            .field(
+                "content_media_type_checks",
+                &self.content_media_type_checks.keys(),
+            )
+            .finish()
     }
 }

--- a/src/compilation/config.rs
+++ b/src/compilation/config.rs
@@ -1,4 +1,8 @@
 use crate::{
+    content_encoding::{
+        ContentTypeCheckType, ContentTypeConverterType, DEFAULT_CONTENT_ENCODING_CHECKS,
+        DEFAULT_CONTENT_ENCODING_CONVERTERS,
+    },
     content_media_type::{ContentMediaTypeCheckType, DEFAULT_CONTENT_MEDIA_TYPE_CHECKS},
     schemas,
 };
@@ -10,6 +14,8 @@ use std::{collections::HashMap, fmt};
 pub struct CompilationConfig {
     pub(crate) draft: Option<schemas::Draft>,
     content_media_type_checks: HashMap<String, Option<ContentMediaTypeCheckType>>,
+    content_encoding_checks: HashMap<String, Option<ContentTypeCheckType>>,
+    content_encoding_converters: HashMap<String, Option<ContentTypeConverterType>>,
 }
 
 #[allow(missing_docs)]
@@ -53,6 +59,52 @@ impl CompilationConfig {
             .insert(media_type.into(), media_type_check);
         self
     }
+
+    pub(crate) fn content_encoding_check(
+        &self,
+        content_encoding: &str,
+    ) -> Option<ContentTypeCheckType> {
+        if let Some(value) = self.content_encoding_checks.get(content_encoding) {
+            *value
+        } else if let Some(value) = DEFAULT_CONTENT_ENCODING_CHECKS.get(content_encoding) {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn add_content_encoding_check<IS: Into<String>>(
+        &mut self,
+        content_encoding: IS,
+        content_encoding_check: Option<ContentTypeCheckType>,
+    ) -> &mut Self {
+        self.content_encoding_checks
+            .insert(content_encoding.into(), content_encoding_check);
+        self
+    }
+
+    pub(crate) fn content_encoding_convert(
+        &self,
+        content_encoding: &str,
+    ) -> Option<ContentTypeConverterType> {
+        if let Some(value) = self.content_encoding_converters.get(content_encoding) {
+            *value
+        } else if let Some(value) = DEFAULT_CONTENT_ENCODING_CONVERTERS.get(content_encoding) {
+            Some(*value)
+        } else {
+            None
+        }
+    }
+
+    pub fn add_content_encoding_convert<IS: Into<String>>(
+        &mut self,
+        content_encoding: IS,
+        content_encoding_convert: Option<ContentTypeConverterType>,
+    ) -> &mut Self {
+        self.content_encoding_converters
+            .insert(content_encoding.into(), content_encoding_convert);
+        self
+    }
 }
 
 impl fmt::Debug for CompilationConfig {
@@ -62,6 +114,14 @@ impl fmt::Debug for CompilationConfig {
             .field(
                 "content_media_type_checks",
                 &self.content_media_type_checks.keys(),
+            )
+            .field(
+                "content_encoding_checks",
+                &self.content_encoding_checks.keys(),
+            )
+            .field(
+                "content_encoding_converts",
+                &self.content_encoding_converters.keys(),
             )
             .finish()
     }

--- a/src/compilation/config.rs
+++ b/src/compilation/config.rs
@@ -1,0 +1,28 @@
+use crate::schemas;
+use serde_json::Value;
+
+#[allow(missing_docs)]
+#[derive(Clone, Debug, Default)]
+pub struct CompilationConfig {
+    pub(crate) draft: Option<schemas::Draft>,
+}
+
+#[allow(missing_docs)]
+impl CompilationConfig {
+    pub(crate) fn draft(&self) -> schemas::Draft {
+        self.draft
+            .expect("JSONSchema::compile should have defined a specific draft version.")
+    }
+
+    pub(crate) fn set_draft_if_missing(&mut self, schema: &Value) -> &mut Self {
+        if self.draft.is_none() {
+            self.draft = Some(schemas::draft_from_schema(schema).unwrap_or(schemas::Draft::Draft7));
+        }
+        self
+    }
+
+    pub fn set_draft(&mut self, draft: schemas::Draft) -> &mut Self {
+        self.draft = Some(draft);
+        self
+    }
+}

--- a/src/compilation/context.rs
+++ b/src/compilation/context.rs
@@ -1,0 +1,52 @@
+use super::config::CompilationConfig;
+use crate::schemas;
+use serde_json::Value;
+use std::borrow::Cow;
+use url::{ParseError, Url};
+
+/// Context holds information about used draft and current scope.
+#[derive(Debug)]
+pub struct CompilationContext<'a> {
+    pub(crate) scope: Cow<'a, Url>,
+    pub(crate) config: Cow<'a, CompilationConfig>,
+}
+
+impl<'a> CompilationContext<'a> {
+    pub(crate) fn new(scope: Url, config: Cow<'a, CompilationConfig>) -> Self {
+        CompilationContext {
+            scope: Cow::Owned(scope),
+            config,
+        }
+    }
+
+    #[allow(clippy::doc_markdown)]
+    /// Push a new scope. All URLs built from the new context will have this scope in them.
+    /// Before push:
+    ///    scope = http://example.com/
+    ///    build_url("#/definitions/foo") -> "http://example.com/#/definitions/foo"
+    /// After push this schema - {"$id": "folder/", ...}
+    ///    scope = http://example.com/folder/
+    ///    build_url("#/definitions/foo") -> "http://example.com/folder/#/definitions/foo"
+    ///
+    /// In other words it keeps track of sub-folders during compilation.
+    #[inline]
+    pub(crate) fn push(&'a self, schema: &Value) -> Result<Self, ParseError> {
+        if let Some(id) = schemas::id_of(self.config.draft(), schema) {
+            let scope = Url::options().base_url(Some(&self.scope)).parse(id)?;
+            Ok(CompilationContext {
+                scope: Cow::Owned(scope),
+                config: Cow::Borrowed(&self.config),
+            })
+        } else {
+            Ok(CompilationContext {
+                scope: Cow::Borrowed(self.scope.as_ref()),
+                config: Cow::Borrowed(&self.config),
+            })
+        }
+    }
+
+    /// Build a new URL. Used for `ref` compilation to keep their full paths.
+    pub(crate) fn build_url(&self, reference: &str) -> Result<Url, ParseError> {
+        Url::options().base_url(Some(&self.scope)).parse(reference)
+    }
+}

--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -1,8 +1,9 @@
 use crate::error::{error, no_error, ErrorIterator, ValidationError};
 use serde_json::Value;
+use std::collections::HashMap;
 
 pub(crate) type ContentTypeCheckType = for<'a> fn(&'a Value, &str) -> ErrorIterator<'a>;
-pub(crate) type ContentTypeConvertType =
+pub(crate) type ContentTypeConverterType =
     for<'a> fn(&'a Value, &str) -> Result<String, ValidationError<'a>>;
 
 pub fn is_base64<'a>(instance: &'a Value, instance_string: &str) -> ErrorIterator<'a> {
@@ -22,8 +23,16 @@ pub fn from_base64<'a>(
     }
 }
 
-pub(crate) static CONTENT_TYPE_CHECK_BUILDER: &[(&str, ContentTypeCheckType)] =
-    &[("base64", is_base64)];
+lazy_static::lazy_static! {
+    pub(crate) static ref DEFAULT_CONTENT_ENCODING_CHECKS: HashMap<&'static str, ContentTypeCheckType> = {
+        let mut map: HashMap<&'static str, ContentTypeCheckType> = HashMap::with_capacity(1);
+        map.insert("base64", is_base64);
+        map
+    };
 
-pub(crate) static CONTENT_TYPE_CONVERT_BUILDER: &[(&str, ContentTypeConvertType)] =
-    &[("base64", from_base64)];
+    pub(crate) static ref DEFAULT_CONTENT_ENCODING_CONVERTERS: HashMap<&'static str, ContentTypeConverterType> = {
+        let mut map: HashMap<&'static str, ContentTypeConverterType> = HashMap::with_capacity(1);
+        map.insert("base64", from_base64);
+        map
+    };
+}

--- a/src/content_media_type.rs
+++ b/src/content_media_type.rs
@@ -1,0 +1,20 @@
+use crate::error::{error, no_error, ErrorIterator, ValidationError};
+use serde_json::{from_str, Value};
+use std::collections::HashMap;
+
+pub(crate) type ContentMediaTypeCheckType = for<'a> fn(&'a Value, &str) -> ErrorIterator<'a>;
+
+pub(crate) fn is_json<'a>(instance: &'a Value, instance_string: &str) -> ErrorIterator<'a> {
+    if from_str::<Value>(instance_string).is_err() {
+        return error(ValidationError::format(instance, "application/json"));
+    }
+    no_error()
+}
+
+lazy_static::lazy_static! {
+    pub(crate) static ref DEFAULT_CONTENT_MEDIA_TYPE_CHECKS: HashMap<&'static str, ContentMediaTypeCheckType> = {
+        let mut map: HashMap<&'static str, ContentMediaTypeCheckType> = HashMap::with_capacity(1);
+        map.insert("application/json", is_json);
+        map
+    };
+}

--- a/src/content_type.rs
+++ b/src/content_type.rs
@@ -1,0 +1,29 @@
+use crate::error::{error, no_error, ErrorIterator, ValidationError};
+use serde_json::Value;
+
+pub(crate) type ContentTypeCheckType = for<'a> fn(&'a Value, &str) -> ErrorIterator<'a>;
+pub(crate) type ContentTypeConvertType =
+    for<'a> fn(&'a Value, &str) -> Result<String, ValidationError<'a>>;
+
+pub fn is_base64<'a>(instance: &'a Value, instance_string: &str) -> ErrorIterator<'a> {
+    if base64::decode(instance_string).is_err() {
+        return error(ValidationError::format(instance, "base64"));
+    }
+    no_error()
+}
+
+pub fn from_base64<'a>(
+    instance: &'a Value,
+    instance_string: &str,
+) -> Result<String, ValidationError<'a>> {
+    match base64::decode(instance_string) {
+        Ok(value) => Ok(String::from_utf8(value)?),
+        Err(_) => Err(ValidationError::format(instance, "base64")),
+    }
+}
+
+pub(crate) static CONTENT_TYPE_CHECK_BUILDER: &[(&str, ContentTypeCheckType)] =
+    &[("base64", is_base64)];
+
+pub(crate) static CONTENT_TYPE_CONVERT_BUILDER: &[(&str, ContentTypeConvertType)] =
+    &[("base64", from_base64)];

--- a/src/keywords/additional_items.rs
+++ b/src/keywords/additional_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::{
         boolean::{FalseValidator, TrueValidator},

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/all_of.rs
+++ b/src/keywords/all_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{CompilationError, ErrorIterator},
     keywords::{format_vec_of_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{CompilationError, ValidationError},
     keywords::{format_vec_of_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/const_.rs
+++ b/src/keywords/const_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator, ValidationError},
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -1,6 +1,6 @@
 //! Validators for `contentMediaType` and `contentEncoding` keywords.
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/dependencies.rs
+++ b/src/keywords/dependencies.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator},
     keywords::{
         format_key_value_validators, required::RequiredValidator, CompilationResult, Validators,

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{CompilationError, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/format.rs
+++ b/src/keywords/format.rs
@@ -1,6 +1,6 @@
 //! Validator for `format` keyword.
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
@@ -169,27 +169,36 @@ pub fn compile(
             "email" => Some(EmailValidator::compile()),
             "hostname" => Some(HostnameValidator::compile()),
             "idn-email" => Some(IDNEmailValidator::compile()),
-            "idn-hostname" if context.draft == Draft::Draft7 => {
+            "idn-hostname" if context.config.draft() == Draft::Draft7 => {
                 Some(IDNHostnameValidator::compile())
             }
             "ipv4" => Some(IpV4Validator::compile()),
             "ipv6" => Some(IpV6Validator::compile()),
-            "iri-reference" if context.draft == Draft::Draft7 => {
+            "iri-reference" if context.config.draft() == Draft::Draft7 => {
                 Some(IRIReferenceValidator::compile())
             }
-            "iri" if context.draft == Draft::Draft7 => Some(IRIValidator::compile()),
-            "json-pointer" if context.draft == Draft::Draft6 || context.draft == Draft::Draft7 => {
+            "iri" if context.config.draft() == Draft::Draft7 => Some(IRIValidator::compile()),
+            "json-pointer"
+                if context.config.draft() == Draft::Draft6
+                    || context.config.draft() == Draft::Draft7 =>
+            {
                 Some(JSONPointerValidator::compile())
             }
             "regex" => Some(RegexValidator::compile()),
-            "relative-json-pointer" if context.draft == Draft::Draft7 => {
+            "relative-json-pointer" if context.config.draft() == Draft::Draft7 => {
                 Some(RelativeJSONPointerValidator::compile())
             }
             "time" => Some(TimeValidator::compile()),
-            "uri-reference" if context.draft == Draft::Draft6 || context.draft == Draft::Draft7 => {
+            "uri-reference"
+                if context.config.draft() == Draft::Draft6
+                    || context.config.draft() == Draft::Draft7 =>
+            {
                 Some(URIReferenceValidator::compile())
             }
-            "uri-template" if context.draft == Draft::Draft6 || context.draft == Draft::Draft7 => {
+            "uri-template"
+                if context.config.draft() == Draft::Draft6
+                    || context.config.draft() == Draft::Draft7 =>
+            {
                 Some(URITemplateValidator::compile())
             }
             "uri" => Some(URIValidator::compile()),

--- a/src/keywords/if_.rs
+++ b/src/keywords/if_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator},
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/items.rs
+++ b/src/keywords/items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator},
     keywords::{
         boolean::TrueValidator, format_validators, format_vec_of_validators, CompilationResult,

--- a/src/keywords/legacy/maximum_draft_4.rs
+++ b/src/keywords/legacy/maximum_draft_4.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::CompilationContext,
+    compilation::context::CompilationContext,
     keywords::{exclusive_maximum, maximum, CompilationResult},
 };
 use serde_json::{Map, Value};

--- a/src/keywords/legacy/minimum_draft_4.rs
+++ b/src/keywords/legacy/minimum_draft_4.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::CompilationContext,
+    compilation::context::CompilationContext,
     keywords::{exclusive_minimum, minimum, CompilationResult},
 };
 use serde_json::{Map, Value};

--- a/src/keywords/legacy/type_draft_4.rs
+++ b/src/keywords/legacy/type_draft_4.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::{type_, CompilationResult},
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/not.rs
+++ b/src/keywords/not.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::ValidationError,
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/one_of.rs
+++ b/src/keywords/one_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::{format_vec_of_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/pattern.rs
+++ b/src/keywords/pattern.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/pattern_properties.rs
+++ b/src/keywords/pattern_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator},
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/properties.rs
+++ b/src/keywords/properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, CompilationError, ErrorIterator},
     keywords::{format_key_value_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/property_names.rs
+++ b/src/keywords/property_names.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator, ValidationError},
     keywords::{format_validators, CompilationResult, Validators},
     validator::Validate,

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},

--- a/src/keywords/unique_items.rs
+++ b/src/keywords/unique_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{CompilationContext, JSONSchema},
+    compilation::{context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
     variant_size_differences
 )]
 mod compilation;
+mod content_media_type;
 mod error;
 mod keywords;
 mod primitive_type;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,13 +10,15 @@
 //! ## Example:
 //!
 //! ```rust
-//! use jsonschema::{JSONSchema, Draft, CompilationError};
+//! use jsonschema::{CompilationError, Draft, JSONSchema, CompilationConfig};
 //! use serde_json::json;
 //!
 //!fn main() -> Result<(), CompilationError> {
 //!    let schema = json!({"maxLength": 5});
 //!    let instance = json!("foo");
-//!    let compiled = JSONSchema::compile(&schema, Some(Draft::Draft7))?;
+//!    let mut schema_compile_config = CompilationConfig::default();
+//!    schema_compile_config.set_draft(Draft::Draft7);
+//!    let compiled = JSONSchema::compile(&schema, Some(schema_compile_config))?;
 //!    let result = compiled.validate(&instance);
 //!    if let Err(errors) = result {
 //!        for error in errors {
@@ -59,7 +61,7 @@ mod primitive_type;
 mod resolver;
 mod schemas;
 mod validator;
-pub use compilation::JSONSchema;
+pub use compilation::{config::CompilationConfig, JSONSchema};
 pub use error::{CompilationError, ErrorIterator, ValidationError};
 pub use schemas::Draft;
 use serde_json::Value;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,7 @@
     variant_size_differences
 )]
 mod compilation;
+mod content_encoding;
 mod content_media_type;
 mod error;
 mod keywords;

--- a/src/schemas.rs
+++ b/src/schemas.rs
@@ -1,4 +1,4 @@
-use crate::{compilation::CompilationContext, keywords};
+use crate::{compilation::context::CompilationContext, keywords};
 use serde_json::{Map, Value};
 
 /// JSON Schema Draft version

--- a/tests/test_suite.rs
+++ b/tests/test_suite.rs
@@ -1,5 +1,5 @@
 use json_schema_test_suite::{json_schema_test_suite, TestCase};
-use jsonschema::{Draft, JSONSchema};
+use jsonschema::{CompilationConfig, Draft, JSONSchema};
 
 #[json_schema_test_suite("tests/suite", "draft4", {"optional_bignum_0_0", "optional_bignum_2_0"})]
 #[json_schema_test_suite("tests/suite", "draft6")]
@@ -14,7 +14,10 @@ fn test_draft(_server_address: &str, test_case: TestCase) {
         _ => panic!("Unsupported draft"),
     };
 
-    let compiled = JSONSchema::compile(&test_case.schema, Some(draft_version)).unwrap();
+    let mut schema_compile_config = CompilationConfig::default();
+    schema_compile_config.set_draft(draft_version);
+
+    let compiled = JSONSchema::compile(&test_case.schema, Some(schema_compile_config)).unwrap();
 
     let result = compiled.validate(&test_case.instance);
 


### PR DESCRIPTION
Publishing this as draft in order to gather feedback on the approach.
**NOTE**: Currently documentation of public methods is missing as well as tests on usage of custom encoding.

The general idea is to allow customisation of the `JSONSchema::compile` behaviour via `JSONSchemaCompileConfig`.

At the current state I'm extending it to allow customisable definition of `mediaType` and `contentEncoding` (as we're only supporting JSON and Base64) but it might allow (something that would eventually be provided in subsequent PRs);
 * custom formats (ie. what if we would like to honor user defined formats) (ie. `idn-hostname` is not properly supported in rust, but we might embed the `python` library for the python binding)
 * embedding schema pre-processing/optimisation performed before the schema compilation (ie. embedding jsonschema-equivalent)

NOTE: In order to achieve it by ensuring that we're limiting clone (for example in `$ref` keyword) we need to have a specific lifetime into `Validate` trait, but overall I feel like it was an acceptable tradeoff to have.
