### PR TITLE
Extend json schema options with content media type and content encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `ToString` trait implementation for validators.
 - Define `JSONSchema::options` to customise `JSONSchema` compilation [#131](https://github.com/Stranger6667/jsonschema-rs/issues/131)
+- Allow user-defined `contentEncoding` and `contentMediaType` keywords
 
 ### Fixed
 

--- a/src/content_encoding.rs
+++ b/src/content_encoding.rs
@@ -1,0 +1,27 @@
+use crate::error::ValidationError;
+use std::collections::HashMap;
+
+pub(crate) type ContentEncodingCheckType = fn(&str) -> bool;
+pub(crate) type ContentEncodingConverterType =
+    fn(&str) -> Result<Option<String>, ValidationError<'static>>;
+
+pub(crate) fn is_base64(instance_string: &str) -> bool {
+    base64::decode(instance_string).is_ok()
+}
+
+pub(crate) fn from_base64(
+    instance_string: &str,
+) -> Result<Option<String>, ValidationError<'static>> {
+    match base64::decode(instance_string) {
+        Ok(value) => Ok(Some(String::from_utf8(value)?)),
+        Err(_) => Ok(None),
+    }
+}
+
+lazy_static::lazy_static! {
+    pub(crate) static ref DEFAULT_CONTENT_ENCODING_CHECKS_AND_CONVERTERS: HashMap<&'static str, (ContentEncodingCheckType, ContentEncodingConverterType)> = {
+        let mut map: HashMap<&'static str, (ContentEncodingCheckType, ContentEncodingConverterType)> = HashMap::with_capacity(1);
+        map.insert("base64", (is_base64, from_base64));
+        map
+    };
+}

--- a/src/content_media_type.rs
+++ b/src/content_media_type.rs
@@ -1,0 +1,16 @@
+use serde_json::{from_str, Value};
+use std::collections::HashMap;
+
+pub(crate) type ContentMediaTypeCheckType = fn(&str) -> bool;
+
+pub(crate) fn is_json(instance_string: &str) -> bool {
+    from_str::<Value>(instance_string).is_ok()
+}
+
+lazy_static::lazy_static! {
+    pub(crate) static ref DEFAULT_CONTENT_MEDIA_TYPE_CHECKS: HashMap<&'static str, ContentMediaTypeCheckType> = {
+        let mut map: HashMap<&'static str, ContentMediaTypeCheckType> = HashMap::with_capacity(1);
+        map.insert("application/json", is_json);
+        map
+    };
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -91,6 +91,8 @@ pub(crate) enum ValidationErrorKind {
     Constant { expected_value: Value },
     /// The input array doesn't contain items conforming to the specified schema.
     Contains,
+    /// Ths input value does not respect the defined contentMediaType
+    ContentMediaType { content_media_type: String },
     /// The input value doesn't match any of specified options.
     Enum { options: Value },
     /// Value is too large.
@@ -250,6 +252,14 @@ impl<'a> ValidationError<'a> {
         ValidationError {
             instance: Cow::Borrowed(instance),
             kind: ValidationErrorKind::Contains,
+        }
+    }
+    pub(crate) fn content_media_type(instance: &'a Value, media_type: &str) -> ValidationError<'a> {
+        ValidationError {
+            instance: Cow::Borrowed(instance),
+            kind: ValidationErrorKind::ContentMediaType {
+                content_media_type: media_type.to_string(),
+            },
         }
     }
     pub(crate) fn enumeration(instance: &'a Value, options: &Value) -> ValidationError<'a> {
@@ -564,6 +574,9 @@ impl fmt::Display for ValidationError<'_> {
             ),
             ValidationErrorKind::Constant { expected_value } => {
                 write!(f, "'{}' was expected", expected_value)
+            }
+            ValidationErrorKind::ContentMediaType { content_media_type } => {
+                write!(f, "'{}' is not compliant with media_type={}", self.instance, content_media_type)
             }
             ValidationErrorKind::FromUtf8 { error } => write!(f, "{}", error),
             ValidationErrorKind::Utf8 { error } => write!(f, "{}", error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 #![cfg(not(test))]
 #![allow(clippy::integer_arithmetic, clippy::unwrap_used)]
 mod compilation;
+mod content_encoding;
 mod content_media_type;
 mod error;
 mod keywords;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,7 @@
 #![cfg(not(test))]
 #![allow(clippy::integer_arithmetic, clippy::unwrap_used)]
 mod compilation;
+mod content_media_type;
 mod error;
 mod keywords;
 mod primitive_type;


### PR DESCRIPTION
The goal of this PR is to complete the feature proposal drafted in #129 

In order to simplify external crates to define methods for content encoding/media type support I've modified the signature such that `ValidationError` instances are created only within `jsonschema` crate instead of returned by the check/converter method.
This allows us to not do much work on exposing the all APIs of `ValidationError` (especially considering that it might change in the future).

I don't expect specific performance regressions, but I did not really tested them :)