### PR TITLE
Add support for look-around patterns using fancy-regex

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -24,6 +24,7 @@ url = "2"
 lazy_static = "1"
 percent-encoding = "2"
 regex = "1"
+fancy-regex = "0.5"
 base64 = ">= 0.2"
 chrono = ">= 0.2"
 reqwest = { version = ">= 0.10", features = ["blocking", "json"], optional = true}

--- a/jsonschema/src/error.rs
+++ b/jsonschema/src/error.rs
@@ -33,9 +33,9 @@ impl fmt::Display for CompilationError {
     }
 }
 
-impl From<regex::Error> for CompilationError {
+impl From<fancy_regex::Error> for CompilationError {
     #[inline]
-    fn from(_: regex::Error) -> Self {
+    fn from(_: fancy_regex::Error) -> Self {
         CompilationError::SchemaError
     }
 }

--- a/jsonschema/src/error.rs
+++ b/jsonschema/src/error.rs
@@ -104,9 +104,9 @@ pub enum ValidationErrorKind {
     Constant { expected_value: Value },
     /// The input array doesn't contain items conforming to the specified schema.
     Contains,
-    /// Ths input value does not respect the defined contentEncoding
+    /// The input value does not respect the defined contentEncoding
     ContentEncoding { content_encoding: String },
-    /// Ths input value does not respect the defined contentMediaType
+    /// The input value does not respect the defined contentMediaType
     ContentMediaType { content_media_type: String },
     /// The input value doesn't match any of specified options.
     Enum { options: Value },

--- a/jsonschema/src/keywords/format.rs
+++ b/jsonschema/src/keywords/format.rs
@@ -8,7 +8,7 @@ use crate::{
     Draft,
 };
 use chrono::{DateTime, NaiveDate};
-use regex::Regex;
+use fancy_regex::Regex;
 use serde_json::{Map, Value};
 
 use std::{net::IpAddr, str::FromStr};
@@ -82,7 +82,9 @@ impl Validate for DateValidator {
                 // Padding with zeroes is ignored by the underlying parser. The most efficient
                 // way to check it will be to use a custom parser that won't ignore zeroes,
                 // but this regex will do the trick and costs ~20% extra time in this validator.
-                DATE_RE.is_match(item.as_str())
+                DATE_RE
+                    .is_match(item.as_str())
+                    .expect("Simple DATE_RE pattern")
             } else {
                 false
             }
@@ -219,7 +221,9 @@ impl Validate for IRIReferenceValidator {
     validate!("iri-reference");
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            IRI_REFERENCE_RE.is_match(item)
+            IRI_REFERENCE_RE
+                .is_match(item)
+                .expect("Simple IRI_REFERENCE_RE pattern")
         } else {
             true
         }
@@ -230,7 +234,9 @@ impl Validate for JSONPointerValidator {
     validate!("json-pointer");
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            JSON_POINTER_RE.is_match(item)
+            JSON_POINTER_RE
+                .is_match(item)
+                .expect("Simple JSON_POINTER_RE pattern")
         } else {
             true
         }
@@ -252,7 +258,9 @@ impl Validate for RelativeJSONPointerValidator {
     validate!("relative-json-pointer");
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            RELATIVE_JSON_POINTER_RE.is_match(item)
+            RELATIVE_JSON_POINTER_RE
+                .is_match(item)
+                .expect("Simple RELATIVE_JSON_POINTER_RE pattern")
         } else {
             true
         }
@@ -263,7 +271,7 @@ impl Validate for TimeValidator {
     validate!("time");
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            TIME_RE.is_match(item)
+            TIME_RE.is_match(item).expect("Simple TIME_RE pattern")
         } else {
             true
         }
@@ -274,7 +282,9 @@ impl Validate for URIReferenceValidator {
     validate!("uri-reference");
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            URI_REFERENCE_RE.is_match(item)
+            URI_REFERENCE_RE
+                .is_match(item)
+                .expect("Simple URI_REFERENCE_RE pattern")
         } else {
             true
         }
@@ -285,7 +295,9 @@ impl Validate for URITemplateValidator {
     validate!("uri-template");
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            URI_TEMPLATE_RE.is_match(item)
+            URI_TEMPLATE_RE
+                .is_match(item)
+                .expect("Simple URI_TEMPLATE_RE pattern")
         } else {
             true
         }

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -56,11 +56,7 @@ impl Validate for PatternValidator {
 
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         if let Value::String(item) = instance {
-            if let Ok(is_match) = self.pattern.is_match(item) {
-                if !is_match {
-                    return false;
-                }
-            }
+            return self.pattern.is_match(item).unwrap_or(false);
         }
         true
     }

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -41,12 +41,21 @@ impl Validate for PatternValidator {
         instance_path: &InstancePath,
     ) -> ErrorIterator<'a> {
         if let Value::String(item) = instance {
-            if let Ok(is_match) = self.pattern.is_match(item) {
-                if !is_match {
-                    return error(ValidationError::pattern(
+            match self.pattern.is_match(item) {
+                Ok(is_match) => {
+                    if !is_match {
+                        return error(ValidationError::pattern(
+                            instance_path.into(),
+                            instance,
+                            self.original.clone(),
+                        ));
+                    }
+                }
+                Err(e) => {
+                    return error(ValidationError::backtrack_limit(
                         instance_path.into(),
                         instance,
-                        self.original.clone(),
+                        e,
                     ));
                 }
             }

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -7,6 +7,8 @@ use crate::{
 };
 use serde_json::{Map, Value};
 
+use std::ops::Index;
+
 lazy_static::lazy_static! {
     // Use regex::Regex here to take advantage of replace_all method not available in fancy_regex::Regex
     static ref CONTROL_GROUPS_RE: regex::Regex = regex::Regex::new(r"\\c[A-Za-z]").expect("Is a valid regex");
@@ -124,9 +126,7 @@ fn convert_regex(pattern: &str) -> Result<fancy_regex::Regex, fancy_regex::Error
 fn replace_control_group(captures: &regex::Captures) -> String {
     // There will be no overflow, because the minimum value is 65 (char 'A')
     ((captures
-        .get(0)
-        .map(|m| m.as_str())
-        .expect("index 0 to return the whole match")
+        .index(0)
         .trim_start_matches(r"\c")
         .chars()
         .next()

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -147,8 +147,8 @@ pub(crate) fn compile(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::{Value, json};
     use super::*;
+    use serde_json::{json, Value};
     use test_case::test_case;
 
     #[test_case(r"^[\w\-\.\+]+$", "CC-BY-4.0", true)]
@@ -178,9 +178,6 @@ mod tests {
 
         let compiled = PatternValidator::compile(&pattern).unwrap();
         let schema = JSONSchema::compile(&schema).unwrap();
-        assert_eq!(
-            compiled.is_valid(&schema, &text),
-            is_matching,
-        )
+        assert_eq!(compiled.is_valid(&schema, &text), is_matching,)
     }
 }

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -147,6 +147,7 @@ pub(crate) fn compile(
 
 #[cfg(test)]
 mod tests {
+    use serde_json::{Value, json};
     use super::*;
     use test_case::test_case;
 
@@ -166,5 +167,20 @@ mod tests {
     #[test_case(r"\d\")]
     fn invalid_escape_sequences(pattern: &str) {
         assert!(convert_regex(pattern).is_err())
+    }
+
+    #[test_case("^(?!eo:)", "eo:bands", false)]
+    #[test_case("^(?!eo:)", "proj:epsg", true)]
+    fn negative_lookbehind_match(pattern: &str, text: &str, is_matching: bool) {
+        let pattern = Value::String(pattern.into());
+        let text = Value::String(text.into());
+        let schema = json!({});
+
+        let compiled = PatternValidator::compile(&pattern).unwrap();
+        let schema = JSONSchema::compile(&schema).unwrap();
+        assert_eq!(
+            compiled.is_valid(&schema, &text),
+            is_matching,
+        )
     }
 }


### PR DESCRIPTION
Uses [`fancy-regex`](https://docs.rs/fancy-regex/0.5.0/fancy_regex/) in place of [`regex`](https://docs.rs/regex/) for matching against all patterns in JSON schemas. 

`regex` is still used when [converting a RegEx for ECMA 262](https://github.com/duckontheweb/jsonschema-rs/blob/b689ac5b32c29db0a36cf7ad3890e78f0cea96e3/jsonschema/src/keywords/pattern.rs#L78) to take advantage of the `Regex::replace_all` method, which is not included in `fancy-regex`.  Since `fancy-regex` depends on `regex` anyway, this does not affect the final size of the compiled binary (thanks to [this commit](https://github.com/niklasfasching/check_timed_logs_fast/commit/fa2ec6ef77d3befd03d8674e0ceae24846b620a6) for the idea). 

I also removed the test from #214, since that pattern is supported in this PR.