### PR TITLE
Make reqwest an optional dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ exclude = ["tests", "python", "benches/*.json", ".github", ".yamllint", ".pre-co
 categories = ["web-programming"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+default = ["reqwest"]
 
 [dependencies]
 serde_json = "1"
@@ -22,7 +24,7 @@ regex = "1"
 base64 = ">= 0.2"
 chrono = ">= 0.2"
 rayon = "1"
-reqwest = { version = ">= 0.10", features = ["blocking", "json"]}
+reqwest = { version = ">= 0.10", features = ["blocking", "json"], optional = true}
 parking_lot = ">= 0.1"
 num-cmp = ">= 0.1"
 paste = ">= 0.1"
@@ -35,6 +37,7 @@ json_schema_test_suite = ">= 0.3"
 jsonschema-valid = ">= 0.1"
 valico = "3"
 test-case = "1"
+reqwest = { version = ">= 0.10", features = ["blocking", "json"] }
 
 [[bench]]
 name = "jsonschema"

--- a/src/error.rs
+++ b/src/error.rs
@@ -146,6 +146,7 @@ pub(crate) enum ValidationErrorKind {
     /// When a required property is missing.
     Required { property: String },
     /// Any error that happens during network request via `reqwest` crate
+    #[cfg(any(feature = "reqwest", test))]
     Reqwest { error: reqwest::Error },
     /// Resolved schema failed to compile.
     Schema,
@@ -418,6 +419,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Required { property },
         }
     }
+    #[cfg(any(feature = "reqwest", test))]
     pub(crate) fn reqwest(error: reqwest::Error) -> ValidationError<'a> {
         ValidationError {
             instance: Cow::Owned(Value::Null),
@@ -520,6 +522,7 @@ impl From<url::ParseError> for ValidationError<'_> {
         ValidationError::invalid_url(err)
     }
 }
+#[cfg(any(feature = "reqwest", test))]
 impl From<reqwest::Error> for ValidationError<'_> {
     #[inline]
     fn from(err: reqwest::Error) -> Self {
@@ -535,6 +538,7 @@ impl fmt::Display for ValidationError<'_> {
         match &self.kind {
             ValidationErrorKind::Schema => write!(f, "Schema error"),
             ValidationErrorKind::JSONParse { error } => write!(f, "{}", error),
+            #[cfg(any(feature = "reqwest", test))]
             ValidationErrorKind::Reqwest { error } => write!(f, "{}", error),
             ValidationErrorKind::FileNotFound { error } => write!(f, "{}", error),
             ValidationErrorKind::InvalidURL { error } => write!(f, "{}", error),

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -44,9 +44,14 @@ impl<'a> Resolver<'a> {
                 Some(value) => Ok(Cow::Borrowed(value)),
                 None => match url.scheme() {
                     "http" | "https" => {
-                        let response = reqwest::blocking::get(url.as_str())?;
-                        let document: Value = response.json()?;
-                        Ok(Cow::Owned(document))
+                        #[cfg(any(feature = "reqwest", test))]
+                        {
+                            let response = reqwest::blocking::get(url.as_str())?;
+                            let document: Value = response.json()?;
+                            Ok(Cow::Owned(document))
+                        }
+                        #[cfg(not(any(feature = "reqwest", test)))]
+                        panic!("trying to resolve an http(s), but reqwest support has not been included");
                     }
                     http_scheme => Err(ValidationError::unknown_reference_scheme(
                         http_scheme.to_owned(),


### PR DESCRIPTION
With this PR, `reqwest`is an optional dependency. It is still a default feature, and it is also used from the dev profile.

The parts in the code that use `reqwest` are compiled either if the relative feature is used or if `cfg(test)`. However, there is still an issue if tests runs with `--no-default-features`, because `test_suite` is an integration test, therefore the `test` feature is not enabled and many tests fail.

If this behavior must be fixed, I am a bit unsure about the best solution. Surely one of them is making the tests inside the suite aware of the availability of `reqwest` in order to be automatically skipped, but I think that there should be a better way to handle the situation.

Closes #137 