### PR TITLE
Improve Python error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- `paths::JSONPointer` implements `IntoIterator` over `paths::PathChunk`.
+
 ### Fixed
 
 - Skipped validation on an unsupported regular expression in `patternProperties`. [#213](https://github.com/Stranger6667/jsonschema-rs/issues/213)

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -12,6 +12,8 @@
 ## Changed
 
 - Update `PyO3` to `0.13.x`.
+- Improved error message for the `additionalProperties` validator. After - `Additional properties are not allowed ('faz' was unexpected)`, before - `False schema does not allow '"faz"'`.
+- The `additionalProperties` validator emits a single error for all unexpected properties instead of separate errors for each unexpected property.
 
 ### Fixed
 

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Error messages show paths to the erroneous part of the input instance. [#144](https://github.com/Stranger6667/jsonschema-rs/issues/144)
+
 ### Fixed
 
 - Skipped validation on an unsupported regular expression in `patternProperties`. [#213](https://github.com/Stranger6667/jsonschema-rs/issues/213)

--- a/bindings/python/Cargo.lock
+++ b/bindings/python/Cargo.lock
@@ -446,7 +446,7 @@ dependencies = [
 
 [[package]]
 name = "jsonschema"
-version = "0.8.1"
+version = "0.8.2"
 dependencies = [
  "ahash",
  "base64",
@@ -466,7 +466,7 @@ dependencies = [
 
 [[package]]
 name = "jsonschema-python"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "built",
  "jsonschema",

--- a/bindings/python/tests-py/test_jsonschema.py
+++ b/bindings/python/tests-py/test_jsonschema.py
@@ -101,3 +101,19 @@ def test_invalid_value(method):
     schema = JSONSchema({"minimum": 42})
     with pytest.raises(ValueError, match="Unsupported type: 'object'"):
         getattr(schema, method)(object())
+
+
+def test_error_message():
+    schema = {"properties": {"foo": {"type": "integer"}}}
+    instance = {"foo": None}
+    try:
+        validate(schema, instance)
+        pytest.fail("Validation error should happen")
+    except ValidationError as exc:
+        assert (
+            str(exc)
+            == """null is not of type "integer"
+
+On instance["foo"]:
+    null"""
+        )

--- a/jsonschema/src/error.rs
+++ b/jsonschema/src/error.rs
@@ -961,9 +961,9 @@ mod tests {
     }
 
     #[test_case(true, &json!([1, {"foo": ["42"]}]), &[PathChunk::Index(0)])]
-    #[test_case(true, &json!(["a", {"foo": [42]}]), &[PathChunk::Index(1), PathChunk::Name("foo".to_string()), PathChunk::Index(0)])]
+    #[test_case(true, &json!(["a", {"foo": [42]}]), &[PathChunk::Index(1), PathChunk::Property("foo".to_string()), PathChunk::Index(0)])]
     #[test_case(false, &json!([1, {"foo": ["42"]}]), &[PathChunk::Index(0)])]
-    #[test_case(false, &json!(["a", {"foo": [42]}]), &[PathChunk::Index(1), PathChunk::Name("foo".to_string()), PathChunk::Index(0)])]
+    #[test_case(false, &json!(["a", {"foo": [42]}]), &[PathChunk::Index(1), PathChunk::Property("foo".to_string()), PathChunk::Index(0)])]
     fn instance_path_properties_and_arrays(
         additional_items: bool,
         instance: &Value,


### PR DESCRIPTION
Validation errors now include instance paths, in a form similar to the `jsonschema` Python package.

Resolves #144 