### PR TITLE
fix: Ensure that tests are executed

### DIFF
--- a/src/compilation/options.rs
+++ b/src/compilation/options.rs
@@ -203,7 +203,7 @@ impl CompilationOptions {
     /// fn check_custom_encoding(instance_string: &str) -> bool {
     ///     if let Some(first_space_index) = instance_string.find(' ') {
     ///         if let Ok(value) = instance_string[..first_space_index].parse::<u64>() {
-    ///             return instance_string[(first_space_index + 1)..].chars().count() == value as usize;
+    ///             return instance_string[first_space_index + 1..].chars().count() == value as usize;
     ///         }
     ///     }
     ///     false
@@ -211,8 +211,8 @@ impl CompilationOptions {
     /// fn converter_custom_encoding(instance_string: &str) -> Result<Option<String>, ValidationError<'static>> {
     ///     if let Some(first_space_index) = instance_string.find(' ') {
     ///         if let Ok(value) = instance_string[..first_space_index].parse::<u64>() {
-    ///             if instance_string[(first_space_index + 1)..].chars().count() == value as usize {
-    ///                 return Ok(Some(instance_string[(first_space_index + 1)..].to_string()));
+    ///             if instance_string[first_space_index + 1..].chars().count() == value as usize {
+    ///                 return Ok(Some(instance_string[first_space_index + 1..].to_string()));
     ///             }
     ///         }
     ///     }

--- a/src/keywords/content.rs
+++ b/src/keywords/content.rs
@@ -289,19 +289,17 @@ mod tests {
     ) -> Result<Option<String>, ValidationError<'static>> {
         if let Some(first_space_index) = instance_string.find(' ') {
             if let Ok(value) = instance_string[..first_space_index].parse::<u64>() {
-                if instance_string[first_space_index..].chars().count() == value as usize {
-                    Ok(Some(instance_string[first_space_index..].to_string()));
+                if instance_string[first_space_index + 1..].chars().count() as u64 == value {
+                    return Ok(Some(instance_string[first_space_index + 1..].to_string()));
                 }
             }
-        } else {
-            Ok(None)
         }
+        Ok(None)
     }
     fn check_custom_encoding(instance_string: &str) -> bool {
         if let Some(first_space_index) = instance_string.find(' ') {
             if let Ok(value) = instance_string[..first_space_index].parse::<u64>() {
-                return instance_string[(first_space_index + 1)..].chars().count()
-                    == value as usize;
+                return instance_string[first_space_index + 1..].chars().count() as u64 == value;
             }
         }
         false
@@ -363,9 +361,9 @@ mod tests {
         assert!(compiled.is_valid(instance))
     }
 
-    #[test_case("2 {" => false)] // Content Encoding not respected
-    #[test_case("2 {a" => false)] // Content Media Type not respected
-    #[test_case("2 {}" => true)]
+    #[test_case(&json!("2 {") => false)] // Content Encoding not respected
+    #[test_case(&json!("2 {a") => false)] // Content Media Type not respected
+    #[test_case(&json!("2 {}") => true)]
     fn test_custom_media_type_and_encoding(instance: &Value) -> bool {
         let schema = json!({
             "contentMediaType": "application/json",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,8 +73,7 @@
     unreachable_pub,
     variant_size_differences
 )]
-#![cfg(not(test))]
-#![allow(clippy::integer_arithmetic, clippy::unwrap_used)]
+#![cfg_attr(not(test), allow(clippy::integer_arithmetic, clippy::unwrap_used))]
 mod compilation;
 mod content_encoding;
 mod content_media_type;

--- a/src/validator.rs
+++ b/src/validator.rs
@@ -216,10 +216,33 @@ pub(crate) trait Validate: Send + Sync + ToString {
     }
     #[inline]
     fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
-        if self.is_valid(schema, instance) {
-            no_error()
-        } else {
-            error(self.build_validation_error(instance))
+        match instance {
+            Value::Array(instance_array) => self.validate_array(schema, instance, instance_array),
+            Value::Bool(instance_boolean) => {
+                self.validate_boolean(schema, instance, *instance_boolean)
+            }
+            Value::Null => self.validate_null(schema, instance, ()),
+            Value::Number(instance_number) => {
+                if let Some(instance_unsigned_integer) = instance_number.as_u64() {
+                    self.validate_unsigned_integer(schema, instance, instance_unsigned_integer)
+                } else if let Some(instance_signed_integer) = instance_number.as_i64() {
+                    self.validate_signed_integer(schema, instance, instance_signed_integer)
+                } else {
+                    self.validate_number(
+                        schema,
+                        instance,
+                        instance_number
+                            .as_f64()
+                            .expect("A JSON number will always be representable as f64"),
+                    )
+                }
+            }
+            Value::Object(instance_object) => {
+                self.validate_object(schema, instance, instance_object)
+            }
+            Value::String(instance_string) => {
+                self.validate_string(schema, instance, instance_string)
+            }
         }
     }
 }


### PR DESCRIPTION
@Stranger6667 : Apology for the caused issue

In #132 I've added the support of optional (depending on testing environment) of certain clippy lint.
Unfortunately this was poorly done and as side effect was de-activating all the unit-tests 😢

To fix the issue this is the minimal diff (doc in [here](https://doc.rust-lang.org/reference/conditional-compilation.html#the-cfg_attr-attribute))
```diff
-#![cfg(not(test))]	
-#![allow(clippy::integer_arithmetic, clippy::unwrap_used)]	
+#![cfg_attr(not(test), allow(clippy::integer_arithmetic, clippy::unwrap_used))]
```

After tests have been re-activated I've found out that in the last few PRs (#133 and #134) there were some tests that were failing that have been fixed in this PR.

NOTE: src/validator.rs change is a revert of #134 change because certain validators (ie. `$ref`, `anyOf`) do not return validation errors by themselves but rely received ones and so we cannot really generate the `ValidationError` at that level (if tests would have been run that change would not have been provided).