### PR TITLE
Add a `path` field to `ValidationError`

### DIFF
--- a/jsonschema/src/compilation/mod.rs
+++ b/jsonschema/src/compilation/mod.rs
@@ -4,6 +4,8 @@
 pub(crate) mod context;
 pub(crate) mod options;
 
+use std::{cell::RefCell, rc::Rc};
+
 use crate::{
     error::{CompilationError, ErrorIterator},
     keywords,
@@ -63,7 +65,14 @@ impl<'a> JSONSchema<'a> {
         let mut errors = self
             .validators
             .iter()
-            .flat_map(move |validator| validator.validate(self, instance))
+            .flat_map(move |validator| {
+                // The path capacity should be the average depth so we avoid extra allocations
+                validator.validate(
+                    self,
+                    instance,
+                    Rc::new(RefCell::new(Vec::with_capacity(6))).into(),
+                )
+            })
             .peekable();
         if errors.peek().is_none() {
             Ok(())

--- a/jsonschema/src/keywords/all_of.rs
+++ b/jsonschema/src/keywords/all_of.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{CompilationError, ErrorIterator},
@@ -35,14 +36,20 @@ impl Validate for AllOfValidator {
         })
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         let errors: Vec<_> = self
             .schemas
             .iter()
             .flat_map(move |validators| {
-                validators
-                    .iter()
-                    .flat_map(move |validator| validator.validate(schema, instance))
+                let curr_instance_path = curr_instance_path.clone();
+                validators.iter().flat_map(move |validator| {
+                    validator.validate(schema, instance, curr_instance_path.clone())
+                })
             })
             .collect();
         Box::new(errors.into_iter())

--- a/jsonschema/src/keywords/any_of.rs
+++ b/jsonschema/src/keywords/any_of.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -39,11 +40,16 @@ impl Validate for AnyOfValidator {
         false
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::any_of(instance))
+            error(ValidationError::any_of(curr_instance_path.into(), instance))
         }
     }
 }

--- a/jsonschema/src/keywords/boolean.rs
+++ b/jsonschema/src/keywords/boolean.rs
@@ -1,3 +1,5 @@
+use crate::keywords::InstancePath;
+
 use crate::{
     compilation::JSONSchema,
     error::{error, no_error, ErrorIterator, ValidationError},
@@ -18,7 +20,12 @@ impl Validate for TrueValidator {
         true
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, _: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        _: &'a Value,
+        _: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         no_error()
     }
 }
@@ -41,7 +48,12 @@ impl Validate for FalseValidator {
         false
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        _: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         error(ValidationError::false_schema(instance))
     }
 }

--- a/jsonschema/src/keywords/const_.rs
+++ b/jsonschema/src/keywords/const_.rs
@@ -8,6 +8,8 @@ use crate::{
 use serde_json::{Map, Number, Value};
 use std::f64::EPSILON;
 
+use super::InstancePath;
+
 struct ConstArrayValidator {
     value: Vec<Value>,
 }
@@ -21,11 +23,20 @@ impl ConstArrayValidator {
 }
 impl Validate for ConstArrayValidator {
     #[inline]
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::constant_array(instance, &self.value))
+            error(ValidationError::constant_array(
+                curr_instance_path.into(),
+                instance,
+                &self.value,
+            ))
         }
     }
 
@@ -62,11 +73,20 @@ impl ConstBooleanValidator {
 }
 impl Validate for ConstBooleanValidator {
     #[inline]
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::constant_boolean(instance, self.value))
+            error(ValidationError::constant_boolean(
+                curr_instance_path.into(),
+                instance,
+                self.value,
+            ))
         }
     }
 
@@ -94,11 +114,19 @@ impl ConstNullValidator {
 }
 impl Validate for ConstNullValidator {
     #[inline]
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::constant_null(instance))
+            error(ValidationError::constant_null(
+                curr_instance_path.into(),
+                instance,
+            ))
         }
     }
 
@@ -132,11 +160,17 @@ impl ConstNumberValidator {
 }
 
 impl Validate for ConstNumberValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::constant_number(
+                curr_instance_path.into(),
                 instance,
                 &self.original_value,
             ))
@@ -172,11 +206,20 @@ impl ConstObjectValidator {
 }
 
 impl Validate for ConstObjectValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::constant_object(instance, &self.value))
+            error(ValidationError::constant_object(
+                curr_instance_path.into(),
+                instance,
+                &self.value,
+            ))
         }
     }
 
