### PR TITLE
chore: A stub support for Draft 2019-09 behind a feature flag

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
           profile: minimal
           toolchain: stable
           override: true
-      - run: cargo test --no-fail-fast
+      - run: cargo test --no-fail-fast --features draft201909
         working-directory: ./jsonschema
 
   coverage:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **INTERNAL**. A new `Draft201909` variant for the `Draft` enum that is available only under the `draft201909` feature. This feature is considered private and should not be used outside of the testing context.
+  It allows us to add features from the 2019-09 Draft without exposing them in the public API. Therefore, support for this draft can be added incrementally.
+- The `Draft` enum is now marked as `non_exhaustive`.
+
 ## [0.12.1] - 2021-07-29
 
 ### Fixed

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -18,6 +18,7 @@ name = "jsonschema"
 [features]
 default = ["reqwest", "cli"]
 cli = ["structopt"]
+draft201909 = []
 
 [dependencies]
 serde_json = "1"

--- a/jsonschema/benches/jsonschema.rs
+++ b/jsonschema/benches/jsonschema.rs
@@ -90,7 +90,7 @@ fn keywords(c: &mut Criterion) {
 }
 
 fn validate_valid(c: &mut Criterion, name: &str, schema: &Value, instance: &Value) {
-    let compiled = JSONSchema::compile(&schema).expect("Valid schema");
+    let compiled = JSONSchema::compile(schema).expect("Valid schema");
     c.bench_with_input(
         BenchmarkId::new(name, "jsonschema_rs/is_valid"),
         instance,
@@ -112,7 +112,7 @@ fn validate_valid(c: &mut Criterion, name: &str, schema: &Value, instance: &Valu
 }
 
 fn validate_invalid(c: &mut Criterion, name: &str, schema: &Value, instance: &Value) {
-    let compiled = JSONSchema::compile(&schema).expect("Valid schema");
+    let compiled = JSONSchema::compile(schema).expect("Valid schema");
     c.bench_with_input(
         BenchmarkId::new(name, "jsonschema_rs/is_valid"),
         instance,
@@ -128,7 +128,7 @@ fn validate_invalid(c: &mut Criterion, name: &str, schema: &Value, instance: &Va
         |b, instance| {
             b.iter(|| {
                 let _: Vec<_> = compiled
-                    .validate(&instance)
+                    .validate(instance)
                     .expect_err("There should be errors")
                     .collect();
             })

--- a/jsonschema/benches/jsonschema_valid.rs
+++ b/jsonschema/benches/jsonschema_valid.rs
@@ -71,7 +71,7 @@ fn keywords(c: &mut Criterion) {
                 schema,
                 |b, schema| {
                     b.iter(|| {
-                        jsonschema_valid::Config::from_schema(&schema, Some(schemas::Draft::Draft7))
+                        jsonschema_valid::Config::from_schema(schema, Some(schemas::Draft::Draft7))
                             .expect("Valid schema")
                     })
                 },
@@ -83,7 +83,7 @@ fn keywords(c: &mut Criterion) {
 }
 
 fn validate(c: &mut Criterion, name: &str, schema: &Value, instance: &Value) {
-    let compiled = jsonschema_valid::Config::from_schema(&schema, Some(schemas::Draft::Draft7))
+    let compiled = jsonschema_valid::Config::from_schema(schema, Some(schemas::Draft::Draft7))
         .expect("Valid schema");
     c.bench_with_input(
         BenchmarkId::new(name, "jsonschema_valid"),

--- a/jsonschema/meta_schemas/draft2019-09/meta/applicator.json
+++ b/jsonschema/meta_schemas/draft2019-09/meta/applicator.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/meta/applicator",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/applicator": true
+  },
+  "$recursiveAnchor": true,
+
+  "title": "Applicator vocabulary meta-schema",
+  "type": ["object", "boolean"],
+  "properties": {
+    "additionalItems": {"$recursiveRef": "#"},
+    "unevaluatedItems": {"$recursiveRef": "#"},
+    "items": {
+      "anyOf": [{"$recursiveRef": "#"}, {"$ref": "#/$defs/schemaArray"}]
+    },
+    "contains": {"$recursiveRef": "#"},
+    "additionalProperties": {"$recursiveRef": "#"},
+    "unevaluatedProperties": {"$recursiveRef": "#"},
+    "properties": {
+      "type": "object",
+      "additionalProperties": {"$recursiveRef": "#"},
+      "default": {}
+    },
+    "patternProperties": {
+      "type": "object",
+      "additionalProperties": {"$recursiveRef": "#"},
+      "propertyNames": {"format": "regex"},
+      "default": {}
+    },
+    "dependentSchemas": {
+      "type": "object",
+      "additionalProperties": {
+        "$recursiveRef": "#"
+      }
+    },
+    "propertyNames": {"$recursiveRef": "#"},
+    "if": {"$recursiveRef": "#"},
+    "then": {"$recursiveRef": "#"},
+    "else": {"$recursiveRef": "#"},
+    "allOf": {"$ref": "#/$defs/schemaArray"},
+    "anyOf": {"$ref": "#/$defs/schemaArray"},
+    "oneOf": {"$ref": "#/$defs/schemaArray"},
+    "not": {"$recursiveRef": "#"}
+  },
+  "$defs": {
+    "schemaArray": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$recursiveRef": "#"}
+    }
+  }
+}

--- a/jsonschema/meta_schemas/draft2019-09/meta/content.json
+++ b/jsonschema/meta_schemas/draft2019-09/meta/content.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/meta/content",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/content": true
+  },
+  "$recursiveAnchor": true,
+
+  "title": "Content vocabulary meta-schema",
+
+  "type": ["object", "boolean"],
+  "properties": {
+    "contentMediaType": {"type": "string"},
+    "contentEncoding": {"type": "string"},
+    "contentSchema": {"$recursiveRef": "#"}
+  }
+}

--- a/jsonschema/meta_schemas/draft2019-09/meta/core.json
+++ b/jsonschema/meta_schemas/draft2019-09/meta/core.json
@@ -1,0 +1,57 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/meta/core",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/core": true
+  },
+  "$recursiveAnchor": true,
+
+  "title": "Core vocabulary meta-schema",
+  "type": ["object", "boolean"],
+  "properties": {
+    "$id": {
+      "type": "string",
+      "format": "uri-reference",
+      "$comment": "Non-empty fragments not allowed.",
+      "pattern": "^[^#]*#?$"
+    },
+    "$schema": {
+      "type": "string",
+      "format": "uri"
+    },
+    "$anchor": {
+      "type": "string",
+      "pattern": "^[A-Za-z][-A-Za-z0-9.:_]*$"
+    },
+    "$ref": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$recursiveRef": {
+      "type": "string",
+      "format": "uri-reference"
+    },
+    "$recursiveAnchor": {
+      "type": "boolean",
+      "default": false
+    },
+    "$vocabulary": {
+      "type": "object",
+      "propertyNames": {
+        "type": "string",
+        "format": "uri"
+      },
+      "additionalProperties": {
+        "type": "boolean"
+      }
+    },
+    "$comment": {
+      "type": "string"
+    },
+    "$defs": {
+      "type": "object",
+      "additionalProperties": {"$recursiveRef": "#"},
+      "default": {}
+    }
+  }
+}

--- a/jsonschema/meta_schemas/draft2019-09/meta/format.json
+++ b/jsonschema/meta_schemas/draft2019-09/meta/format.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/meta/format",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/format": true
+  },
+  "$recursiveAnchor": true,
+
+  "title": "Format vocabulary meta-schema",
+  "type": ["object", "boolean"],
+  "properties": {
+    "format": {"type": "string"}
+  }
+}

