### PR TITLE
fix: Integers not recognized as numbers when the `type` keyword is a list of multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Integers not recognized as numbers when the `type` keyword is a list of multiple values. [#147](https://github.com/Stranger6667/jsonschema-rs/issues/147)
+
 ## [0.4.0] - 2020-11-09
 
 ### Added

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Integers not recognized as numbers when the `type` keyword is a list of multiple values. [#147](https://github.com/Stranger6667/jsonschema-rs/issues/147)
+
 ## [0.4.0] - 2020-11-09
 
 ### Added

--- a/src/keywords/additional_properties.rs
+++ b/src/keywords/additional_properties.rs
@@ -6,7 +6,7 @@ use crate::{
 };
 use regex::Regex;
 use serde_json::{Map, Value};
-use std::{collections::BTreeSet, iter::FromIterator};
+use std::collections::BTreeSet;
 
 pub(crate) struct AdditionalPropertiesValidator {
     validators: Validators,
@@ -124,7 +124,7 @@ impl AdditionalPropertiesNotEmptyFalseValidator {
     pub(crate) fn compile(properties: &Value) -> CompilationResult {
         if let Value::Object(properties) = properties {
             Ok(Box::new(AdditionalPropertiesNotEmptyFalseValidator {
-                properties: BTreeSet::from_iter(properties.keys().cloned()),
+                properties: properties.keys().cloned().collect(),
             }))
         } else {
             Err(CompilationError::SchemaError)
@@ -203,7 +203,7 @@ impl AdditionalPropertiesNotEmptyValidator {
     ) -> CompilationResult {
         if let Value::Object(properties) = properties {
             Ok(Box::new(AdditionalPropertiesNotEmptyValidator {
-                properties: BTreeSet::from_iter(properties.keys().cloned()),
+                properties: properties.keys().cloned().collect(),
                 validators: compile_validators(schema, context)?,
             }))
         } else {
@@ -433,7 +433,7 @@ impl AdditionalPropertiesWithPatternsNotEmptyValidator {
             Ok(Box::new(
                 AdditionalPropertiesWithPatternsNotEmptyValidator {
                     validators: compile_validators(schema, context)?,
-                    properties: BTreeSet::from_iter(properties.keys().cloned()),
+                    properties: properties.keys().cloned().collect(),
                     pattern,
                 },
             ))
@@ -519,7 +519,7 @@ impl AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
         if let Value::Object(properties) = properties {
             Ok(Box::new(
                 AdditionalPropertiesWithPatternsNotEmptyFalseValidator {
-                    properties: BTreeSet::from_iter(properties.keys().cloned()),
+                    properties: properties.keys().cloned().collect(),
                     pattern,
                 },
             ))

--- a/src/keywords/mod.rs
+++ b/src/keywords/mod.rs
@@ -245,4 +245,12 @@ mod tests {
         let compiled = JSONSchema::compile(schema).unwrap();
         assert!(compiled.is_valid(instance))
     }
+
+    #[test_case(&json!({"type": "number"}), &json!(42))]
+    #[test_case(&json!({"type": ["number", "null"]}), &json!(42))]
+    fn integer_is_valid_number_multi_type(schema: &Value, instance: &Value) {
+        // Regression: https://github.com/Stranger6667/jsonschema-rs/issues/147
+        let compiled = JSONSchema::compile(schema).unwrap();
+        assert!(compiled.is_valid(instance))
+    }
 }

--- a/src/keywords/type_.rs
+++ b/src/keywords/type_.rs
@@ -62,6 +62,7 @@ impl Validate for MultipleTypesValidator {
     #[inline]
     fn is_valid_signed_integer(&self, _: &JSONSchema, _: &Value, _: i64) -> bool {
         self.types.contains_type(PrimitiveType::Integer)
+            || self.types.contains_type(PrimitiveType::Number)
     }
     #[inline]
     fn is_valid_string(&self, _: &JSONSchema, _: &Value, _: &str) -> bool {
@@ -70,6 +71,7 @@ impl Validate for MultipleTypesValidator {
     #[inline]
     fn is_valid_unsigned_integer(&self, _: &JSONSchema, _: &Value, _: u64) -> bool {
         self.types.contains_type(PrimitiveType::Integer)
+            || self.types.contains_type(PrimitiveType::Number)
     }
 }
 impl ToString for MultipleTypesValidator {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -73,6 +73,7 @@
     unreachable_pub,
     variant_size_differences
 )]
+#![allow(clippy::unnecessary_unwrap)]
 #![cfg_attr(not(test), allow(clippy::integer_arithmetic, clippy::unwrap_used))]
 mod compilation;
 mod content_encoding;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -163,7 +163,7 @@ pub(crate) fn pointer<'a>(
     document: &'a Value,
     pointer: &str,
 ) -> Option<(Vec<&'a str>, &'a Value)> {
-    if pointer == "" {
+    if pointer.is_empty() {
         return Some((vec![], document));
     }
     if !pointer.starts_with('/') {


### PR DESCRIPTION
Fixes #147 