### PR TITLE
fix: Missing `array` type in error messages for `type` validators containing multiple values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Skipped validation on an unsupported regular expression in `patternProperties`. [#213](https://github.com/Stranger6667/jsonschema-rs/issues/213)
+- Missing `array` type in error messages for `type` validators containing multiple values. [#216](https://github.com/Stranger6667/jsonschema-rs/issues/216)
 
 ## [0.8.2] - 2021-05-03
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Skipped validation on an unsupported regular expression in `patternProperties`. [#213](https://github.com/Stranger6667/jsonschema-rs/issues/213)
+- Missing `array` type in error messages for `type` validators containing multiple values. [#216](https://github.com/Stranger6667/jsonschema-rs/issues/216)
 
 ## [0.6.2] - 2021-05-03
 

--- a/jsonschema/src/primitive_type.rs
+++ b/jsonschema/src/primitive_type.rs
@@ -5,7 +5,7 @@ use std::{convert::TryFrom, fmt, ops::BitOrAssign};
 
 /// For faster error handling in "type" keyword validator we have this enum, to match
 /// with it instead of a string.
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
 #[allow(missing_docs)]
 pub enum PrimitiveType {
     Array,
@@ -121,7 +121,7 @@ impl IntoIterator for PrimitiveTypesBitMap {
     type IntoIter = PrimitiveTypesBitMapIterator;
     fn into_iter(self) -> Self::IntoIter {
         PrimitiveTypesBitMapIterator {
-            range: 1..7,
+            range: 0..7,
             bit_map: self,
         }
     }
@@ -157,5 +157,29 @@ impl Iterator for PrimitiveTypesBitMapIterator {
                 return None;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_multiple_types() {
+        let mut types = PrimitiveTypesBitMap::new();
+        types |= PrimitiveType::Null;
+        types |= PrimitiveType::String;
+        types |= PrimitiveType::Array;
+        assert!(types.contains_type(PrimitiveType::Null));
+        assert!(types.contains_type(PrimitiveType::String));
+        assert!(types.contains_type(PrimitiveType::Array));
+        assert_eq!(
+            types.into_iter().collect::<Vec<PrimitiveType>>(),
+            vec![
+                PrimitiveType::Array,
+                PrimitiveType::Null,
+                PrimitiveType::String
+            ]
+        )
     }
 }


### PR DESCRIPTION
Fixes #216 