### PR TITLE
Make schemas own their data

### DIFF
--- a/bindings/python/src/lib.rs
+++ b/bindings/python/src/lib.rs
@@ -251,7 +251,7 @@ fn validate(
 #[pyclass]
 #[pyo3(text_signature = "(schema, draft=None, with_meta_schemas=False)")]
 struct JSONSchema {
-    schema: jsonschema::JSONSchema<'static>,
+    schema: jsonschema::JSONSchema,
     raw_schema: &'static Value,
 }
 

--- a/jsonschema/src/compilation/context.rs
+++ b/jsonschema/src/compilation/context.rs
@@ -16,10 +16,10 @@ pub(crate) struct CompilationContext<'a> {
 }
 
 impl<'a> CompilationContext<'a> {
-    pub(crate) const fn new(scope: Url, config: Cow<'a, CompilationOptions>) -> Self {
+    pub(crate) const fn new(scope: Url, config: &'a CompilationOptions) -> Self {
         CompilationContext {
             scope: Cow::Owned(scope),
-            config,
+            config: Cow::Borrowed(config),
             schema_path: InstancePath::new(),
         }
     }

--- a/jsonschema/src/compilation/context.rs
+++ b/jsonschema/src/compilation/context.rs
@@ -11,7 +11,7 @@ use url::{ParseError, Url};
 #[derive(Debug)]
 pub(crate) struct CompilationContext<'a> {
     pub(crate) scope: Cow<'a, Url>,
-    pub(crate) config: Cow<'a, CompilationOptions>,
+    pub(crate) config: &'a CompilationOptions,
     pub(crate) schema_path: InstancePath<'a>,
 }
 
@@ -19,7 +19,7 @@ impl<'a> CompilationContext<'a> {
     pub(crate) const fn new(scope: Url, config: &'a CompilationOptions) -> Self {
         CompilationContext {
             scope: Cow::Owned(scope),
-            config: Cow::Borrowed(config),
+            config,
             schema_path: InstancePath::new(),
         }
     }
@@ -40,13 +40,13 @@ impl<'a> CompilationContext<'a> {
             let scope = Url::options().base_url(Some(&self.scope)).parse(id)?;
             Ok(CompilationContext {
                 scope: Cow::Owned(scope),
-                config: Cow::Borrowed(&self.config),
+                config: self.config,
                 schema_path: self.schema_path.clone(),
             })
         } else {
             Ok(CompilationContext {
                 scope: Cow::Borrowed(self.scope.as_ref()),
-                config: Cow::Borrowed(&self.config),
+                config: self.config,
                 schema_path: self.schema_path.clone(),
             })
         }
@@ -57,7 +57,7 @@ impl<'a> CompilationContext<'a> {
         let schema_path = self.schema_path.push(chunk);
         CompilationContext {
             scope: Cow::Borrowed(self.scope.as_ref()),
-            config: Cow::Borrowed(&self.config),
+            config: self.config,
             schema_path,
         }
     }

--- a/jsonschema/src/keywords/additional_items.rs
+++ b/jsonschema/src/keywords/additional_items.rs
@@ -38,12 +38,12 @@ impl Validate for AdditionalItemsObjectValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             let errors: Vec<_> = items
                 .iter()
@@ -98,12 +98,12 @@ impl Validate for AdditionalItemsBooleanValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             if items.len() > self.items_count {
                 return error(ValidationError::additional_items(

--- a/jsonschema/src/keywords/additional_properties.rs
+++ b/jsonschema/src/keywords/additional_properties.rs
@@ -199,12 +199,12 @@ impl Validate for AdditionalPropertiesValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let errors: Vec<_> = item
                 .iter()
@@ -260,12 +260,12 @@ impl Validate for AdditionalPropertiesFalseValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             if let Some((_, value)) = item.iter().next() {
                 return error(ValidationError::false_schema(
@@ -344,12 +344,12 @@ impl<M: PropertiesValidatorsMap> Validate for AdditionalPropertiesNotEmptyFalseV
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let mut errors = vec![];
             let mut unexpected = vec![];
@@ -453,12 +453,12 @@ impl<M: PropertiesValidatorsMap> Validate for AdditionalPropertiesNotEmptyValida
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(map) = instance {
             let mut errors = vec![];
             for (property, value) in map {
@@ -556,12 +556,12 @@ impl Validate for AdditionalPropertiesWithPatternsValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let mut errors = vec![];
             for (property, value) in item.iter() {
@@ -650,12 +650,12 @@ impl Validate for AdditionalPropertiesWithPatternsFalseValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let mut errors = vec![];
             let mut unexpected = vec![];
@@ -799,12 +799,12 @@ impl<M: PropertiesValidatorsMap> Validate for AdditionalPropertiesWithPatternsNo
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let mut errors = vec![];
             for (property, value) in item.iter() {
@@ -950,12 +950,12 @@ impl<M: PropertiesValidatorsMap> Validate
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let mut errors = vec![];
             let mut unexpected = vec![];

--- a/jsonschema/src/keywords/all_of.rs
+++ b/jsonschema/src/keywords/all_of.rs
@@ -38,12 +38,12 @@ impl Validate for AllOfValidator {
         })
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         let errors: Vec<_> = self
             .schemas
             .iter()
@@ -86,12 +86,12 @@ impl Validate for SingleValueAllOfValidator {
             .all(move |validator| validator.is_valid(schema, instance))
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         let errors: Vec<_> = self
             .validators
             .iter()

--- a/jsonschema/src/keywords/any_of.rs
+++ b/jsonschema/src/keywords/any_of.rs
@@ -51,12 +51,12 @@ impl Validate for AnyOfValidator {
         false
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/boolean.rs
+++ b/jsonschema/src/keywords/boolean.rs
@@ -22,12 +22,12 @@ impl Validate for FalseValidator {
         false
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         error(ValidationError::false_schema(
             self.schema_path.clone(),
             instance_path.into(),

--- a/jsonschema/src/keywords/const_.rs
+++ b/jsonschema/src/keywords/const_.rs
@@ -24,12 +24,12 @@ impl ConstArrayValidator {
 }
 impl Validate for ConstArrayValidator {
     #[inline]
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -77,12 +77,12 @@ impl ConstBooleanValidator {
 }
 impl Validate for ConstBooleanValidator {
     #[inline]
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -121,12 +121,12 @@ impl ConstNullValidator {
 }
 impl Validate for ConstNullValidator {
     #[inline]
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -170,12 +170,12 @@ impl ConstNumberValidator {
 }
 
 impl Validate for ConstNumberValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -222,12 +222,12 @@ impl ConstObjectValidator {
 }
 
 impl Validate for ConstObjectValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -279,12 +279,12 @@ impl ConstStringValidator {
 }
 
 impl Validate for ConstStringValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/contains.rs
+++ b/jsonschema/src/keywords/contains.rs
@@ -44,12 +44,12 @@ impl Validate for ContainsValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             for item in items {
                 if self

--- a/jsonschema/src/keywords/content.rs
+++ b/jsonschema/src/keywords/content.rs
@@ -42,12 +42,12 @@ impl Validate for ContentMediaTypeValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(item) = instance {
             if (self.func)(item) {
                 no_error()
@@ -102,12 +102,12 @@ impl Validate for ContentEncodingValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(item) = instance {
             if (self.func)(item) {
                 no_error()
@@ -172,12 +172,12 @@ impl Validate for ContentMediaTypeAndEncodingValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(item) = instance {
             match (self.converter)(item) {
                 Ok(None) => error(ValidationError::content_encoding(

--- a/jsonschema/src/keywords/dependencies.rs
+++ b/jsonschema/src/keywords/dependencies.rs
@@ -57,12 +57,12 @@ impl Validate for DependenciesValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let errors: Vec<_> = self
                 .dependencies

--- a/jsonschema/src/keywords/enum_.rs
+++ b/jsonschema/src/keywords/enum_.rs
@@ -38,12 +38,12 @@ impl EnumValidator {
 }
 
 impl Validate for EnumValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -105,12 +105,12 @@ impl SingleValueEnumValidator {
 }
 
 impl Validate for SingleValueEnumValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/exclusive_maximum.rs
+++ b/jsonschema/src/keywords/exclusive_maximum.rs
@@ -24,12 +24,12 @@ pub(crate) struct ExclusiveMaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
+            fn validate<'a, 'b>(
                 &self,
                 schema: &'a JSONSchema,
-                instance: &'a Value,
+                instance: &'b Value,
                 instance_path: &InstancePath,
-            ) -> ErrorIterator<'a> {
+            ) -> ErrorIterator<'b> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
@@ -84,12 +84,12 @@ impl Validate for ExclusiveMaximumF64Validator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/exclusive_minimum.rs
+++ b/jsonschema/src/keywords/exclusive_minimum.rs
@@ -24,12 +24,12 @@ pub(crate) struct ExclusiveMinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
+            fn validate<'a, 'b>(
                 &self,
                 schema: &'a JSONSchema,
-                instance: &'a Value,
+                instance: &'b Value,
                 instance_path: &InstancePath,
-            ) -> ErrorIterator<'a> {
+            ) -> ErrorIterator<'b> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
@@ -82,12 +82,12 @@ impl Validate for ExclusiveMinimumF64Validator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/format.rs
+++ b/jsonschema/src/keywords/format.rs
@@ -56,12 +56,12 @@ macro_rules! format_validator {
 
 macro_rules! validate {
     ($format:expr) => {
-        fn validate<'a>(
+        fn validate<'a, 'b>(
             &self,
             schema: &'a JSONSchema,
-            instance: &'a Value,
+            instance: &'b Value,
             instance_path: &InstancePath,
-        ) -> ErrorIterator<'a> {
+        ) -> ErrorIterator<'b> {
             if let Value::String(_item) = instance {
                 if !self.is_valid(schema, instance) {
                     return error(ValidationError::format(
@@ -354,12 +354,12 @@ impl core::fmt::Display for CustomFormatValidator {
 }
 
 impl Validate for CustomFormatValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(_item) = instance {
             if !self.is_valid(schema, instance) {
                 return error(ValidationError::format(

--- a/jsonschema/src/keywords/if_.rs
+++ b/jsonschema/src/keywords/if_.rs
@@ -47,12 +47,12 @@ impl Validate for IfThenValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self
             .schema
             .iter()
@@ -121,12 +121,12 @@ impl Validate for IfElseValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self
             .schema
             .iter()
@@ -203,12 +203,12 @@ impl Validate for IfThenElseValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self
             .schema
             .iter()

--- a/jsonschema/src/keywords/items.rs
+++ b/jsonschema/src/keywords/items.rs
@@ -42,12 +42,12 @@ impl Validate for ItemsArrayValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             let errors: Vec<_> = items
                 .iter()
@@ -99,12 +99,12 @@ impl Validate for ItemsObjectValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             let errors: Vec<_> = self
                 .validators

--- a/jsonschema/src/keywords/legacy/type_draft_4.rs
+++ b/jsonschema/src/keywords/legacy/type_draft_4.rs
@@ -48,12 +48,12 @@ impl Validate for MultipleTypesValidator {
             Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -101,12 +101,12 @@ impl Validate for IntegerTypeValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/max_items.rs
+++ b/jsonschema/src/keywords/max_items.rs
@@ -33,12 +33,12 @@ impl Validate for MaxItemsValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             if (items.len() as u64) > self.limit {
                 return error(ValidationError::max_items(

--- a/jsonschema/src/keywords/max_length.rs
+++ b/jsonschema/src/keywords/max_length.rs
@@ -33,12 +33,12 @@ impl Validate for MaxLengthValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(item) = instance {
             if (item.chars().count() as u64) > self.limit {
                 return error(ValidationError::max_length(

--- a/jsonschema/src/keywords/max_properties.rs
+++ b/jsonschema/src/keywords/max_properties.rs
@@ -33,12 +33,12 @@ impl Validate for MaxPropertiesValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             if (item.len() as u64) > self.limit {
                 return error(ValidationError::max_properties(

--- a/jsonschema/src/keywords/maximum.rs
+++ b/jsonschema/src/keywords/maximum.rs
@@ -24,12 +24,12 @@ pub(crate) struct MaximumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
+            fn validate<'a, 'b>(
                 &self,
                 schema: &'a JSONSchema,
-                instance: &'a Value,
+                instance: &'b Value,
                 instance_path: &InstancePath,
-            ) -> ErrorIterator<'a> {
+            ) -> ErrorIterator<'b> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
@@ -82,12 +82,12 @@ impl Validate for MaximumF64Validator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/min_items.rs
+++ b/jsonschema/src/keywords/min_items.rs
@@ -33,12 +33,12 @@ impl Validate for MinItemsValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
             if (items.len() as u64) < self.limit {
                 return error(ValidationError::min_items(

--- a/jsonschema/src/keywords/min_length.rs
+++ b/jsonschema/src/keywords/min_length.rs
@@ -33,12 +33,12 @@ impl Validate for MinLengthValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(item) = instance {
             if (item.chars().count() as u64) < self.limit {
                 return error(ValidationError::min_length(

--- a/jsonschema/src/keywords/min_properties.rs
+++ b/jsonschema/src/keywords/min_properties.rs
@@ -33,12 +33,12 @@ impl Validate for MinPropertiesValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             if (item.len() as u64) < self.limit {
                 return error(ValidationError::min_properties(

--- a/jsonschema/src/keywords/minimum.rs
+++ b/jsonschema/src/keywords/minimum.rs
@@ -24,12 +24,12 @@ pub(crate) struct MinimumF64Validator {
 macro_rules! validate {
     ($validator: ty) => {
         impl Validate for $validator {
-            fn validate<'a>(
+            fn validate<'a, 'b>(
                 &self,
                 schema: &'a JSONSchema,
-                instance: &'a Value,
+                instance: &'b Value,
                 instance_path: &InstancePath,
-            ) -> ErrorIterator<'a> {
+            ) -> ErrorIterator<'b> {
                 if self.is_valid(schema, instance) {
                     no_error()
                 } else {
@@ -82,12 +82,12 @@ impl Validate for MinimumF64Validator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/multiple_of.rs
+++ b/jsonschema/src/keywords/multiple_of.rs
@@ -42,12 +42,12 @@ impl Validate for MultipleOfFloatValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if !self.is_valid(schema, instance) {
             return error(ValidationError::multiple_of(
                 self.schema_path.clone(),
@@ -98,12 +98,12 @@ impl Validate for MultipleOfIntegerValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if !self.is_valid(schema, instance) {
             return error(ValidationError::multiple_of(
                 self.schema_path.clone(),

--- a/jsonschema/src/keywords/not.rs
+++ b/jsonschema/src/keywords/not.rs
@@ -37,12 +37,12 @@ impl Validate for NotValidator {
             .all(|validator| validator.is_valid(schema, instance))
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/one_of.rs
+++ b/jsonschema/src/keywords/one_of.rs
@@ -69,12 +69,12 @@ impl Validate for OneOfValidator {
         let first_valid_idx = self.get_first_valid(schema, instance);
         first_valid_idx.map_or(false, |idx| !self.are_others_valid(schema, instance, idx))
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         let first_valid_idx = self.get_first_valid(schema, instance);
         if let Some(idx) = first_valid_idx {
             if self.are_others_valid(schema, instance, idx) {

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -45,12 +45,12 @@ impl PatternValidator {
 }
 
 impl Validate for PatternValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::String(item) = instance {
             match self.pattern.is_match(item) {
                 Ok(is_match) => {

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -188,7 +188,7 @@ mod tests {
         let text = Value::String(text.into());
         let schema = json!({});
         let schema = JSONSchema::compile(&schema).unwrap();
-        let context = CompilationContext::new(DEFAULT_SCOPE.clone(), schema.context.config.clone());
+        let context = CompilationContext::new(DEFAULT_SCOPE.clone(), schema.config());
         let compiled = PatternValidator::compile(&pattern, &context).unwrap();
         assert_eq!(compiled.is_valid(&schema, &text), is_matching,)
     }

--- a/jsonschema/src/keywords/pattern_properties.rs
+++ b/jsonschema/src/keywords/pattern_properties.rs
@@ -51,12 +51,12 @@ impl Validate for PatternPropertiesValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let errors: Vec<_> = self
                 .patterns
@@ -132,12 +132,12 @@ impl Validate for SingleValuePatternPropertiesValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let errors: Vec<_> = item
                 .iter()

--- a/jsonschema/src/keywords/properties.rs
+++ b/jsonschema/src/keywords/properties.rs
@@ -51,12 +51,12 @@ impl Validate for PropertiesValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let errors: Vec<_> = self
                 .properties

--- a/jsonschema/src/keywords/property_names.rs
+++ b/jsonschema/src/keywords/property_names.rs
@@ -38,12 +38,12 @@ impl Validate for PropertyNamesObjectValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = &instance {
             let errors: Vec<_> = self
                 .validators
@@ -100,12 +100,12 @@ impl Validate for PropertyNamesBooleanValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/ref_.rs
+++ b/jsonschema/src/keywords/ref_.rs
@@ -7,7 +7,6 @@ use crate::{
 };
 use parking_lot::RwLock;
 use serde_json::Value;
-use std::borrow::Cow;
 use url::Url;
 
 pub(crate) struct RefValidator {
@@ -43,12 +42,11 @@ impl Validate for RefValidator {
                 .iter()
                 .all(move |validator| validator.is_valid(schema, instance));
         }
-        if let Ok((scope, resolved)) = schema.resolver.resolve_fragment(
-            schema.context.config.draft(),
-            &self.reference,
-            schema.schema,
-        ) {
-            let context = CompilationContext::new(scope, Cow::Borrowed(&schema.context.config));
+        if let Ok((scope, resolved)) = schema
+            .resolver
+            .resolve_fragment(schema.draft(), &self.reference)
+        {
+            let context = CompilationContext::new(scope, schema.config());
             if let Ok(validators) = compile_validators(&resolved, &context) {
                 let result = validators
                     .iter()
@@ -75,13 +73,12 @@ impl Validate for RefValidator {
                     .into_iter(),
             );
         }
-        match schema.resolver.resolve_fragment(
-            schema.context.config.draft(),
-            &self.reference,
-            schema.schema,
-        ) {
+        match schema
+            .resolver
+            .resolve_fragment(schema.draft(), &self.reference)
+        {
             Ok((scope, resolved)) => {
-                let context = CompilationContext::new(scope, Cow::Borrowed(&schema.context.config));
+                let context = CompilationContext::new(scope, schema.config());
                 match compile_validators(&resolved, &context) {
                     Ok(validators) => {
                         let result = Box::new(

--- a/jsonschema/src/keywords/ref_.rs
+++ b/jsonschema/src/keywords/ref_.rs
@@ -58,12 +58,12 @@ impl Validate for RefValidator {
         false
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Some(validators) = self.validators.read().as_ref() {
             return Box::new(
                 validators
@@ -104,7 +104,7 @@ impl Validate for RefValidator {
                     Err(err) => error(err.into_owned()),
                 }
             }
-            Err(err) => error(err),
+            Err(err) => error(err.into_owned()),
         }
     }
 }

--- a/jsonschema/src/keywords/required.rs
+++ b/jsonschema/src/keywords/required.rs
@@ -40,12 +40,12 @@ impl Validate for RequiredValidator {
         }
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         _: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if let Value::Object(item) = instance {
             let mut errors = vec![];
             for property_name in &self.required {
@@ -89,12 +89,12 @@ impl SingleItemRequiredValidator {
 }
 
 impl Validate for SingleItemRequiredValidator {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if !self.is_valid(schema, instance) {
             return error(ValidationError::required(
                 self.schema_path.clone(),

--- a/jsonschema/src/keywords/type_.rs
+++ b/jsonschema/src/keywords/type_.rs
@@ -49,12 +49,12 @@ impl Validate for MultipleTypesValidator {
             Value::String(_) => self.types.contains_type(PrimitiveType::String),
         }
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -97,12 +97,12 @@ impl Validate for NullTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_null()
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -137,12 +137,12 @@ impl Validate for BooleanTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_boolean()
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -178,12 +178,12 @@ impl Validate for StringTypeValidator {
         instance.is_string()
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -218,12 +218,12 @@ impl Validate for ArrayTypeValidator {
         instance.is_array()
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -258,12 +258,12 @@ impl Validate for ObjectTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_object()
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {
@@ -298,12 +298,12 @@ impl Validate for NumberTypeValidator {
     fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
         instance.is_number()
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         config: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(config, instance) {
             no_error()
         } else {
@@ -340,12 +340,12 @@ impl Validate for IntegerTypeValidator {
             false
         }
     }
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/keywords/unique_items.rs
+++ b/jsonschema/src/keywords/unique_items.rs
@@ -103,12 +103,12 @@ impl Validate for UniqueItemsValidator {
         true
     }
 
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a> {
+    ) -> ErrorIterator<'b> {
         if self.is_valid(schema, instance) {
             no_error()
         } else {

--- a/jsonschema/src/validator.rs
+++ b/jsonschema/src/validator.rs
@@ -5,12 +5,12 @@ use serde_json::Value;
 use std::fmt;
 
 pub(crate) trait Validate: Send + Sync + core::fmt::Display {
-    fn validate<'a>(
+    fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
-        instance: &'a Value,
+        instance: &'b Value,
         instance_path: &InstancePath,
-    ) -> ErrorIterator<'a>;
+    ) -> ErrorIterator<'b>;
     // The same as above, but does not construct ErrorIterator.
     // It is faster for cases when the result is not needed (like anyOf), since errors are
     // not constructed


### PR DESCRIPTION
I've modified the `JSONSchema` struct so that it clones the `serde_json::Value` it is constructed with. i.e `JSONSchema` now looks like this:

```rust
pub struct JSONSchema {
    pub(crate) schema: Arc<Value>,
    pub(crate) validators: Validators,
    pub(crate) resolver: Resolver,
    config: CompilationOptions,
}
```
The important point here being that the `schema` is now an `Arc` rather than a `&'` and the schema no longer holds on to it's `CompilationContext` (everything that it needed is on `CompilationOptions` and by not holding on to the context we can own all our data).

This has had some implications, primarily `Resolver` now holds on to a `AHashMap<String, Arc<Value>>` rather than `AHashMap<String, &'a Value>`. We are also able to split the lifetimes of `Validator::validate`, which now looks like this:

```rust
    fn validate<'a, 'b>(
        &self,
        schema: &'a JSONSchema,
        instance: &'b Value,
        instance_path: &InstancePath,
    ) -> ErrorIterator<'b>;
```

i.e the lifetime of the schema is no longer the same as the lifetime of the instance and the lifetime of the `ErrorIterator` is tied to the instance rather than the schema.

## Performance

This does have an impact on performance, I've attached two criterion baselines, one for `master` and one for `owning-schemas` (this PR). You can compare these with `critcmp` but I've also attached a summary in `benchmarks.csv`. I also split the benchmarks into three categories: compilation, validation, and `is_valid`, in these three categories I see the following:

|Category|Average fractional change
--|--
| compile|0.03065573770491807
| `is_valid`|-0.011854838709677414
|validate| 0.0030645161290322625

This is broadly what we would expect, compilation is slightly slower on average, is valid is a bit quicker (maybe due to memory locality?). Validate is pretty much the same.

### Benchmark Data

[baselines.zip](https://github.com/Stranger6667/jsonschema-rs/files/6872408/baselines.zip)
[benchmarks.csv](https://github.com/Stranger6667/jsonschema-rs/files/6872411/benchmarks.csv)


## How to read

I've split this PR into two commits. The first is most of the substantive work of introducing an `Arc` to `JSONSchema` and modifying lifetimes. The second is just changing the signature of `Validator::validate`, this meant touching every implementation of `Validator` which was a lot of code but is fairly mechanical.