--- a/jsonschema/meta_schemas/draft2019-09/meta/meta-data.json
+++ b/jsonschema/meta_schemas/draft2019-09/meta/meta-data.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/meta/meta-data",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/meta-data": true
+  },
+  "$recursiveAnchor": true,
+
+  "title": "Meta-data vocabulary meta-schema",
+
+  "type": ["object", "boolean"],
+  "properties": {
+    "title": {
+      "type": "string"
+    },
+    "description": {
+      "type": "string"
+    },
+    "default": true,
+    "deprecated": {
+      "type": "boolean",
+      "default": false
+    },
+    "readOnly": {
+      "type": "boolean",
+      "default": false
+    },
+    "writeOnly": {
+      "type": "boolean",
+      "default": false
+    },
+    "examples": {
+      "type": "array",
+      "items": true
+    }
+  }
+}

--- a/jsonschema/meta_schemas/draft2019-09/meta/validation.json
+++ b/jsonschema/meta_schemas/draft2019-09/meta/validation.json
@@ -1,0 +1,90 @@
+{
+  "$schema": "https://json-schema.org/draft/2019-09/schema",
+  "$id": "https://json-schema.org/draft/2019-09/meta/validation",
+  "$vocabulary": {
+    "https://json-schema.org/draft/2019-09/vocab/validation": true
+  },
+  "$recursiveAnchor": true,
+
+  "title": "Validation vocabulary meta-schema",
+  "type": ["object", "boolean"],
+  "properties": {
+    "multipleOf": {
+      "type": "number",
+      "exclusiveMinimum": 0
+    },
+    "maximum": {
+      "type": "number"
+    },
+    "exclusiveMaximum": {
+      "type": "number"
+    },
+    "minimum": {
+      "type": "number"
+    },
+    "exclusiveMinimum": {
+      "type": "number"
+    },
+    "maxLength": {"$ref": "#/$defs/nonNegativeInteger"},
+    "minLength": {"$ref": "#/$defs/nonNegativeIntegerDefault0"},
+    "pattern": {
+      "type": "string",
+      "format": "regex"
+    },
+    "maxItems": {"$ref": "#/$defs/nonNegativeInteger"},
+    "minItems": {"$ref": "#/$defs/nonNegativeIntegerDefault0"},
+    "uniqueItems": {
+      "type": "boolean",
+      "default": false
+    },
+    "maxContains": {"$ref": "#/$defs/nonNegativeInteger"},
+    "minContains": {
+      "$ref": "#/$defs/nonNegativeInteger",
+      "default": 1
+    },
+    "maxProperties": {"$ref": "#/$defs/nonNegativeInteger"},
+    "minProperties": {"$ref": "#/$defs/nonNegativeIntegerDefault0"},
+    "required": {"$ref": "#/$defs/stringArray"},
+    "dependentRequired": {
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/$defs/stringArray"
+      }
+    },
+    "const": true,
+    "enum": {
+      "type": "array",
+      "items": true
+    },
+    "type": {
+      "anyOf": [
+        {"$ref": "#/$defs/simpleTypes"},
+        {
+          "type": "array",
+          "items": {"$ref": "#/$defs/simpleTypes"},
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      ]
+    }
+  },
+  "$defs": {
+    "nonNegativeInteger": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "nonNegativeIntegerDefault0": {
+      "$ref": "#/$defs/nonNegativeInteger",
+      "default": 0
+    },
+    "simpleTypes": {
+      "enum": ["array", "boolean", "integer", "null", "number", "object", "string"]
+    },
+    "stringArray": {
+      "type": "array",
+      "items": {"type": "string"},
+      "uniqueItems": true,
+      "default": []
+    }
+  }
+}

