### PR TITLE
chore: Use Display formatting for Regex

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -24,7 +24,7 @@ url = "2"
 lazy_static = "1"
 percent-encoding = "2"
 regex = "1"
-fancy-regex = "0.5"
+fancy-regex = "0.6"
 base64 = ">= 0.2"
 chrono = ">= 0.2"
 reqwest = { version = ">= 0.10", features = ["blocking", "json"], optional = true}

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -75,7 +75,7 @@ impl Validate for PatternValidator {
 
 impl ToString for PatternValidator {
     fn to_string(&self) -> String {
-        format!("pattern: {:?}", self.pattern)
+        format!("pattern: {}", self.pattern)
     }
 }
 

--- a/jsonschema/src/keywords/pattern_properties.rs
+++ b/jsonschema/src/keywords/pattern_properties.rs
@@ -80,9 +80,7 @@ impl ToString for PatternPropertiesValidator {
             "patternProperties: {{{}}}",
             self.patterns
                 .iter()
-                .map(|(key, validators)| {
-                    format!("{:?}: {}", key, format_validators(validators))
-                })
+                .map(|(key, validators)| { format!("{}: {}", key, format_validators(validators)) })
                 .collect::<Vec<String>>()
                 .join(", ")
         )
@@ -150,7 +148,7 @@ impl Validate for SingleValuePatternPropertiesValidator {
 impl ToString for SingleValuePatternPropertiesValidator {
     fn to_string(&self) -> String {
         format!(
-            "patternProperties: {{{:?}: {}}}",
+            "patternProperties: {{{}: {}}}",
             self.pattern,
             format_validators(&self.validators)
         )


### PR DESCRIPTION
Bumps `fancy-regex` to v0.6.0 (which now implements `Display` for the `Regex` struct) so we can go back to using `Display` formatting (see [this comment](https://github.com/Stranger6667/jsonschema-rs/pull/220#discussion_r627744671) from #220).