### PR TITLE
chore: Fix more `clippy` warnings

### DIFF
--- a/jsonschema/src/compilation/context.rs
+++ b/jsonschema/src/compilation/context.rs
@@ -12,7 +12,7 @@ pub(crate) struct CompilationContext<'a> {
 }
 
 impl<'a> CompilationContext<'a> {
-    pub(crate) fn new(scope: Url, config: Cow<'a, CompilationOptions>) -> Self {
+    pub(crate) const fn new(scope: Url, config: Cow<'a, CompilationOptions>) -> Self {
         CompilationContext {
             scope: Cow::Owned(scope),
             config,

--- a/jsonschema/src/compilation/mod.rs
+++ b/jsonschema/src/compilation/mod.rs
@@ -46,6 +46,7 @@ impl<'a> JSONSchema<'a> {
     ///     .with_draft(Draft::Draft7)
     ///     .compile(&schema);
     /// ```
+    #[must_use]
     pub fn options() -> CompilationOptions {
         CompilationOptions::default()
     }

--- a/jsonschema/src/error.rs
+++ b/jsonschema/src/error.rs
@@ -190,7 +190,7 @@ impl<'a> ValidationError<'a> {
         }
     }
 
-    pub(crate) fn additional_items(
+    pub(crate) const fn additional_items(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: usize,
@@ -212,7 +212,10 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::AdditionalProperties { unexpected },
         }
     }
-    pub(crate) fn any_of(instance_path: JSONPointer, instance: &'a Value) -> ValidationError<'a> {
+    pub(crate) const fn any_of(
+        instance_path: JSONPointer,
+        instance: &'a Value,
+    ) -> ValidationError<'a> {
         ValidationError {
             instance_path,
             instance: Cow::Borrowed(instance),
@@ -232,7 +235,7 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn constant_boolean(
+    pub(crate) const fn constant_boolean(
         instance_path: JSONPointer,
         instance: &'a Value,
         expected_value: bool,
@@ -245,7 +248,7 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn constant_null(
+    pub(crate) const fn constant_null(
         instance_path: JSONPointer,
         instance: &'a Value,
     ) -> ValidationError<'a> {
@@ -296,7 +299,10 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn contains(instance_path: JSONPointer, instance: &'a Value) -> ValidationError<'a> {
+    pub(crate) const fn contains(
+        instance_path: JSONPointer,
+        instance: &'a Value,
+    ) -> ValidationError<'a> {
         ValidationError {
             instance_path,
             instance: Cow::Borrowed(instance),
@@ -342,7 +348,7 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn exclusive_maximum(
+    pub(crate) const fn exclusive_maximum(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: f64,
@@ -353,7 +359,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::ExclusiveMaximum { limit },
         }
     }
-    pub(crate) fn exclusive_minimum(
+    pub(crate) const fn exclusive_minimum(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: f64,
@@ -364,7 +370,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::ExclusiveMinimum { limit },
         }
     }
-    pub(crate) fn false_schema(
+    pub(crate) const fn false_schema(
         instance_path: JSONPointer,
         instance: &'a Value,
     ) -> ValidationError<'a> {
@@ -381,7 +387,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::FileNotFound { error },
         }
     }
-    pub(crate) fn format(
+    pub(crate) const fn format(
         instance_path: JSONPointer,
         instance: &'a Value,
         format: &'static str,
@@ -420,7 +426,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::InvalidURL { error },
         }
     }
-    pub(crate) fn max_items(
+    pub(crate) const fn max_items(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: u64,
@@ -431,7 +437,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MaxItems { limit },
         }
     }
-    pub(crate) fn maximum(
+    pub(crate) const fn maximum(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: f64,
@@ -442,7 +448,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Maximum { limit },
         }
     }
-    pub(crate) fn max_length(
+    pub(crate) const fn max_length(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: u64,
@@ -453,7 +459,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MaxLength { limit },
         }
     }
-    pub(crate) fn max_properties(
+    pub(crate) const fn max_properties(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: u64,
@@ -464,7 +470,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MaxProperties { limit },
         }
     }
-    pub(crate) fn min_items(
+    pub(crate) const fn min_items(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: u64,
@@ -475,7 +481,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MinItems { limit },
         }
     }
-    pub(crate) fn minimum(
+    pub(crate) const fn minimum(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: f64,
@@ -486,7 +492,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Minimum { limit },
         }
     }
-    pub(crate) fn min_length(
+    pub(crate) const fn min_length(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: u64,
@@ -497,7 +503,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MinLength { limit },
         }
     }
-    pub(crate) fn min_properties(
+    pub(crate) const fn min_properties(
         instance_path: JSONPointer,
         instance: &'a Value,
         limit: u64,
@@ -508,7 +514,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MinProperties { limit },
         }
     }
-    pub(crate) fn multiple_of(
+    pub(crate) const fn multiple_of(
         instance_path: JSONPointer,
         instance: &'a Value,
         multiple_of: f64,
@@ -519,7 +525,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::MultipleOf { multiple_of },
         }
     }
-    pub(crate) fn not(
+    pub(crate) const fn not(
         instance_path: JSONPointer,
         instance: &'a Value,
         schema: Value,
@@ -530,7 +536,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Not { schema },
         }
     }
-    pub(crate) fn one_of_multiple_valid(
+    pub(crate) const fn one_of_multiple_valid(
         instance_path: JSONPointer,
         instance: &'a Value,
     ) -> ValidationError<'a> {
@@ -540,7 +546,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::OneOfMultipleValid,
         }
     }
-    pub(crate) fn one_of_not_valid(
+    pub(crate) const fn one_of_not_valid(
         instance_path: JSONPointer,
         instance: &'a Value,
     ) -> ValidationError<'a> {
@@ -550,7 +556,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::OneOfNotValid,
         }
     }
-    pub(crate) fn pattern(
+    pub(crate) const fn pattern(
         instance_path: JSONPointer,
         instance: &'a Value,
         pattern: String,
@@ -574,7 +580,7 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn required(
+    pub(crate) const fn required(
         instance_path: JSONPointer,
         instance: &'a Value,
         property: Value,
@@ -600,7 +606,7 @@ impl<'a> ValidationError<'a> {
             kind: ValidationErrorKind::Schema,
         }
     }
-    pub(crate) fn single_type_error(
+    pub(crate) const fn single_type_error(
         instance_path: JSONPointer,
         instance: &'a Value,
         type_name: PrimitiveType,
@@ -613,7 +619,7 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn multiple_type_error(
+    pub(crate) const fn multiple_type_error(
         instance_path: JSONPointer,
         instance: &'a Value,
         types: PrimitiveTypesBitMap,
@@ -626,7 +632,7 @@ impl<'a> ValidationError<'a> {
             },
         }
     }
-    pub(crate) fn unique_items(
+    pub(crate) const fn unique_items(
         instance_path: JSONPointer,
         instance: &'a Value,
     ) -> ValidationError<'a> {

--- a/jsonschema/src/keywords/enum_.rs
+++ b/jsonschema/src/keywords/enum_.rs
@@ -38,14 +38,14 @@ impl Validate for EnumValidator {
         instance: &'a Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
             error(ValidationError::enumeration(
                 instance_path.into(),
                 instance,
                 &self.options,
             ))
-        } else {
-            no_error()
         }
     }
 
@@ -97,14 +97,14 @@ impl Validate for SingleValueEnumValidator {
         instance: &'a Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'a> {
-        if !self.is_valid(schema, instance) {
+        if self.is_valid(schema, instance) {
+            no_error()
+        } else {
             error(ValidationError::enumeration(
                 instance_path.into(),
                 instance,
                 &self.options,
             ))
-        } else {
-            no_error()
         }
     }
 

--- a/jsonschema/src/keywords/multiple_of.rs
+++ b/jsonschema/src/keywords/multiple_of.rs
@@ -29,7 +29,7 @@ impl Validate for MultipleOfFloatValidator {
                 // Involves heap allocations via the underlying `BigUint` type
                 let fraction = BigFraction::from(item) / BigFraction::from(self.multiple_of);
                 if let Some(denom) = fraction.denom() {
-                    return denom == &BigUint::from(1u8);
+                    return denom == &BigUint::from(1_u8);
                 }
             } else if !(remainder < EPSILON && remainder < (1. - EPSILON)) {
                 return false;

--- a/jsonschema/src/keywords/one_of.rs
+++ b/jsonschema/src/keywords/one_of.rs
@@ -59,11 +59,7 @@ impl OneOfValidator {
 impl Validate for OneOfValidator {
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
         let first_valid_idx = self.get_first_valid(schema, instance);
-        if let Some(idx) = first_valid_idx {
-            !self.are_others_valid(schema, instance, idx)
-        } else {
-            false
-        }
+        first_valid_idx.map_or(false, |idx| !self.are_others_valid(schema, instance, idx))
     }
     fn validate<'a>(
         &self,

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -66,6 +66,7 @@
     clippy::print_stdout,
     clippy::redundant_closure,
     clippy::trivially_copy_pass_by_ref,
+    clippy::missing_const_for_fn,
     missing_debug_implementations,
     missing_docs,
     trivial_casts,

--- a/jsonschema/src/paths.rs
+++ b/jsonschema/src/paths.rs
@@ -7,6 +7,7 @@ use std::{fmt, fmt::Write};
 pub struct JSONPointer(Vec<PathChunk>);
 
 impl JSONPointer {
+    #[must_use]
     /// JSON pointer as a vector of strings. Each component is casted to `String`. Consumes `JSONPointer`.
     pub fn into_vec(self) -> Vec<String> {
         self.0
@@ -18,6 +19,7 @@ impl JSONPointer {
             .collect()
     }
 
+    #[must_use]
     /// Return an iterator over the underlying vector of path components.
     pub fn iter(&self) -> Iter<'_, PathChunk> {
         self.0.iter()
@@ -75,7 +77,7 @@ pub(crate) struct InstancePath<'a> {
 }
 
 impl<'a> InstancePath<'a> {
-    pub(crate) fn new() -> Self {
+    pub(crate) const fn new() -> Self {
         InstancePath {
             chunk: None,
             parent: None,
@@ -150,7 +152,7 @@ impl From<&[&str]> for JSONPointer {
     fn from(path: &[&str]) -> Self {
         JSONPointer(
             path.iter()
-                .map(|item| PathChunk::Property(item.to_string()))
+                .map(|item| PathChunk::Property((*item).to_string()))
                 .collect(),
         )
     }

--- a/jsonschema/src/primitive_type.rs
+++ b/jsonschema/src/primitive_type.rs
@@ -62,8 +62,7 @@ impl From<&Value> for PrimitiveType {
     }
 }
 
-#[inline(always)]
-fn primitive_type_to_bit_map_representation(primitive_type: PrimitiveType) -> u8 {
+const fn primitive_type_to_bit_map_representation(primitive_type: PrimitiveType) -> u8 {
     match primitive_type {
         PrimitiveType::Array => 1,
         PrimitiveType::Boolean => 2,
@@ -75,7 +74,6 @@ fn primitive_type_to_bit_map_representation(primitive_type: PrimitiveType) -> u8
     }
 }
 
-#[inline(always)]
 fn bit_map_representation_primitive_type(bit_representation: u8) -> PrimitiveType {
     match bit_representation {
         1 => PrimitiveType::Array,
@@ -100,13 +98,12 @@ impl PrimitiveTypesBitMap {
     }
 
     #[inline]
-    pub(crate) fn add_type(mut self, primitive_type: PrimitiveType) -> Self {
+    pub(crate) const fn add_type(mut self, primitive_type: PrimitiveType) -> Self {
         self.inner |= primitive_type_to_bit_map_representation(primitive_type);
         self
     }
 
-    #[inline(always)]
-    pub(crate) fn contains_type(self, primitive_type: PrimitiveType) -> bool {
+    pub(crate) const fn contains_type(self, primitive_type: PrimitiveType) -> bool {
         primitive_type_to_bit_map_representation(primitive_type) & self.inner != 0
     }
 }


### PR DESCRIPTION
Fix some more warnings from the `nursery` set of lints