--- a/jsonschema/meta_schemas/draft2019-09/schema.json
+++ b/jsonschema/meta_schemas/draft2019-09/schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "https://json-schema.org/draft/2019-09/schema",
+    "$id": "https://json-schema.org/draft/2019-09/schema",
+    "$vocabulary": {
+        "https://json-schema.org/draft/2019-09/vocab/core": true,
+        "https://json-schema.org/draft/2019-09/vocab/applicator": true,
+        "https://json-schema.org/draft/2019-09/vocab/validation": true,
+        "https://json-schema.org/draft/2019-09/vocab/meta-data": true,
+        "https://json-schema.org/draft/2019-09/vocab/format": false,
+        "https://json-schema.org/draft/2019-09/vocab/content": true
+    },
+    "$recursiveAnchor": true,
+
+    "title": "Core and Validation specifications meta-schema",
+    "allOf": [
+        {"$ref": "meta/core"},
+        {"$ref": "meta/applicator"},
+        {"$ref": "meta/validation"},
+        {"$ref": "meta/meta-data"},
+        {"$ref": "meta/format"},
+        {"$ref": "meta/content"}
+    ],
+    "type": ["object", "boolean"],
+    "properties": {
+        "definitions": {
+            "$comment": "While no longer an official keyword as it is replaced by $defs, this keyword is retained in the meta-schema to prevent incompatible extensions as it remains in common use.",
+            "type": "object",
+            "additionalProperties": { "$recursiveRef": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "$comment": "\"dependencies\" is no longer a keyword, but schema authors should avoid redefining it to facilitate a smooth transition to \"dependentSchemas\" and \"dependentRequired\"",
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$recursiveRef": "#" },
+                    { "$ref": "meta/validation#/$defs/stringArray" }
+                ]
+            }
+        }
+    }
+}

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -17,6 +17,13 @@ lazy_static::lazy_static! {
     static ref DRAFT4:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft4.json")).expect("Valid schema!");
     static ref DRAFT6:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft6.json")).expect("Valid schema!");
     static ref DRAFT7:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft7.json")).expect("Valid schema!");
+    static ref DRAFT201909:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/schema.json")).expect("Valid schema!");
+    static ref DRAFT201909_APPLICATOR:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/meta/applicator.json")).expect("Valid schema!");
+    static ref DRAFT201909_CONTENT:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/meta/content.json")).expect("Valid schema!");
+    static ref DRAFT201909_CORE:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/meta/core.json")).expect("Valid schema!");
+    static ref DRAFT201909_FORMAT:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/meta/format.json")).expect("Valid schema!");
+    static ref DRAFT201909_META_DATA:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/meta/meta-data.json")).expect("Valid schema!");
+    static ref DRAFT201909_VALIDATION:serde_json::Value = serde_json::from_str(include_str!("../../meta_schemas/draft2019-09/meta/validation.json")).expect("Valid schema!");
 
     static ref META_SCHEMAS: AHashMap<String, Arc<serde_json::Value>> = {
         let mut store = AHashMap::with_capacity(3);
@@ -32,6 +39,37 @@ lazy_static::lazy_static! {
             "http://json-schema.org/draft-07/schema".to_string(),
             Arc::new(DRAFT7.clone())
         );
+        #[cfg(feature = "draft201909")]
+        {
+            store.insert(
+                "https://json-schema.org/draft/2019-09/schema".to_string(),
+                Arc::new(DRAFT201909.clone())
+            );
+            store.insert(
+                "https://json-schema.org/draft/2019-09/meta/applicator".to_string(),
+                Arc::new(DRAFT201909_APPLICATOR.clone())
+            );
+            store.insert(
+                "https://json-schema.org/draft/2019-09/meta/content".to_string(),
+                Arc::new(DRAFT201909_CONTENT.clone())
+            );
+            store.insert(
+                "https://json-schema.org/draft/2019-09/meta/core".to_string(),
+                Arc::new(DRAFT201909_CORE.clone())
+            );
+            store.insert(
+                "https://json-schema.org/draft/2019-09/meta/format".to_string(),
+                Arc::new(DRAFT201909_FORMAT.clone())
+            );
+            store.insert(
+                "https://json-schema.org/draft/2019-09/meta/meta-data".to_string(),
+                Arc::new(DRAFT201909_META_DATA.clone())
+            );
+            store.insert(
+                "https://json-schema.org/draft/2019-09/meta/validation".to_string(),
+                Arc::new(DRAFT201909_VALIDATION.clone())
+            );
+        }
         store
     };
 
@@ -48,6 +86,38 @@ lazy_static::lazy_static! {
         store.insert(
             schemas::Draft::Draft7,
             JSONSchema::options().without_schema_validation().compile(&DRAFT7).expect(EXPECT_MESSAGE)
+        );
+        #[cfg(feature = "draft201909")]
+        store.insert(
+            schemas::Draft::Draft201909,
+            JSONSchema::options()
+                .without_schema_validation()
+                .with_document(
+                    "https://json-schema.org/draft/2019-09/meta/applicator".to_string(),
+                    DRAFT201909_APPLICATOR.clone()
+                )
+                .with_document(
+                    "https://json-schema.org/draft/2019-09/meta/content".to_string(),
+                    DRAFT201909_CONTENT.clone()
+                )
+                .with_document(
+                    "https://json-schema.org/draft/2019-09/meta/core".to_string(),
+                    DRAFT201909_CORE.clone()
+                )
+                .with_document(
+                    "https://json-schema.org/draft/2019-09/meta/format".to_string(),
+                    DRAFT201909_FORMAT.clone()
+                )
+                .with_document(
+                    "https://json-schema.org/draft/2019-09/meta/meta-data".to_string(),
+                    DRAFT201909_META_DATA.clone()
+                )
+                .with_document(
+                    "https://json-schema.org/draft/2019-09/meta/validation".to_string(),
+                    DRAFT201909_VALIDATION.clone()
+                )
+                .compile(&DRAFT201909)
+                .expect(EXPECT_MESSAGE)
         );
         store
     };

--- a/jsonschema/src/keywords/format.rs
+++ b/jsonschema/src/keywords/format.rs
@@ -402,24 +402,50 @@ pub(crate) fn compile<'a>(
             "idn-hostname" if draft_version == Draft::Draft7 => {
                 Some(IDNHostnameValidator::compile(context))
             }
+            #[cfg(feature = "draft201909")]
+            "idn-hostname" if draft_version == Draft::Draft201909 => {
+                Some(IDNHostnameValidator::compile(context))
+            }
             "ipv4" => Some(IpV4Validator::compile(context)),
             "ipv6" => Some(IpV6Validator::compile(context)),
             "iri-reference" if draft_version == Draft::Draft7 => {
                 Some(IRIReferenceValidator::compile(context))
             }
+            #[cfg(feature = "draft201909")]
+            "iri-reference" if draft_version == Draft::Draft201909 => {
+                Some(IRIReferenceValidator::compile(context))
+            }
             "iri" if draft_version == Draft::Draft7 => Some(IRIValidator::compile(context)),
+            #[cfg(feature = "draft201909")]
+            "iri" if draft_version == Draft::Draft201909 => Some(IRIValidator::compile(context)),
             "json-pointer" if draft_version == Draft::Draft6 || draft_version == Draft::Draft7 => {
+                Some(JSONPointerValidator::compile(context))
+            }
+            #[cfg(feature = "draft201909")]
+            "json-pointer" if draft_version == Draft::Draft201909 => {
                 Some(JSONPointerValidator::compile(context))
             }
             "regex" => Some(RegexValidator::compile(context)),
             "relative-json-pointer" if draft_version == Draft::Draft7 => {
                 Some(RelativeJSONPointerValidator::compile(context))
             }
+            #[cfg(feature = "draft201909")]
+            "relative-json-pointer" if draft_version == Draft::Draft201909 => {
+                Some(RelativeJSONPointerValidator::compile(context))
+            }
             "time" => Some(TimeValidator::compile(context)),
             "uri-reference" if draft_version == Draft::Draft6 || draft_version == Draft::Draft7 => {
                 Some(URIReferenceValidator::compile(context))
             }
+            #[cfg(feature = "draft201909")]
+            "uri-reference" if draft_version == Draft::Draft201909 => {
+                Some(URIReferenceValidator::compile(context))
+            }
             "uri-template" if draft_version == Draft::Draft6 || draft_version == Draft::Draft7 => {
+                Some(URITemplateValidator::compile(context))
+            }
+            #[cfg(feature = "draft201909")]
+            "uri-template" if draft_version == Draft::Draft201909 => {
                 Some(URITemplateValidator::compile(context))
             }
             "uri" => Some(URIValidator::compile(context)),

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -75,7 +75,11 @@
     unreachable_pub,
     variant_size_differences
 )]