@@ -216,11 +259,20 @@ impl ConstStringValidator {
 }
 
 impl Validate for ConstStringValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::constant_string(instance, &self.value))
+            error(ValidationError::constant_string(
+                curr_instance_path.into(),
+                instance,
+                &self.value,
+            ))
         }
     }
 

--- a/jsonschema/src/keywords/contains.rs
+++ b/jsonschema/src/keywords/contains.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
@@ -37,7 +38,12 @@ impl Validate for ContainsValidator {
         }
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
             for item in items {
                 if self
@@ -48,7 +54,10 @@ impl Validate for ContainsValidator {
                     return no_error();
                 }
             }
-            error(ValidationError::contains(instance))
+            error(ValidationError::contains(
+                curr_instance_path.into(),
+                instance,
+            ))
         } else {
             no_error()
         }

--- a/jsonschema/src/keywords/enum_.rs
+++ b/jsonschema/src/keywords/enum_.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -35,9 +36,18 @@ impl EnumValidator {
 }
 
 impl Validate for EnumValidator {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if !self.is_valid(schema, instance) {
-            error(ValidationError::enumeration(instance, &self.options))
+            error(ValidationError::enumeration(
+                curr_instance_path.into(),
+                instance,
+                &self.options,
+            ))
         } else {
             no_error()
         }

--- a/jsonschema/src/keywords/exclusive_maximum.rs
+++ b/jsonschema/src/keywords/exclusive_maximum.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -20,15 +21,17 @@ pub(crate) struct ExclusiveMaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
+            fn validate<'a, 'b>(
+                &'b self,
                 schema: &'a JSONSchema,
                 instance: &'a Value,
+                curr_instance_path: InstancePath<'b>,
             ) -> ErrorIterator<'a> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
                     error(ValidationError::exclusive_maximum(
+                        curr_instance_path.into(),
                         instance,
                         self.limit as f64,
                     ))
@@ -77,11 +80,20 @@ impl Validate for ExclusiveMaximumF64Validator {
         }
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::exclusive_maximum(instance, self.limit))
+            error(ValidationError::exclusive_maximum(
+                curr_instance_path.into(),
+                instance,
+                self.limit,
+            ))
         }
     }
 }

--- a/jsonschema/src/keywords/exclusive_minimum.rs
+++ b/jsonschema/src/keywords/exclusive_minimum.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -20,15 +21,17 @@ pub(crate) struct ExclusiveMinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
+            fn validate<'a, 'b>(
+                &'b self,
                 schema: &'a JSONSchema,
                 instance: &'a Value,
+                curr_instance_path: InstancePath<'b>,
             ) -> ErrorIterator<'a> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
                     error(ValidationError::exclusive_minimum(
+                        curr_instance_path.into(),
                         instance,
                         self.limit as f64,
                     ))
@@ -75,11 +78,20 @@ impl Validate for ExclusiveMinimumF64Validator {
         true
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::exclusive_minimum(instance, self.limit))
+            error(ValidationError::exclusive_minimum(
+                curr_instance_path.into(),
+                instance,
+                self.limit,
+            ))
         }
     }
 }

