### PR TITLE
Reduce explicit returns

### DIFF
--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -123,11 +123,12 @@ impl AdditionalPropertiesNotEmptyFalseValidator {
     #[inline]
     pub(crate) fn compile(properties: &Value) -> CompilationResult {
         if let Value::Object(properties) = properties {
-            return Ok(Box::new(AdditionalPropertiesNotEmptyFalseValidator {
+            Ok(Box::new(AdditionalPropertiesNotEmptyFalseValidator {
                 properties: BTreeSet::from_iter(properties.keys().cloned()),
-            }));
+            }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
@@ -194,12 +195,13 @@ impl AdditionalPropertiesNotEmptyValidator {
         context: &CompilationContext,
     ) -> CompilationResult {
         if let Value::Object(properties) = properties {
-            return Ok(Box::new(AdditionalPropertiesNotEmptyValidator {
+            Ok(Box::new(AdditionalPropertiesNotEmptyValidator {
                 properties: BTreeSet::from_iter(properties.keys().cloned()),
                 validators: compile_validators(schema, context)?,
-            }));
+            }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 impl Validate for AdditionalPropertiesNotEmptyValidator {
@@ -421,15 +423,16 @@ impl AdditionalPropertiesWithPatternsNotEmptyValidator {
         context: &CompilationContext,
     ) -> CompilationResult {
         if let Value::Object(properties) = properties {
-            return Ok(Box::new(
+            Ok(Box::new(
                 AdditionalPropertiesWithPatternsNotEmptyValidator {
                     validators: compile_validators(schema, context)?,
                     properties: BTreeSet::from_iter(properties.keys().cloned()),
                     pattern,
                 },
-            ));
+            ))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 impl Validate for AdditionalPropertiesWithPatternsNotEmptyValidator {
@@ -507,14 +510,15 @@ impl AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
     #[inline]
     pub(crate) fn compile(properties: &Value, pattern: Regex) -> CompilationResult {
         if let Value::Object(properties) = properties {
-            return Ok(Box::new(
+            Ok(Box::new(
                 AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
                     properties: BTreeSet::from_iter(properties.keys().cloned()),
                     pattern,
                 },
-            ));
+            ))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 impl Validate for AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
@@ -582,7 +586,7 @@ pub(crate) fn compile(
     if let Some(patterns) = parent.get("patternProperties") {
         if let Value::Object(obj) = patterns {
             let pattern = obj.keys().cloned().collect::<Vec<String>>().join("|");
-            return match Regex::new(&pattern) {
+            match Regex::new(&pattern) {
                 Ok(re) => {
                     match schema {
                         Value::Bool(true) => None, // "additionalProperties" are "true" by default
@@ -609,9 +613,10 @@ pub(crate) fn compile(
                     }
                 }
                 Err(_) => Some(Err(CompilationError::SchemaError)),
-            };
+            }
+        } else {
+            Some(Err(CompilationError::SchemaError))
         }
-        Some(Err(CompilationError::SchemaError))
     } else {
         match schema {
             Value::Bool(true) => None, // "additionalProperties" are "true" by default

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -159,14 +159,21 @@ impl Validate for AdditionalPropertiesNotEmptyFalseValidator {
         _: &'a Value,
         instance_value: &'a Map<String, Value>,
     ) -> ErrorIterator<'a> {
-        for property in instance_value.keys() {
-            if !self.properties.contains(property) {
-                // No extra properties are allowed
-                let property_value = Value::String(property.to_string());
-                return error(ValidationError::false_schema(&property_value).into_owned());
-            }
-        }
-        no_error()
+        instance_value
+            .keys()
+            .filter_map(|property| {
+                if self.properties.contains(property) {
+                    None
+                } else {
+                    // No extra properties are allowed
+                    let property_value = Value::String(property.to_string());
+                    Some(error(
+                        ValidationError::false_schema(&property_value).into_owned(),
+                    ))
+                }
+            })
+            .next()
+            .unwrap_or_else(no_error)
     }
     #[inline]
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {

--- a/src/keywords/all_of.rs
+++ b/src/keywords/all_of.rs
@@ -19,9 +19,10 @@ impl AllOfValidator {
                 let validators = compile_validators(item, context)?;
                 schemas.push(validators)
             }
-            return Ok(Box::new(AllOfValidator { schemas }));
+            Ok(Box::new(AllOfValidator { schemas }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/any_of.rs
+++ b/src/keywords/any_of.rs
@@ -19,9 +19,10 @@ impl AnyOfValidator {
                 let validators = compile_validators(item, context)?;
                 schemas.push(validators)
             }
-            return Ok(Box::new(AnyOfValidator { schemas }));
+            Ok(Box::new(AnyOfValidator { schemas }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/contains.rs
+++ b/src/keywords/contains.rs
@@ -27,16 +27,11 @@ impl Validate for ContainsValidator {
 
     #[inline]
     fn is_valid_array(&self, schema: &JSONSchema, _: &Value, instance_value: &[Value]) -> bool {
-        for item in instance_value {
-            if self
-                .validators
+        instance_value.iter().any(|item| {
+            self.validators
                 .iter()
                 .all(|validator| validator.is_valid(schema, item))
-            {
-                return true;
-            }
-        }
-        false
+        })
     }
     #[inline]
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -290,11 +290,12 @@ mod tests {
         if let Some(first_space_index) = instance_string.find(' ') {
             if let Ok(value) = instance_string[..first_space_index].parse::<u64>() {
                 if instance_string[first_space_index..].chars().count() == value as usize {
-                    return Ok(Some(instance_string[first_space_index..].to_string()));
+                    Ok(Some(instance_string[first_space_index..].to_string()));
                 }
             }
+        } else {
+            Ok(None)
         }
-        Ok(None)
     }
     fn check_custom_encoding(instance_string: &str) -> bool {
         if let Some(first_space_index) = instance_string.find(' ') {

--- a/src/keywords/dependencies.rs
+++ b/src/keywords/dependencies.rs
@@ -24,9 +24,10 @@ impl DependenciesValidator {
                 };
                 dependencies.push((key.clone(), s))
             }
-            return Ok(Box::new(DependenciesValidator { dependencies }));
+            Ok(Box::new(DependenciesValidator { dependencies }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/enum_.rs
+++ b/src/keywords/enum_.rs
@@ -17,12 +17,13 @@ impl EnumValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Value::Array(items) = schema {
-            return Ok(Box::new(EnumValidator {
+            Ok(Box::new(EnumValidator {
                 options: schema.clone(),
                 items: items.clone(),
-            }));
+            }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/exclusive_maximum.rs
+++ b/src/keywords/exclusive_maximum.rs
@@ -105,16 +105,17 @@ pub(crate) fn compile(
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
     if let Value::Number(limit) = schema {
-        return if let Some(limit) = limit.as_u64() {
+        if let Some(limit) = limit.as_u64() {
             Some(Ok(Box::new(ExclusiveMaximumU64Validator { limit })))
         } else if let Some(limit) = limit.as_i64() {
             Some(Ok(Box::new(ExclusiveMaximumI64Validator { limit })))
         } else {
             let limit = limit.as_f64().expect("Always valid");
             Some(Ok(Box::new(ExclusiveMaximumF64Validator { limit })))
-        };
+        }
+    } else {
+        Some(Err(CompilationError::SchemaError))
     }
-    Some(Err(CompilationError::SchemaError))
 }
 
 #[cfg(test)]

--- a/src/keywords/exclusive_minimum.rs
+++ b/src/keywords/exclusive_minimum.rs
@@ -105,16 +105,17 @@ pub(crate) fn compile(
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
     if let Value::Number(limit) = schema {
-        return if let Some(limit) = limit.as_u64() {
+        if let Some(limit) = limit.as_u64() {
             Some(Ok(Box::new(ExclusiveMinimumU64Validator { limit })))
         } else if let Some(limit) = limit.as_i64() {
             Some(Ok(Box::new(ExclusiveMinimumI64Validator { limit })))
         } else {
             let limit = limit.as_f64().expect("Always valid");
             Some(Ok(Box::new(ExclusiveMinimumF64Validator { limit })))
-        };
+        }
+    } else {
+        Some(Err(CompilationError::SchemaError))
     }
-    Some(Err(CompilationError::SchemaError))
 }
 
 #[cfg(test)]

--- a/src/keywords/max_items.rs
+++ b/src/keywords/max_items.rs
@@ -14,9 +14,10 @@ impl MaxItemsValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
-            return Ok(Box::new(MaxItemsValidator { limit }));
+            Ok(Box::new(MaxItemsValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/max_length.rs
+++ b/src/keywords/max_length.rs
@@ -14,9 +14,10 @@ impl MaxLengthValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
-            return Ok(Box::new(MaxLengthValidator { limit }));
+            Ok(Box::new(MaxLengthValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/max_properties.rs
+++ b/src/keywords/max_properties.rs
@@ -14,9 +14,10 @@ impl MaxPropertiesValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
-            return Ok(Box::new(MaxPropertiesValidator { limit }));
+            Ok(Box::new(MaxPropertiesValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/maximum.rs
+++ b/src/keywords/maximum.rs
@@ -105,16 +105,17 @@ pub(crate) fn compile(
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
     if let Value::Number(limit) = schema {
-        return if let Some(limit) = limit.as_u64() {
+        if let Some(limit) = limit.as_u64() {
             Some(Ok(Box::new(MaximumU64Validator { limit })))
         } else if let Some(limit) = limit.as_i64() {
             Some(Ok(Box::new(MaximumI64Validator { limit })))
         } else {
             let limit = limit.as_f64().expect("Always valid");
             Some(Ok(Box::new(MaximumF64Validator { limit })))
-        };
+        }
+    } else {
+        Some(Err(CompilationError::SchemaError))
     }
-    Some(Err(CompilationError::SchemaError))
 }
 
 #[cfg(test)]

--- a/src/keywords/min_items.rs
+++ b/src/keywords/min_items.rs
@@ -14,9 +14,10 @@ impl MinItemsValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
-            return Ok(Box::new(MinItemsValidator { limit }));
+            Ok(Box::new(MinItemsValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/min_length.rs
+++ b/src/keywords/min_length.rs
@@ -14,9 +14,10 @@ impl MinLengthValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
-            return Ok(Box::new(MinLengthValidator { limit }));
+            Ok(Box::new(MinLengthValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/min_properties.rs
+++ b/src/keywords/min_properties.rs
@@ -14,9 +14,10 @@ impl MinPropertiesValidator {
     #[inline]
     pub(crate) fn compile(schema: &Value) -> CompilationResult {
         if let Some(limit) = schema.as_u64() {
-            return Ok(Box::new(MinPropertiesValidator { limit }));
+            Ok(Box::new(MinPropertiesValidator { limit }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/minimum.rs
+++ b/src/keywords/minimum.rs
@@ -105,16 +105,17 @@ pub(crate) fn compile(
     _: &CompilationContext,
 ) -> Option<CompilationResult> {
     if let Value::Number(limit) = schema {
-        return if let Some(limit) = limit.as_u64() {
+        if let Some(limit) = limit.as_u64() {
             Some(Ok(Box::new(MinimumU64Validator { limit })))
         } else if let Some(limit) = limit.as_i64() {
             Some(Ok(Box::new(MinimumI64Validator { limit })))
         } else {
             let limit = limit.as_f64().expect("Always valid");
             Some(Ok(Box::new(MinimumF64Validator { limit })))
-        };
+        }
+    } else {
+        Some(Err(CompilationError::SchemaError))
     }
-    Some(Err(CompilationError::SchemaError))
 }
 
 #[cfg(test)]

--- a/src/keywords/multiple_of.rs
+++ b/src/keywords/multiple_of.rs
@@ -151,11 +151,12 @@ pub(crate) fn compile(
 ) -> Option<CompilationResult> {
     if let Value::Number(multiple_of) = schema {
         let multiple_of = multiple_of.as_f64().expect("Always valid");
-        return if multiple_of.fract() == 0. {
+        if multiple_of.fract() == 0. {
             Some(MultipleOfIntegerValidator::compile(multiple_of))
         } else {
             Some(MultipleOfFloatValidator::compile(multiple_of))
-        };
+        }
+    } else {
+        Some(Err(CompilationError::SchemaError))
     }
-    Some(Err(CompilationError::SchemaError))
 }

--- a/src/keywords/one_of.rs
+++ b/src/keywords/one_of.rs
@@ -18,9 +18,10 @@ impl OneOfValidator {
             for item in items {
                 schemas.push(compile_validators(item, context)?)
             }
-            return Ok(Box::new(OneOfValidator { schemas }));
+            Ok(Box::new(OneOfValidator { schemas }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/pattern_properties.rs
+++ b/src/keywords/pattern_properties.rs
@@ -22,9 +22,10 @@ impl PatternPropertiesValidator {
                     compile_validators(subschema, context)?,
                 ));
             }
-            return Ok(Box::new(PatternPropertiesValidator { patterns }));
+            Ok(Box::new(PatternPropertiesValidator { patterns }))
+        } else {
+            Err(CompilationError::SchemaError)
         }
-        Err(CompilationError::SchemaError)
     }
 }
 

--- a/src/keywords/required.rs
+++ b/src/keywords/required.rs
@@ -57,12 +57,20 @@ impl Validate for RequiredValidator {
         instance: &'a Value,
         instance_value: &'a Map<String, Value>,
     ) -> ErrorIterator<'a> {
-        for property_name in &self.required {
-            if !instance_value.contains_key(property_name) {
-                return error(ValidationError::required(instance, property_name.clone()));
-            }
-        }
-        no_error()
+        self.required
+            .iter()
+            .filter_map(|property_name| {
+                if !instance_value.contains_key(property_name) {
+                    Some(error(ValidationError::required(
+                        instance,
+                        property_name.clone(),
+                    )))
+                } else {
+                    None
+                }
+            })
+            .next()
+            .unwrap_or_else(no_error)
     }
     #[inline]
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -193,9 +193,10 @@ pub(crate) fn pointer<'a>(
 
 fn parse_index(s: &str) -> Option<usize> {
     if s.starts_with('+') || (s.starts_with('0') && s.len() != 1) {
-        return None;
+        None
+    } else {
+        s.parse().ok()
     }
-    s.parse().ok()
 }
 
 #[cfg(test)]

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -216,33 +216,10 @@ pub(crate) trait Validate: Send + Sync + ToString {
     }
     #[inline]
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        match instance {
-            Value::Array(instance_array) => self.validate_array(schema, instance, instance_array),
-            Value::Bool(instance_boolean) => {
-                self.validate_boolean(schema, instance, *instance_boolean)
-            }
-            Value::Null => self.validate_null(schema, instance, ()),
-            Value::Number(instance_number) => {
-                if let Some(instance_unsigned_integer) = instance_number.as_u64() {
-                    self.validate_unsigned_integer(schema, instance, instance_unsigned_integer)
-                } else if let Some(instance_signed_integer) = instance_number.as_i64() {
-                    self.validate_signed_integer(schema, instance, instance_signed_integer)
-                } else {
-                    self.validate_number(
-                        schema,
-                        instance,
-                        instance_number
-                            .as_f64()
-                            .expect("A JSON number will always be representable as f64"),
-                    )
-                }
-            }
-            Value::Object(instance_object) => {
-                self.validate_object(schema, instance, instance_object)
-            }
-            Value::String(instance_string) => {
-                self.validate_string(schema, instance, instance_string)
-            }
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
+            error(self.build_validation_error(instance))
         }
     }
 }


### PR DESCRIPTION
This PR is mostly introducing stylistic changes aimed to have the code-base reflecting the common rust style.

```rust
if foo() {
    return something;
}
return something_else;
```
can be written with a more idiomatic format
```rust
if foo() {
    something
} else {
    something_else
}
```

Few additional changes are:
 * `Validate::validate` relies on the result of `Validate::is_valid`: This allows to reduce code-duplication and should help in terms of binary size
 * Usage of iterators instead of `for` loops with inner results: This would allow for the same performance but with a more idiomatic style and would help in tuning more performance with parallel iterations if we can prove that this is beneficial (check contains and required files)