-#![allow(clippy::unnecessary_wraps, clippy::upper_case_acronyms)]
+#![allow(
+    clippy::unnecessary_wraps,
+    clippy::upper_case_acronyms,
+    clippy::needless_collect
+)]
 #![cfg_attr(not(test), allow(clippy::integer_arithmetic, clippy::unwrap_used))]
 mod compilation;
 mod content_encoding;

--- a/jsonschema/src/schemas.rs
+++ b/jsonschema/src/schemas.rs
@@ -2,6 +2,7 @@ use crate::{compilation::context::CompilationContext, keywords};
 use serde_json::{Map, Value};
 
 /// JSON Schema Draft version
+#[non_exhaustive]
 #[derive(Debug, PartialEq, Copy, Clone, Hash, Eq)]
 pub enum Draft {
     /// JSON Schema Draft 4
@@ -10,6 +11,9 @@ pub enum Draft {
     Draft6,
     /// JSON Schema Draft 7
     Draft7,
+    #[cfg(feature = "draft201909")]
+    /// JSON Schema Draft 2019-09
+    Draft201909,
 }
 
 impl Default for Draft {
@@ -25,6 +29,7 @@ type CompileFunc<'a> = fn(
 ) -> Option<keywords::CompilationResult<'a>>;
 
 impl Draft {
+    #[allow(clippy::match_same_arms)]
     pub(crate) fn get_validator(self, keyword: &str) -> Option<CompileFunc> {
         match keyword {
             "additionalItems" => Some(keywords::additional_items::compile),
@@ -34,38 +39,56 @@ impl Draft {
             "const" => match self {
                 Draft::Draft4 => None,
                 Draft::Draft6 | Draft::Draft7 => Some(keywords::const_::compile),
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::const_::compile),
             },
             "contains" => match self {
                 Draft::Draft4 => None,
                 Draft::Draft6 | Draft::Draft7 => Some(keywords::contains::compile),
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::contains::compile),
             },
             "contentMediaType" => match self {
                 Draft::Draft7 | Draft::Draft6 => Some(keywords::content::compile_media_type),
                 Draft::Draft4 => None,
+                #[cfg(feature = "draft201909")]
+                // Should be collected as an annotation
+                Draft::Draft201909 => None,
             },
             "contentEncoding" => match self {
                 Draft::Draft7 | Draft::Draft6 => Some(keywords::content::compile_content_encoding),
                 Draft::Draft4 => None,
+                #[cfg(feature = "draft201909")]
+                // Should be collected as an annotation
+                Draft::Draft201909 => None,
             },
             "dependencies" => Some(keywords::dependencies::compile),
             "enum" => Some(keywords::enum_::compile),
             "exclusiveMaximum" => match self {
                 Draft::Draft7 | Draft::Draft6 => Some(keywords::exclusive_maximum::compile),
                 Draft::Draft4 => None,
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::exclusive_maximum::compile),
             },
             "exclusiveMinimum" => match self {
                 Draft::Draft7 | Draft::Draft6 => Some(keywords::exclusive_minimum::compile),
                 Draft::Draft4 => None,
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::exclusive_minimum::compile),
             },
             "format" => Some(keywords::format::compile),
             "if" => match self {
                 Draft::Draft7 => Some(keywords::if_::compile),
                 Draft::Draft6 | Draft::Draft4 => None,
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::if_::compile),
             },
             "items" => Some(keywords::items::compile),
             "maximum" => match self {
                 Draft::Draft4 => Some(keywords::legacy::maximum_draft_4::compile),
                 Draft::Draft6 | Draft::Draft7 => Some(keywords::maximum::compile),
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::maximum::compile),
             },
             "maxItems" => Some(keywords::max_items::compile),
             "maxLength" => Some(keywords::max_length::compile),
@@ -73,6 +96,8 @@ impl Draft {
             "minimum" => match self {
                 Draft::Draft4 => Some(keywords::legacy::minimum_draft_4::compile),
                 Draft::Draft6 | Draft::Draft7 => Some(keywords::minimum::compile),
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::minimum::compile),
             },
             "minItems" => Some(keywords::min_items::compile),
             "minLength" => Some(keywords::min_length::compile),
@@ -86,11 +111,15 @@ impl Draft {
             "propertyNames" => match self {
                 Draft::Draft4 => None,
                 Draft::Draft6 | Draft::Draft7 => Some(keywords::property_names::compile),
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::property_names::compile),
             },
             "required" => Some(keywords::required::compile),
             "type" => match self {
                 Draft::Draft4 => Some(keywords::legacy::type_draft_4::compile),
                 Draft::Draft6 | Draft::Draft7 => Some(keywords::type_::compile),
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::type_::compile),
             },
             "uniqueItems" => Some(keywords::unique_items::compile),
             _ => None,


### PR DESCRIPTION
Adds a new "draft201909" feature that allows us to run tests against the new draft. Once we have everything in place, the feature is going to be removed. At this point, it should be considered private and used only for testing.