--- a/jsonschema/src/keywords/format.rs
+++ b/jsonschema/src/keywords/format.rs
@@ -1,4 +1,5 @@
 //! Validator for `format` keyword.
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -9,6 +10,7 @@ use crate::{
 use chrono::{DateTime, NaiveDate};
 use regex::Regex;
 use serde_json::{Map, Value};
+
 use std::{net::IpAddr, str::FromStr};
 use url::Url;
 
@@ -51,10 +53,19 @@ macro_rules! format_validator {
 
 macro_rules! validate {
     ($format:expr) => {
-        fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+        fn validate<'a, 'b>(
+            &'b self,
+            schema: &'a JSONSchema,
+            instance: &'a Value,
+            curr_instance_path: InstancePath<'b>,
+        ) -> ErrorIterator<'a> {
             if let Value::String(_item) = instance {
                 if !self.is_valid(schema, instance) {
-                    return error(ValidationError::format(instance, $format));
+                    return error(ValidationError::format(
+                        curr_instance_path.into(),
+                        instance,
+                        $format,
+                    ));
                 }
             }
             no_error()

--- a/jsonschema/src/keywords/if_.rs
+++ b/jsonschema/src/keywords/if_.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator},
@@ -40,7 +41,12 @@ impl Validate for IfThenValidator {
         }
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self
             .schema
             .iter()
@@ -49,7 +55,9 @@ impl Validate for IfThenValidator {
             let errors: Vec<_> = self
                 .then_schema
                 .iter()
-                .flat_map(move |validator| validator.validate(schema, instance))
+                .flat_map(move |validator| {
+                    validator.validate(schema, instance, curr_instance_path.clone())
+                })
                 .collect();
             Box::new(errors.into_iter())
         } else {
@@ -102,7 +110,12 @@ impl Validate for IfElseValidator {
         }
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self
             .schema
             .iter()
@@ -111,7 +124,9 @@ impl Validate for IfElseValidator {
             let errors: Vec<_> = self
                 .else_schema
                 .iter()
-                .flat_map(move |validator| validator.validate(schema, instance))
+                .flat_map(move |validator| {
+                    validator.validate(schema, instance, curr_instance_path.clone())
+                })
                 .collect();
             Box::new(errors.into_iter())
         } else {
@@ -169,7 +184,12 @@ impl Validate for IfThenElseValidator {
         }
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self
             .schema
             .iter()
@@ -178,14 +198,18 @@ impl Validate for IfThenElseValidator {
             let errors: Vec<_> = self
                 .then_schema
                 .iter()
-                .flat_map(move |validator| validator.validate(schema, instance))
+                .flat_map(move |validator| {
+                    validator.validate(schema, instance, curr_instance_path.clone())
+                })
                 .collect();
             Box::new(errors.into_iter())
         } else {
             let errors: Vec<_> = self
                 .else_schema
                 .iter()
-                .flat_map(move |validator| validator.validate(schema, instance))
+                .flat_map(move |validator| {
+                    validator.validate(schema, instance, curr_instance_path.clone())
+                })
                 .collect();
             Box::new(errors.into_iter())
         }

--- a/jsonschema/src/keywords/legacy/type_draft_4.rs
+++ b/jsonschema/src/keywords/legacy/type_draft_4.rs
@@ -1,7 +1,7 @@
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
-    keywords::{type_, CompilationResult},
+    keywords::{type_, CompilationResult, InstancePath},
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
     validator::Validate,
 };
@@ -46,11 +46,20 @@ impl Validate for MultipleTypesValidator {
             Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::multiple_type_error(instance, self.types))
+            error(ValidationError::multiple_type_error(
+                curr_instance_path.into(),
+                instance,
+                self.types,
+            ))
         }
     }
 }
@@ -86,11 +95,17 @@ impl Validate for IntegerTypeValidator {
         }
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Integer,
             ))

