### PR TITLE
chore: Disable codecov action checks

### DIFF
--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,2 +1,6 @@
 github_checks:
     annotations: false
+coverage:
+  status:
+    project: off
+    patch: off


### PR DESCRIPTION
As the coverage impl is not stable, the checks are pretty useless