### PR TITLE
feat: Add cache for schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Cache for documents loaded via the `$ref` keyword. [#75](https://github.com/Stranger6667/jsonschema-rs/issues/75)
+
 ### Performance
 
 - Enum validation for input values that have a type that is not present among the enum variants. [#80](https://github.com/Stranger6667/jsonschema-rs/issues/80)

--- a/python/CHANGELOG.md
+++ b/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Cache for documents loaded via the `$ref` keyword. [#75](https://github.com/Stranger6667/jsonschema-rs/issues/75)
+
 ### Performance
 
 - Enum validation for input values that have a type that is not present among the enum variants. [#80](https://github.com/Stranger6667/jsonschema-rs/issues/80)


### PR DESCRIPTION
Resolves #75 

Even though this implementation clones the underlying schema, it is an improvement over the status quo. Working with references could be done separately, as it will likely require changes to `Resolver` itself.

Location-independent identifiers is a separate issue.

This mechanism can be used to store `http://json-schema.org/draft-04/schema` and others.