### PR TITLE
Fetch git submodule with https instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "jsonschema/tests/suite"]
 	path = jsonschema/tests/suite
-	url = git@github.com:json-schema-org/JSON-Schema-Test-Suite.git
+	url = https://github.com/json-schema-org/JSON-Schema-Test-Suite.git


### PR DESCRIPTION
This had been done in the past already (9a4f79af9841266c913d42adf7a70ed532d3a237), but it seems this was changed again in f5be9508d0182fa5f3f673e8e9dd1dcdb45e94ca. Was this on purpose?

Using SSH for the submodule url does not allow anonymous checkout. I am installing the python bindings via pip directly from the git repo while building a docker container. pip does checkout the submodules, too - but because it's in the docker container there are no ssh keys present and the checkout fails. Using https worked before.