### PR TITLE
chore: Exclude JSON blobs from `sdist`

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Exclude unnecessary files from source code distribution.
+
 ## [0.5.0] - 2021-01-29
 
 ### Added

--- a/bindings/python/MANIFEST.in
+++ b/bindings/python/MANIFEST.in
@@ -4,4 +4,7 @@ include pyproject.toml
 include rust-toolchain
 recursive-include src *
 recursive-include jsonschema-lib *
+recursive-exclude jsonschema-lib Cargo.lock
 recursive-exclude jsonschema-lib/target *
+recursive-exclude jsonschema-lib/benches *.json
+recursive-exclude jsonschema-lib/tests *


### PR DESCRIPTION
That `canada.json` file is >5mb and it not needed for building the package