--- a/jsonschema/src/keywords/max_items.rs
+++ b/jsonschema/src/keywords/max_items.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -31,10 +32,19 @@ impl Validate for MaxItemsValidator {
         true
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
             if (items.len() as u64) > self.limit {
-                return error(ValidationError::max_items(instance, self.limit));
+                return error(ValidationError::max_items(
+                    curr_instance_path.into(),
+                    instance,
+                    self.limit,
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/max_length.rs
+++ b/jsonschema/src/keywords/max_length.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -31,10 +32,19 @@ impl Validate for MaxLengthValidator {
         true
     }
 
-    fn validate<'a>(&self, _schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if (item.chars().count() as u64) > self.limit {
-                return error(ValidationError::max_length(instance, self.limit));
+                return error(ValidationError::max_length(
+                    curr_instance_path.into(),
+                    instance,
+                    self.limit,
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/max_properties.rs
+++ b/jsonschema/src/keywords/max_properties.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -31,10 +32,19 @@ impl Validate for MaxPropertiesValidator {
         true
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
             if (item.len() as u64) > self.limit {
-                return error(ValidationError::max_properties(instance, self.limit));
+                return error(ValidationError::max_properties(
+                    curr_instance_path.into(),
+                    instance,
+                    self.limit,
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/maximum.rs
+++ b/jsonschema/src/keywords/maximum.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -20,15 +21,20 @@ pub(crate) struct MaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
+            fn validate<'a, 'b>(
+                &'b self,
                 schema: &'a JSONSchema,
                 instance: &'a Value,
+                curr_instance_path: InstancePath<'b>,
             ) -> ErrorIterator<'a> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
-                    error(ValidationError::maximum(instance, self.limit as f64)) // do not cast
+                    error(ValidationError::maximum(
+                        curr_instance_path.into(),
+                        instance,
+                        self.limit as f64,
+                    )) // do not cast
                 }
             }
 
@@ -72,11 +78,20 @@ impl Validate for MaximumF64Validator {
         true
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::maximum(instance, self.limit))
+            error(ValidationError::maximum(
+                curr_instance_path.into(),
+                instance,
+                self.limit,
+            ))
         }
     }
 }

--- a/jsonschema/src/keywords/min_items.rs
+++ b/jsonschema/src/keywords/min_items.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -31,10 +32,19 @@ impl Validate for MinItemsValidator {
         true
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::Array(items) = instance {
             if (items.len() as u64) < self.limit {
-                return error(ValidationError::min_items(instance, self.limit));
+                return error(ValidationError::min_items(
+                    curr_instance_path.into(),
+                    instance,
+                    self.limit,
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/min_length.rs
+++ b/jsonschema/src/keywords/min_length.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -31,10 +32,19 @@ impl Validate for MinLengthValidator {
         true
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if (item.chars().count() as u64) < self.limit {
-                return error(ValidationError::min_length(instance, self.limit));
+                return error(ValidationError::min_length(
+                    curr_instance_path.into(),
+                    instance,
+                    self.limit,
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/min_properties.rs
+++ b/jsonschema/src/keywords/min_properties.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -31,10 +32,19 @@ impl Validate for MinPropertiesValidator {
         true
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
             if (item.len() as u64) < self.limit {
-                return error(ValidationError::min_properties(instance, self.limit));
+                return error(ValidationError::min_properties(
+                    curr_instance_path.into(),
+                    instance,
+                    self.limit,
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/minimum.rs
+++ b/jsonschema/src/keywords/minimum.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -20,15 +21,20 @@ pub(crate) struct MinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
-                &self,
+            fn validate<'a, 'b>(
+                &'b self,
                 schema: &'a JSONSchema,
                 instance: &'a Value,
+                curr_instance_path: InstancePath<'b>,
             ) -> ErrorIterator<'a> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
-                    error(ValidationError::minimum(instance, self.limit as f64)) // do not cast
+                    error(ValidationError::minimum(
+                        curr_instance_path.into(),
+                        instance,
+                        self.limit as f64,
+                    )) // do not cast
                 }
             }
 
@@ -72,11 +78,20 @@ impl Validate for MinimumF64Validator {
         true
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::minimum(instance, self.limit))
+            error(ValidationError::minimum(
+                curr_instance_path.into(),
+                instance,
+                self.limit,
+            ))
         }
     }
 }

--- a/jsonschema/src/keywords/not.rs
+++ b/jsonschema/src/keywords/not.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
@@ -30,11 +31,20 @@ impl Validate for NotValidator {
             .all(|validator| validator.is_valid(schema, instance))
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::not(instance, self.original.clone()))
+            error(ValidationError::not(
+                curr_instance_path.into(),
+                instance,
+                self.original.clone(),
+            ))
         }
     }
 }

--- a/jsonschema/src/keywords/one_of.rs
+++ b/jsonschema/src/keywords/one_of.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -64,15 +65,26 @@ impl Validate for OneOfValidator {
             false
         }
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         let first_valid_idx = self.get_first_valid(schema, instance);
         if let Some(idx) = first_valid_idx {
             if self.are_others_valid(schema, instance, idx) {
-                return error(ValidationError::one_of_multiple_valid(instance));
+                return error(ValidationError::one_of_multiple_valid(
+                    curr_instance_path.into(),
+                    instance,
+                ));
             }
             no_error()
         } else {
-            error(ValidationError::one_of_not_valid(instance))
+            error(ValidationError::one_of_not_valid(
+                curr_instance_path.into(),
+                instance,
+            ))
         }
     }
 }

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -35,10 +36,19 @@ impl PatternValidator {
 }
 
 impl Validate for PatternValidator {
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
             if !self.pattern.is_match(item) {
-                return error(ValidationError::pattern(instance, self.original.clone()));
+                return error(ValidationError::pattern(
+                    curr_instance_path.into(),
+                    instance,
+                    self.original.clone(),
+                ));
             }
         }
         no_error()

--- a/jsonschema/src/keywords/required.rs
+++ b/jsonschema/src/keywords/required.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, CompilationError, ErrorIterator, ValidationError},
@@ -40,11 +41,20 @@ impl Validate for RequiredValidator {
         }
     }
 
-    fn validate<'a>(&self, _: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        _: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if let Value::Object(item) = instance {
             for property_name in &self.required {
                 if !item.contains_key(property_name) {
-                    return error(ValidationError::required(instance, property_name.clone()));
+                    return error(ValidationError::required(
+                        curr_instance_path.into(),
+                        instance,
+                        property_name.clone(),
+                    ));
                 }
             }
         }

--- a/jsonschema/src/keywords/type_.rs
+++ b/jsonschema/src/keywords/type_.rs
@@ -8,6 +8,8 @@ use crate::{
 use serde_json::{Map, Number, Value};
 use std::convert::TryFrom;
 
+use super::InstancePath;
+
 pub(crate) struct MultipleTypesValidator {
     types: PrimitiveTypesBitMap,
 }
@@ -46,11 +48,20 @@ impl Validate for MultipleTypesValidator {
             Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::multiple_type_error(instance, self.types))
+            error(ValidationError::multiple_type_error(
+                curr_instance_path.into(),
+                instance,
+                self.types,
+            ))
         }
     }
 }
@@ -81,11 +92,17 @@ impl Validate for NullTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_null()
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Null,
             ))
@@ -112,11 +129,17 @@ impl Validate for BooleanTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_boolean()
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Boolean,
             ))
