### PR TITLE
CLI tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Command Line Interface. [#102](https://github.com/Stranger6667/jsonschema-rs/issues/102)
 - `ToString` trait implementation for validators.
 - Define `JSONSchema::options` to customise `JSONSchema` compilation [#131](https://github.com/Stranger6667/jsonschema-rs/issues/131)
 - Allow user-defined `contentEncoding` and `contentMediaType` keywords

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,9 +11,12 @@ keywords = ["jsonschema", "validation"]
 exclude = ["tests", "python", "benches/*.json", ".github", ".yamllint", ".pre-commit-config.yaml", ".gitignore", ".gitmodules", "*.md"]
 categories = ["web-programming"]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[[bin]]
+name = "jsonschema"
+
 [features]
-default = ["reqwest"]
+default = ["reqwest", "cli"]
+cli = ["structopt"]
 
 [dependencies]
 serde_json = "1"
@@ -29,6 +32,7 @@ parking_lot = ">= 0.1"
 num-cmp = ">= 0.1"
 paste = ">= 0.1"
 idna = ">= 0.2"
+structopt = { version = ">= 0.3", optional = true }
 
 [dev-dependencies]
 criterion = ">= 0.1"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,79 @@
+use std::error::Error;
+use std::path::PathBuf;
+use std::{fs, process};
+
+use jsonschema::JSONSchema;
+use structopt::StructOpt;
+
+type BoxErrorResult<T> = Result<T, Box<dyn Error>>;
+
+#[derive(Debug, StructOpt)]
+#[structopt(name = "jsonschema")]
+struct Cli {
+    /// A path to a JSON instance (i.e. filename.json) to validate (may be specified multiple times).
+    #[structopt(short = "i", long = "instance")]
+    instances: Option<Vec<PathBuf>>,
+
+    /// The fully qualified object name of a validator to use, or, for validators that are registered
+    /// with jsonschema, simply the name of the class.
+    #[structopt(short = "V", long = "validator")]
+    validator: Option<String>,
+
+    /// The JSON Schema to validate with (i.e. schema.json).
+    #[structopt(parse(from_os_str), required_unless("version"))]
+    schema: Option<PathBuf>,
+
+    /// Show program's version number and exit.
+    #[structopt(short = "v", long = "version")]
+    version: bool,
+}
+
+pub fn main() -> BoxErrorResult<()> {
+    let config = Cli::from_args();
+
+    if config.version {
+        println!("Version: {}", env!("CARGO_PKG_VERSION"));
+        return Ok(());
+    }
+
+    let mut success = true;
+    if let Some(schema) = config.schema {
+        if let Some(instances) = config.instances {
+            success = validate_instances(&instances, schema)?;
+        }
+    }
+
+    if !success {
+        process::exit(1);
+    }
+
+    Ok(())
+}
+
+fn validate_instances(instances: &[PathBuf], schema: PathBuf) -> BoxErrorResult<bool> {
+    let mut success = true;
+
+    let schema_json = fs::read_to_string(schema)?;
+    let schema_json = serde_json::from_str(&schema_json)?;
+    let schema = JSONSchema::compile(&schema_json)?;
+
+    for instance in instances {
+        let instance_path_name = instance.to_str().unwrap();
+        let instance_json = fs::read_to_string(&instance)?;
+        let instance_json = serde_json::from_str(&instance_json)?;
+        let validation = schema.validate(&instance_json);
+        match validation {
+            Ok(_) => println!("{} - VALID", instance_path_name),
+            Err(errors) => {
+                success = false;
+
+                println!("{} - INVALID. Errors:", instance_path_name);
+                for (i, e) in errors.enumerate() {
+                    println!("{}. {}", i + 1, e);
+                }
+            }
+        }
+    }
+
+    Ok(success)
+}


### PR DESCRIPTION
This PR adds a simple command-line interface tool for JSON schema validation.

```
cli 0.3.1

USAGE:
    cli [OPTIONS] <schema>

FLAGS:
    -h, --help       Prints help information
    -v, --version    Show program's version number and exit

OPTIONS:
    -i, --instance <instances>...    A path to a JSON instance (i.e. filename.json) to validate (may be specified
                                     multiple times)

ARGS:
    <schema>    The JSON Schema to validate with (i.e. schema.json)
```

Example:

```
cargo run -- benches/small_schema.json -i benches/small_invalid.json -i benches/small_valid.json
```

Prints:

```
benches/small_invalid.json - INVALID. Errors:
1. 10 is greater than or equal to the maximum of 10
benches/small_valid.json - VALID
```

Closes #102.