### PR TITLE
perf: Enum validation performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- Enum validation for input values that have a type that is not present among the enum variants. [#80](https://github.com/Stranger6667/jsonschema-rs/issues/80)
+
 ## [0.4.3] - 2020-12-11
 
 ### Documentation

--- a/benches/jsonschema.rs
+++ b/benches/jsonschema.rs
@@ -281,7 +281,7 @@ bench!(
   name = "enum";
   schema = {"enum": [1, 2, 3, 4]};
   valid = 4;
-  invalid = 5;
+  invalid = 5, "6";
 );
 bench!(
   name = "exclusive_maximum";

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- Enum validation for input values that have a type that is not present among the enum variants. [#80](https://github.com/Stranger6667/jsonschema-rs/issues/80)
+
 ## [0.4.3] - 2020-12-15
 
 ### Changed

--- a/src/primitive_type.rs
+++ b/src/primitive_type.rs
@@ -1,3 +1,4 @@
+use serde_json::Value;
 use std::{convert::TryFrom, fmt, ops::BitOrAssign};
 
 /// For faster error handling in "type" keyword validator we have this enum, to match
@@ -45,6 +46,19 @@ impl TryFrom<&str> for PrimitiveType {
     }
 }
 
+impl From<&Value> for PrimitiveType {
+    fn from(instance: &Value) -> Self {
+        match instance {
+            Value::Null => PrimitiveType::Null,
+            Value::Bool(_) => PrimitiveType::Boolean,
+            Value::Number(_) => PrimitiveType::Number,
+            Value::String(_) => PrimitiveType::String,
+            Value::Array(_) => PrimitiveType::Array,
+            Value::Object(_) => PrimitiveType::Object,
+        }
+    }
+}
+
 #[inline(always)]
 fn primitive_type_to_bit_map_representation(primitive_type: PrimitiveType) -> u8 {
     match primitive_type {
@@ -68,7 +82,7 @@ fn bit_map_representation_primitive_type(bit_representation: u8) -> PrimitiveTyp
         16 => PrimitiveType::Number,
         32 => PrimitiveType::Object,
         64 => PrimitiveType::String,
-        _ => unreachable!("This shoud never be possible"),
+        _ => unreachable!("This should never be possible"),
     }
 }
 


### PR DESCRIPTION
Resolves #80.

For the benched case it gives 2 ns vs 12 ns and almost no visible change in the compilation speed (it will be more visible in larger enums though) and other cases don't seem to be affected as well.