@@ -144,11 +167,17 @@ impl Validate for StringTypeValidator {
         instance.is_string()
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::String,
             ))
@@ -175,11 +204,17 @@ impl Validate for ArrayTypeValidator {
         instance.is_array()
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Array,
             ))
@@ -206,11 +241,17 @@ impl Validate for ObjectTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_object()
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Object,
             ))
@@ -237,11 +278,17 @@ impl Validate for NumberTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_number()
     }
-    fn validate<'a>(&self, config: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        config: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(config, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Number,
             ))
@@ -270,11 +317,17 @@ impl Validate for IntegerTypeValidator {
             false
         }
     }
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
+                curr_instance_path.into(),
                 instance,
                 PrimitiveType::Integer,
             ))

--- a/jsonschema/src/keywords/unique_items.rs
+++ b/jsonschema/src/keywords/unique_items.rs
@@ -1,3 +1,4 @@
+use crate::keywords::InstancePath;
 use crate::{
     compilation::{context::CompilationContext, JSONSchema},
     error::{error, no_error, ErrorIterator, ValidationError},
@@ -6,6 +7,7 @@ use crate::{
 };
 use ahash::{AHashSet, AHasher};
 use serde_json::{Map, Value};
+
 use std::hash::{Hash, Hasher};
 
 // Based on implementation proposed by Sven Marnach:
@@ -76,11 +78,19 @@ impl Validate for UniqueItemsValidator {
         true
     }
 
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a> {
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
-            error(ValidationError::unique_items(instance))
+            error(ValidationError::unique_items(
+                curr_instance_path.into(),
+                instance,
+            ))
         }
     }
 }

--- a/jsonschema/src/validator.rs
+++ b/jsonschema/src/validator.rs
@@ -1,9 +1,14 @@
-use crate::{compilation::JSONSchema, error::ErrorIterator};
+use crate::{compilation::JSONSchema, error::ErrorIterator, keywords::InstancePath};
 use serde_json::Value;
 use std::fmt;
 
 pub(crate) trait Validate: Send + Sync + ToString {
-    fn validate<'a>(&self, schema: &'a JSONSchema, instance: &'a Value) -> ErrorIterator<'a>;
+    fn validate<'a, 'b>(
+        &'b self,
+        schema: &'a JSONSchema,
+        instance: &'a Value,
+        curr_instance_path: InstancePath<'b>,
+    ) -> ErrorIterator<'a>;
     // The same as above, but does not construct ErrorIterator.
     // It is faster for cases when the result is not needed (like anyOf), since errors are
     // not constructed


### PR DESCRIPTION
### Summary
On validation error make the path to the problematic field available to the client. Currently the path is only a field in `ValidationError` but later it can be used to improve the error messages (related to #100, #144)
### Example

##### Schema
```json
{
   "type":"object",
   "properties":{
      "foo":{
         "type":"object",
         "properties":{
            "bar":{
               "type":"integer"
            }
         }
      }
   }
}
```
##### Input
```json
{
  "foo": {
    "bar": "some string"
  }
}
```

##### Produced Error
`path: [foo, bar]`