### PR TITLE
fix: Allow using empty arrays or arrays with non-unique elements for the `enum` keyword in schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow using empty arrays or arrays with non-unique elements for the `enum` keyword in schemas. [#258](https://github.com/Stranger6667/jsonschema-rs/issues/258)
+
 ## [0.12.0] - 2021-07-24
 
 ### Added

--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow using empty arrays or arrays with non-unique elements for the `enum` keyword in schemas. [#258](https://github.com/Stranger6667/jsonschema-rs/issues/258)
+
 ## [0.12.0] - 2021-07-24
 
 ### Changed

--- a/jsonschema/meta_schemas/draft4.json
+++ b/jsonschema/meta_schemas/draft4.json
@@ -120,9 +120,7 @@
             }
         },
         "enum": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true
+            "type": "array"
         },
         "type": {
             "anyOf": [

--- a/jsonschema/meta_schemas/draft6.json
+++ b/jsonschema/meta_schemas/draft6.json
@@ -130,9 +130,7 @@
         "propertyNames": { "$ref": "#" },
         "const": {},
         "enum": {
-            "type": "array",
-            "minItems": 1,
-            "uniqueItems": true
+            "type": "array"
         },
         "type": {
             "anyOf": [

--- a/jsonschema/meta_schemas/draft7.json
+++ b/jsonschema/meta_schemas/draft7.json
@@ -142,9 +142,7 @@
         "const": true,
         "enum": {
             "type": "array",
-            "items": true,
-            "minItems": 1,
-            "uniqueItems": true
+            "items": true
         },
         "type": {
             "anyOf": [

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -185,8 +185,9 @@ pub(crate) mod tests_util {
 
 #[cfg(test)]
 mod tests {
-    use super::is_valid;
+    use super::{is_valid, Draft, JSONSchema};
     use serde_json::json;
+    use test_case::test_case;
 
     #[test]
     fn test_is_valid() {
@@ -195,5 +196,18 @@ mod tests {
         let invalid = json!("foo");
         assert!(is_valid(&schema, &valid));
         assert!(!is_valid(&schema, &invalid));
+    }
+
+    #[test_case(Draft::Draft4)]
+    #[test_case(Draft::Draft6)]
+    #[test_case(Draft::Draft7)]
+    fn meta_schemas(draft: Draft) {
+        // See GH-258
+        for schema in [json!({"enum": [0, 0.0]}), json!({"enum": []})] {
+            assert!(JSONSchema::options()
+                .with_draft(draft)
+                .compile(&schema)
+                .is_ok())
+        }
     }
 }


### PR DESCRIPTION
Fixes #258 