### PR TITLE
Output formats

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -22,6 +22,7 @@ draft201909 = []
 
 [dependencies]
 serde_json = "1"
+serde = "1"
 url = "2"
 lazy_static = "1"
 percent-encoding = "2"
@@ -32,7 +33,7 @@ chrono = ">= 0.2"
 reqwest = { version = ">= 0.10", features = ["blocking", "json"], optional = true}
 parking_lot = ">= 0.1"
 num-cmp = ">= 0.1"
-ahash = "0.7"
+ahash = { version = "0.7", features = ["serde"] }
 structopt = { version = ">= 0.3", optional = true }
 itoa = "0.4"
 fraction = { version = "0.8", default-features = false, features = ["with-bigint"] }

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -186,7 +186,7 @@ impl CompilationOptions {
         };
         let schema_json = Arc::new(schema.clone());
         let resolver = Resolver::new(draft, &scope, schema_json.clone(), self.store.clone())?;
-        let context = CompilationContext::new(scope, &config);
+        let context = CompilationContext::new(scope.into(), &config);
 
         if self.validate_schema {
             if let Some(mut errors) = META_SCHEMA_VALIDATORS
@@ -199,12 +199,11 @@ impl CompilationOptions {
             }
         }
 
-        let mut validators = compile_validators(schema, &context)?;
-        validators.shrink_to_fit();
+        let node = compile_validators(schema, &context)?;
 
         Ok(JSONSchema {
             schema: schema_json,
-            validators,
+            node,
             resolver,
             config,
         })

--- a/jsonschema/src/keywords/mod.rs
+++ b/jsonschema/src/keywords/mod.rs
@@ -122,7 +122,10 @@ mod tests {
     #[test_case(&json!({"uniqueItems": true}), "uniqueItems: true")]
     fn debug_representation(schema: &Value, expected: &str) {
         let compiled = JSONSchema::compile(schema).unwrap();
-        assert_eq!(format!("{:?}", compiled.validators[0]), expected);
+        assert_eq!(
+            format!("{:?}", compiled.node.validators().next().unwrap()),
+            expected
+        );
     }
 
     #[test_case(&json!({"items": [{}], "additionalItems": {"type": "integer"}}), &json!([ null, 2, 3, "foo" ]), r#""foo" is not of type "integer""#)]

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -159,7 +159,7 @@ pub(crate) fn compile<'a>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{compilation::DEFAULT_SCOPE, tests_util};
+    use crate::{compilation::context::BaseUri, tests_util};
     use serde_json::{json, Value};
     use test_case::test_case;
 
@@ -188,7 +188,7 @@ mod tests {
         let text = Value::String(text.into());
         let schema = json!({});
         let schema = JSONSchema::compile(&schema).unwrap();
-        let context = CompilationContext::new(DEFAULT_SCOPE.clone(), schema.config());
+        let context = CompilationContext::new(BaseUri::Unknown, schema.config());
         let compiled = PatternValidator::compile(&pattern, &context).unwrap();
         assert_eq!(compiled.is_valid(&schema, &text), is_matching,)
     }

--- a/jsonschema/src/keywords/pattern_properties.rs
+++ b/jsonschema/src/keywords/pattern_properties.rs
@@ -2,14 +2,16 @@ use crate::{
     compilation::{compile_validators, context::CompilationContext, JSONSchema},
     error::{no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
+    output::BasicOutput,
     paths::InstancePath,
-    validator::{format_validators, Validate, Validators},
+    schema_node::SchemaNode,
+    validator::{format_validators, PartialApplication, Validate},
 };
 use fancy_regex::Regex;
 use serde_json::{Map, Value};
 
 pub(crate) struct PatternPropertiesValidator {
-    patterns: Vec<(Regex, Validators)>,
+    patterns: Vec<(Regex, SchemaNode)>,
 }
 
 impl PatternPropertiesValidator {
@@ -37,20 +39,17 @@ impl PatternPropertiesValidator {
 impl Validate for PatternPropertiesValidator {
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
-            self.patterns.iter().all(move |(re, validators)| {
+            self.patterns.iter().all(move |(re, node)| {
                 item.iter()
                     .filter(move |(key, _)| re.is_match(key).unwrap_or(false))
-                    .all(move |(_key, value)| {
-                        validators
-                            .iter()
-                            .all(move |validator| validator.is_valid(schema, value))
-                    })
+                    .all(move |(_key, value)| node.is_valid(schema, value))
             })
         } else {
             true
         }
     }
 
+    #[allow(clippy::needless_collect)]
     fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
@@ -61,20 +60,44 @@ impl Validate for PatternPropertiesValidator {
             let errors: Vec<_> = self
                 .patterns
                 .iter()
-                .flat_map(move |(re, validators)| {
+                .flat_map(move |(re, node)| {
                     item.iter()
                         .filter(move |(key, _)| re.is_match(key).unwrap_or(false))
                         .flat_map(move |(key, value)| {
                             let instance_path = instance_path.push(key.clone());
-                            validators.iter().flat_map(move |validator| {
-                                validator.validate(schema, value, &instance_path)
-                            })
+                            node.validate(schema, value, &instance_path)
                         })
                 })
                 .collect();
             Box::new(errors.into_iter())
         } else {
             no_error()
+        }
+    }
+
+    fn apply<'a>(
+        &'a self,
+        schema: &JSONSchema,
+        instance: &Value,
+        instance_path: &InstancePath,
+    ) -> PartialApplication<'a> {
+        if let Value::Object(item) = instance {
+            let mut matched_propnames = Vec::with_capacity(item.len());
+            let mut sub_results = BasicOutput::default();
+            for (pattern, node) in &self.patterns {
+                for (key, value) in item {
+                    if pattern.is_match(key).unwrap_or(false) {
+                        let path = instance_path.push(key.clone());
+                        matched_propnames.push(key.clone());
+                        sub_results += node.apply_rooted(schema, value, &path);
+                    }
+                }
+            }
+            let mut result: PartialApplication = sub_results.into();
+            result.annotate(serde_json::Value::from(matched_propnames).into());
+            result
+        } else {
+            PartialApplication::valid_empty()
         }
     }
 }
@@ -86,7 +109,7 @@ impl core::fmt::Display for PatternPropertiesValidator {
             "patternProperties: {{{}}}",
             self.patterns
                 .iter()
-                .map(|(key, validators)| { format!("{}: {}", key, format_validators(validators)) })
+                .map(|(key, node)| { format!("{}: {}", key, format_validators(node.validators())) })
                 .collect::<Vec<String>>()
                 .join(", ")
         )
@@ -95,7 +118,7 @@ impl core::fmt::Display for PatternPropertiesValidator {
 
 pub(crate) struct SingleValuePatternPropertiesValidator {
     pattern: Regex,
-    validators: Validators,
+    node: SchemaNode,
 }
 
 impl SingleValuePatternPropertiesValidator {
@@ -112,7 +135,7 @@ impl SingleValuePatternPropertiesValidator {
                 Ok(r) => r,
                 Err(_) => return Err(ValidationError::schema(schema)),
             },
-            validators: compile_validators(schema, &pattern_context)?,
+            node: compile_validators(schema, &pattern_context)?,
         }))
     }
 }
@@ -122,16 +145,13 @@ impl Validate for SingleValuePatternPropertiesValidator {
         if let Value::Object(item) = instance {
             item.iter()
                 .filter(move |(key, _)| self.pattern.is_match(key).unwrap_or(false))
-                .all(move |(_key, value)| {
-                    self.validators
-                        .iter()
-                        .all(move |validator| validator.is_valid(schema, value))
-                })
+                .all(move |(_key, value)| self.node.is_valid(schema, value))
         } else {
             true
         }
     }
 
+    #[allow(clippy::needless_collect)]
     fn validate<'a, 'b>(
         &self,
         schema: &'a JSONSchema,
@@ -144,14 +164,36 @@ impl Validate for SingleValuePatternPropertiesValidator {
                 .filter(move |(key, _)| self.pattern.is_match(key).unwrap_or(false))
                 .flat_map(move |(key, value)| {
                     let instance_path = instance_path.push(key.clone());
-                    self.validators.iter().flat_map(move |validator| {
-                        validator.validate(schema, value, &instance_path)
-                    })
+                    self.node.validate(schema, value, &instance_path)
                 })
                 .collect();
             Box::new(errors.into_iter())
         } else {
             no_error()
+        }
+    }
+
+    fn apply<'a>(
+        &'a self,
+        schema: &JSONSchema,
+        instance: &Value,
+        instance_path: &InstancePath,
+    ) -> PartialApplication<'a> {
+        if let Value::Object(item) = instance {
+            let mut matched_propnames = Vec::with_capacity(item.len());
+            let mut outputs = BasicOutput::default();
+            for (key, value) in item {
+                if self.pattern.is_match(key).unwrap_or(false) {
+                    let path = instance_path.push(key.clone());
+                    matched_propnames.push(key.clone());
+                    outputs += self.node.apply_rooted(schema, value, &path);
+                }
+            }
+            let mut result: PartialApplication = outputs.into();
+            result.annotate(serde_json::Value::from(matched_propnames).into());
+            result
+        } else {
+            PartialApplication::valid_empty()
         }
     }
 }
@@ -162,7 +204,7 @@ impl core::fmt::Display for SingleValuePatternPropertiesValidator {
             f,
             "patternProperties: {{{}: {}}}",
             self.pattern,
-            format_validators(&self.validators)
+            format_validators(self.node.validators())
         )
     }
 }

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -86,9 +86,12 @@ mod content_encoding;
 mod content_media_type;
 pub mod error;
 mod keywords;
+mod output;
+pub use output::{BasicOutput, Output};
 pub mod paths;
 pub mod primitive_type;
 mod resolver;
+mod schema_node;
 mod schemas;
 mod validator;
 

--- a/jsonschema/src/output.rs
+++ b/jsonschema/src/output.rs
@@ -1,0 +1,280 @@
+use std::{
+    collections::VecDeque,
+    iter::{FromIterator, Sum},
+    ops::AddAssign,
+};
+
+use crate::{validator::PartialApplication, ValidationError};
+use ahash::AHashMap;
+use serde::ser::SerializeMap;
+
+use crate::{
+    paths::{AbsolutePath, InstancePath, JSONPointer},
+    schema_node::SchemaNode,
+    JSONSchema,
+};
+
+/// The output format resulting from the application of a schema. This can be
+/// converted into various representations based on the definitions in
+/// <https://json-schema.org/draft/2020-12/json-schema-core.html#rfc.section.12.2>
+///
+/// Currently only the "flag" and "basic" output formats are supported
+#[derive(Debug, Clone)]
+pub struct Output<'a, 'b> {
+    schema: &'a JSONSchema,
+    root_node: &'a SchemaNode,
+    instance: &'b serde_json::Value,
+}
+
+impl<'a, 'b> Output<'a, 'b> {
+    pub(crate) const fn new<'c, 'd>(
+        schema: &'c JSONSchema,
+        root_node: &'c SchemaNode,
+        instance: &'d serde_json::Value,
+    ) -> Output<'c, 'd> {
+        Output {
+            schema,
+            root_node,
+            instance,
+        }
+    }
+
+    /// Indicates whether the schema was valid, corresponds to the "flag" output
+    /// format
+    pub fn flag(&self) -> bool {
+        self.schema.is_valid(self.instance)
+    }
+
+    /// Output a list of errors and annotations for each element in the schema
+    /// according to the basic output format
+    pub fn basic(&self) -> BasicOutput<'a> {
+        self.root_node
+            .apply_rooted(self.schema, self.instance, &InstancePath::new())
+    }
+}
+
+/// The "basic" output format
+#[derive(Debug, PartialEq)]
+pub enum BasicOutput<'a> {
+    /// The schema was valid, collected annotations can be examined
+    Valid(VecDeque<OutputUnit<Annotations<'a>>>),
+    /// The schema was invalid
+    Invalid(VecDeque<OutputUnit<ErrorDescription>>),
+}
+
+impl<'a> BasicOutput<'a> {
+    pub(crate) const fn is_valid(&self) -> bool {
+        match self {
+            BasicOutput::Valid(..) => true,
+            BasicOutput::Invalid(..) => false,
+        }
+    }
+}
+
+impl<'a> From<OutputUnit<Annotations<'a>>> for BasicOutput<'a> {
+    fn from(unit: OutputUnit<Annotations<'a>>) -> Self {
+        let mut units = VecDeque::new();
+        units.push_front(unit);
+        BasicOutput::Valid(units)
+    }
+}
+
+impl<'a> AddAssign for BasicOutput<'a> {
+    fn add_assign(&mut self, rhs: Self) {
+        match (&mut *self, rhs) {
+            (BasicOutput::Valid(ref mut anns), BasicOutput::Valid(anns_rhs)) => {
+                anns.extend(anns_rhs);
+            }
+            (BasicOutput::Valid(..), BasicOutput::Invalid(errors)) => {
+                *self = BasicOutput::Invalid(errors)
+            }
+            (BasicOutput::Invalid(..), BasicOutput::Valid(..)) => {}
+            (BasicOutput::Invalid(errors), BasicOutput::Invalid(errors_rhs)) => {
+                errors.extend(errors_rhs)
+            }
+        }
+    }
+}
+
+impl<'a> Sum for BasicOutput<'a> {
+    fn sum<I: Iterator<Item = Self>>(iter: I) -> Self {
+        let result = BasicOutput::Valid(VecDeque::new());
+        iter.fold(result, |mut acc, elem| {
+            acc += elem;
+            acc
+        })
+    }
+}
+
+impl<'a> Default for BasicOutput<'a> {
+    fn default() -> Self {
+        BasicOutput::Valid(VecDeque::new())
+    }
+}
+
+impl<'a> From<BasicOutput<'a>> for PartialApplication<'a> {
+    fn from(output: BasicOutput<'a>) -> Self {
+        match output {
+            BasicOutput::Valid(anns) => PartialApplication::Valid {
+                annotations: None,
+                child_results: anns,
+            },
+            BasicOutput::Invalid(errors) => PartialApplication::Invalid {
+                errors: Vec::new(),
+                child_results: errors,
+            },
+        }
+    }
+}
+
+impl<'a> FromIterator<BasicOutput<'a>> for PartialApplication<'a> {
+    fn from_iter<T: IntoIterator<Item = BasicOutput<'a>>>(iter: T) -> Self {
+        iter.into_iter().sum::<BasicOutput<'_>>().into()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct OutputUnit<T> {
+    keyword_location: JSONPointer,
+    instance_location: JSONPointer,
+    absolute_keyword_location: Option<AbsolutePath>,
+    value: T,
+}
+
+impl<T> OutputUnit<T> {
+    pub(crate) const fn annotations(
+        keyword_location: JSONPointer,
+        instance_location: JSONPointer,
+        absolute_keyword_location: Option<AbsolutePath>,
+        annotations: Annotations<'_>,
+    ) -> OutputUnit<Annotations<'_>> {
+        OutputUnit {
+            keyword_location,
+            instance_location,
+            absolute_keyword_location,
+            value: annotations,
+        }
+    }
+
+    pub(crate) const fn error(
+        keyword_location: JSONPointer,
+        instance_location: JSONPointer,
+        absolute_keyword_location: Option<AbsolutePath>,
+        error: ErrorDescription,
+    ) -> OutputUnit<ErrorDescription> {
+        OutputUnit {
+            keyword_location,
+            instance_location,
+            absolute_keyword_location,
+            value: error,
+        }
+    }
+}
+
+#[derive(serde::Serialize, Debug, Clone, PartialEq)]
+pub struct Annotations<'a>(AnnotationsInner<'a>);
+
+#[derive(Debug, Clone, PartialEq)]
+enum AnnotationsInner<'a> {
+    UnmatchedKeywords(&'a AHashMap<String, serde_json::Value>),
+    ValueRef(&'a serde_json::Value),
+    Value(Box<serde_json::Value>),
+}
+
+impl<'a> From<&'a AHashMap<String, serde_json::Value>> for Annotations<'a> {
+    fn from(anns: &'a AHashMap<String, serde_json::Value>) -> Self {
+        Annotations(AnnotationsInner::UnmatchedKeywords(anns))
+    }
+}
+
+impl<'a> From<&'a serde_json::Value> for Annotations<'a> {
+    fn from(v: &'a serde_json::Value) -> Self {
+        Annotations(AnnotationsInner::ValueRef(v))
+    }
+}
+
+impl<'a> From<serde_json::Value> for Annotations<'a> {
+    fn from(v: serde_json::Value) -> Self {
+        Annotations(AnnotationsInner::Value(Box::new(v)))
+    }
+}
+
+#[derive(serde::Serialize, Debug, Clone, PartialEq)]
+pub struct ErrorDescription(String);
+
+impl From<ValidationError<'_>> for ErrorDescription {
+    fn from(e: ValidationError<'_>) -> Self {
+        ErrorDescription(e.to_string())
+    }
+}
+
+impl<'a> From<&'a str> for ErrorDescription {
+    fn from(s: &'a str) -> Self {
+        ErrorDescription(s.to_string())
+    }
+}
+
+impl<'a> serde::Serialize for BasicOutput<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(2))?;
+        match self {
+            BasicOutput::Valid(outputs) => {
+                map_ser.serialize_entry("valid", &true)?;
+                map_ser.serialize_entry("annotations", outputs)?;
+            }
+            BasicOutput::Invalid(errors) => {
+                map_ser.serialize_entry("valid", &false)?;
+                map_ser.serialize_entry("errors", errors)?;
+            }
+        }
+        map_ser.end()
+    }
+}
+
+impl<'a> serde::Serialize for AnnotationsInner<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            Self::UnmatchedKeywords(kvs) => kvs.serialize(serializer),
+            Self::Value(v) => v.serialize(serializer),
+            Self::ValueRef(v) => v.serialize(serializer),
+        }
+    }
+}
+
+impl<'a> serde::Serialize for OutputUnit<Annotations<'a>> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(4))?;
+        map_ser.serialize_entry("keywordLocation", &self.keyword_location)?;
+        map_ser.serialize_entry("instanceLocation", &self.instance_location)?;
+        if let Some(absolute) = &self.absolute_keyword_location {
+            map_ser.serialize_entry("absoluteKeywordLocation", &absolute)?;
+        }
+        map_ser.serialize_entry("annotations", &self.value)?;
+        map_ser.end()
+    }
+}
+
+impl<'a> serde::Serialize for OutputUnit<ErrorDescription> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let mut map_ser = serializer.serialize_map(Some(4))?;
+        map_ser.serialize_entry("keywordLocation", &self.keyword_location)?;
+        map_ser.serialize_entry("instanceLocation", &self.instance_location)?;
+        if let Some(absolute) = &self.absolute_keyword_location {
+            map_ser.serialize_entry("absoluteKeywordLocation", &absolute)?;
+        }
+        map_ser.serialize_entry("error", &self.value)?;
+        map_ser.end()
+    }
+}

--- a/jsonschema/src/schema_node.rs
+++ b/jsonschema/src/schema_node.rs
@@ -1,0 +1,427 @@
+use crate::{
+    compilation::context::CompilationContext,
+    error::ErrorIterator,
+    keywords::BoxedValidator,
+    output::{Annotations, BasicOutput, ErrorDescription, OutputUnit},
+    paths::{AbsolutePath, InstancePath, JSONPointer},
+    validator::{format_validators, PartialApplication, Validate},
+    JSONSchema,
+};
+use ahash::AHashMap;
+use std::{collections::VecDeque, fmt};
+
+/// A node in the schema tree, returned by [`compile_validators`]
+#[derive(Debug)]
+pub(crate) struct SchemaNode {
+    validators: NodeValidators,
+    relative_path: JSONPointer,
+    absolute_path: Option<AbsolutePath>,
+}
+
+#[derive(Debug)]
+enum NodeValidators {
+    /// The result of compiling a boolean valued schema, e.g
+    ///
+    /// ```json
+    /// {
+    ///     "additionalProperties": false
+    /// }
+    /// ```
+    ///
+    /// Here the result of `compile_validators` called with the `false` value will return a
+    /// `SchemaNode` with a single `BooleanValidator` as it's `validators`.
+    Boolean { validator: Option<BoxedValidator> },
+    /// The result of compiling a schema which is composed of keywords (almost all schemas)
+    Keyword(Box<KeywordValidators>),
+    /// The result of compiling a schema which is "array valued", e.g the "dependencies" keyword of
+    /// draft 7 which can take values which are an array of other property names
+    Array { validators: Vec<BoxedValidator> },
+}
+
+#[derive(Debug)]
+struct KeywordValidators {
+    /// The keywords on this node which were not recognized by any vocabularies. These are
+    /// stored so we can later produce them as annotations
+    unmatched_keywords: Option<AHashMap<String, serde_json::Value>>,
+    // We should probably use AHashMap here but it breaks a bunch of test which assume
+    // validators are in a particular order
+    validators: Vec<(String, BoxedValidator)>,
+}
+
+impl SchemaNode {
+    pub(crate) fn new_from_boolean(
+        context: &CompilationContext<'_>,
+        validator: Option<BoxedValidator>,
+    ) -> SchemaNode {
+        SchemaNode {
+            relative_path: context.clone().into_pointer(),
+            absolute_path: context.base_uri().map(AbsolutePath::from),
+            validators: NodeValidators::Boolean { validator },
+        }
+    }
+
+    pub(crate) fn new_from_keywords(
+        context: &CompilationContext<'_>,
+        mut validators: Vec<(String, BoxedValidator)>,
+        unmatched_keywords: Option<AHashMap<String, serde_json::Value>>,
+    ) -> SchemaNode {
+        validators.shrink_to_fit();
+        SchemaNode {
+            relative_path: context.clone().into_pointer(),
+            absolute_path: context.base_uri().map(AbsolutePath::from),
+            validators: NodeValidators::Keyword(Box::new(KeywordValidators {
+                unmatched_keywords,
+                validators,
+            })),
+        }
+    }
+
+    pub(crate) fn new_from_array(
+        context: &CompilationContext<'_>,
+        mut validators: Vec<BoxedValidator>,
+    ) -> SchemaNode {
+        validators.shrink_to_fit();
+        SchemaNode {
+            relative_path: context.clone().into_pointer(),
+            absolute_path: context.base_uri().map(AbsolutePath::from),
+            validators: NodeValidators::Array { validators },
+        }
+    }
+
+    pub(crate) fn validators(&self) -> impl Iterator<Item = &BoxedValidator> + ExactSizeIterator {
+        match &self.validators {
+            NodeValidators::Boolean { validator } => {
+                if let Some(v) = validator {
+                    NodeValidatorsIter::BooleanValidators(std::iter::once(v))
+                } else {
+                    NodeValidatorsIter::NoValidator
+                }
+            }
+            NodeValidators::Keyword(kvals) => {
+                NodeValidatorsIter::KeywordValidators(kvals.validators.iter())
+            }
+            NodeValidators::Array { validators } => {
+                NodeValidatorsIter::ArrayValidators(validators.iter())
+            }
+        }
+    }
+
+    fn format_validators(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", format_validators(self.validators()))
+    }
+
+    /// This is similar to `Validate::apply` except that `SchemaNode` knows where it is in the
+    /// validator tree and so rather than returning a `PartialApplication` it is able to return a
+    /// complete `BasicOutput`. This is the mechanism which compositional validators use to combine
+    /// results from sub-schemas
+    pub(crate) fn apply_rooted(
+        &self,
+        schema: &JSONSchema,
+        instance: &serde_json::Value,
+        instance_path: &InstancePath,
+    ) -> BasicOutput {
+        match self.apply(schema, instance, instance_path) {
+            PartialApplication::Valid {
+                annotations,
+                mut child_results,
+            } => {
+                if let Some(annotations) = annotations {
+                    child_results.insert(0, self.annotation_at(instance_path, annotations));
+                };
+                BasicOutput::Valid(child_results)
+            }
+            PartialApplication::Invalid {
+                errors,
+                mut child_results,
+            } => {
+                for error in errors {
+                    child_results.insert(0, self.error_at(instance_path, error));
+                }
+                BasicOutput::Invalid(child_results)
+            }
+        }
+    }
+
+    /// Create an error output which is marked as occurring at this schema node
+    pub(crate) fn error_at(
+        &self,
+        instance_path: &InstancePath,
+        error: ErrorDescription,
+    ) -> OutputUnit<ErrorDescription> {
+        OutputUnit::<ErrorDescription>::error(
+            self.relative_path.clone(),
+            instance_path.clone().into(),
+            self.absolute_path.clone(),
+            error,
+        )
+    }
+
+    /// Create an anontation output which is marked as occurring at this schema node
+    pub(crate) fn annotation_at<'a>(
+        &self,
+        instance_path: &InstancePath,
+        annotations: Annotations<'a>,
+    ) -> OutputUnit<Annotations<'a>> {
+        OutputUnit::<Annotations<'_>>::annotations(
+            self.relative_path.clone(),
+            instance_path.clone().into(),
+            self.absolute_path.clone(),
+            annotations,
+        )
+    }
+
+    /// Here we return a `NodeValidatorsErrIter` to avoid allocating in some situations. This isn't
+    /// always possible but for a lot of common cases (e.g nodes with a single child) we can do it.
+    /// This is wrapped in a `Box` by `SchemaNode::validate`
+    pub(crate) fn err_iter<'a, 'b>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'b serde_json::Value,
+        instance_path: &InstancePath,
+    ) -> NodeValidatorsErrIter<'b> {
+        match &self.validators {
+            NodeValidators::Keyword(kvs) if kvs.validators.len() == 1 => {
+                NodeValidatorsErrIter::Single(kvs.validators[0].1.validate(
+                    schema,
+                    instance,
+                    instance_path,
+                ))
+            }
+            NodeValidators::Keyword(kvs) => NodeValidatorsErrIter::Multiple(
+                kvs.validators
+                    .iter()
+                    .flat_map(|(_, v)| v.validate(schema, instance, instance_path))
+                    .collect::<Vec<_>>()
+                    .into_iter(),
+            ),
+            NodeValidators::Boolean {
+                validator: Some(v), ..
+            } => NodeValidatorsErrIter::Single(v.validate(schema, instance, instance_path)),
+            NodeValidators::Boolean {
+                validator: None, ..
+            } => NodeValidatorsErrIter::NoErrs,
+            NodeValidators::Array { validators } => NodeValidatorsErrIter::Multiple(
+                validators
+                    .iter()
+                    .flat_map(move |v| v.validate(schema, instance, instance_path))
+                    .collect::<Vec<_>>()
+                    .into_iter(),
+            ),
+        }
+    }
+
+    /// Helper function to apply an iterator of `(Into<PathChunk>, Validate)` to a value. This is
+    /// useful as a keyword schemanode has a set of validators keyed by their keywords, so the
+    /// `Into<Pathchunk>` is a `String` whereas an array schemanode has an array of validators so
+    /// the `Into<PathChunk>` is a `usize`
+    fn apply_subschemas<'a, I, P>(
+        &self,
+        schema: &JSONSchema,
+        instance: &serde_json::Value,
+        instance_path: &InstancePath,
+        path_and_validators: I,
+        annotations: Option<Annotations<'a>>,
+    ) -> PartialApplication<'a>
+    where
+        I: Iterator<Item = (P, &'a Box<dyn Validate + Send + Sync + 'a>)> + 'a,
+        P: Into<crate::paths::PathChunk>,
+        P: std::fmt::Display,
+    {
+        let mut success_results: VecDeque<OutputUnit<Annotations>> = VecDeque::new();
+        let mut error_results = VecDeque::new();
+        for (path, validator) in path_and_validators {
+            let path = self.relative_path.extend_with(&[path.into()]);
+            let absolute_path = self
+                .absolute_path
+                .clone()
+                .map(|p| p.with_path(path.to_string().as_str()));
+            match validator.apply(schema, instance, instance_path) {
+                PartialApplication::Valid {
+                    annotations,
+                    child_results,
+                } => {
+                    if let Some(annotations) = annotations {
+                        success_results.push_front(OutputUnit::<Annotations<'a>>::annotations(
+                            path,
+                            instance_path.into(),
+                            absolute_path,
+                            annotations,
+                        ));
+                    }
+                    success_results.extend(child_results);
+                }
+                PartialApplication::Invalid {
+                    errors: these_errors,
+                    child_results,
+                } => {
+                    error_results.extend(child_results);
+                    error_results.extend(these_errors.into_iter().map(|error| {
+                        OutputUnit::<ErrorDescription>::error(
+                            path.clone(),
+                            instance_path.into(),
+                            absolute_path.clone(),
+                            error,
+                        )
+                    }));
+                }
+            }
+        }
+        if !error_results.is_empty() {
+            PartialApplication::Invalid {
+                errors: Vec::new(),
+                child_results: error_results,
+            }
+        } else {
+            PartialApplication::Valid {
+                annotations,
+                child_results: success_results,
+            }
+        }
+    }
+}
+
+impl fmt::Display for SchemaNode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.format_validators(f)
+    }
+}
+
+impl Validate for SchemaNode {
+    fn validate<'a, 'b>(
+        &self,
+        schema: &'a JSONSchema,
+        instance: &'b serde_json::Value,
+        instance_path: &InstancePath,
+    ) -> ErrorIterator<'b> {
+        return Box::new(self.err_iter(schema, instance, instance_path));
+    }
+
+    fn is_valid(&self, schema: &JSONSchema, instance: &serde_json::Value) -> bool {
+        match &self.validators {
+            // If we only have one validator then calling it's `is_valid` directly does
+            // actually save the 20 or so instructions required to call the `slice::Iter::all`
+            // implementation. Validators at the leaf of a tree are all single node validators so
+            // this optimization can have significant cumulative benefits
+            NodeValidators::Keyword(kvs) if kvs.validators.len() == 1 => {
+                kvs.validators[0].1.is_valid(schema, instance)
+            }
+            NodeValidators::Keyword(kvs) => kvs
+                .validators
+                .iter()
+                .all(|(_, v)| v.is_valid(schema, instance)),
+            NodeValidators::Array { validators } => {
+                validators.iter().all(|v| v.is_valid(schema, instance))
+            }
+            NodeValidators::Boolean {
+                validator: Some(v), ..
+            } => v.is_valid(schema, instance),
+            NodeValidators::Boolean {
+                validator: None, ..
+            } => true,
+        }
+    }
+
+    fn apply<'a>(
+        &'a self,
+        schema: &JSONSchema,
+        instance: &serde_json::Value,
+        instance_path: &InstancePath,
+    ) -> PartialApplication<'a> {
+        match self.validators {
+            NodeValidators::Array { ref validators } => self.apply_subschemas(
+                schema,
+                instance,
+                instance_path,
+                validators.iter().enumerate(),
+                None,
+            ),
+            NodeValidators::Boolean { ref validator } => {
+                if let Some(validator) = validator {
+                    validator.apply(schema, instance, instance_path)
+                } else {
+                    PartialApplication::Valid {
+                        annotations: None,
+                        child_results: VecDeque::new(),
+                    }
+                }
+            }
+            NodeValidators::Keyword(ref kvals) => {
+                let KeywordValidators {
+                    ref unmatched_keywords,
+                    ref validators,
+                } = **kvals;
+                let annotations: Option<Annotations<'a>> =
+                    unmatched_keywords.as_ref().map(Annotations::from);
+                self.apply_subschemas(
+                    schema,
+                    instance,
+                    instance_path,
+                    validators.iter().map(|(p, v)| (p.clone(), v)),
+                    annotations,
+                )
+            }
+        }
+    }
+}
+
+enum NodeValidatorsIter<'a> {
+    NoValidator,
+    BooleanValidators(std::iter::Once<&'a BoxedValidator>),
+    KeywordValidators(std::slice::Iter<'a, (String, BoxedValidator)>),
+    ArrayValidators(std::slice::Iter<'a, BoxedValidator>),
+}
+
+impl<'a> Iterator for NodeValidatorsIter<'a> {
+    type Item = &'a BoxedValidator;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::NoValidator => None,
+            Self::BooleanValidators(i) => i.next(),
+            Self::KeywordValidators(v) => v.next().map(|(_, v)| v),
+            Self::ArrayValidators(v) => v.next(),
+        }
+    }
+
+    fn all<F>(&mut self, mut f: F) -> bool
+    where
+        Self: Sized,
+        F: FnMut(Self::Item) -> bool,
+    {
+        match self {
+            Self::NoValidator => true,
+            Self::BooleanValidators(i) => i.all(f),
+            Self::KeywordValidators(v) => v.all(|(_, v)| f(v)),
+            Self::ArrayValidators(v) => v.all(f),
+        }
+    }
+}
+
+impl<'a> ExactSizeIterator for NodeValidatorsIter<'a> {
+    fn len(&self) -> usize {
+        match self {
+            Self::NoValidator => 0,
+            Self::BooleanValidators(..) => 1,
+            Self::KeywordValidators(v) => v.len(),
+            Self::ArrayValidators(v) => v.len(),
+        }
+    }
+}
+
+pub(crate) enum NodeValidatorsErrIter<'a> {
+    NoErrs,
+    Single(ErrorIterator<'a>),
+    Multiple(std::vec::IntoIter<crate::error::ValidationError<'a>>),
+}
+
+impl<'a> Iterator for NodeValidatorsErrIter<'a> {
+    type Item = crate::error::ValidationError<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::NoErrs => None,
+            Self::Single(i) => i.next(),
+            Self::Multiple(ms) => ms.next(),
+        }
+    }
+}

--- a/jsonschema/src/validator.rs
+++ b/jsonschema/src/validator.rs
@@ -1,9 +1,28 @@
 use crate::{
-    compilation::JSONSchema, error::ErrorIterator, keywords::BoxedValidator, paths::InstancePath,
+    compilation::JSONSchema,
+    error::ErrorIterator,
+    keywords::BoxedValidator,
+    output::{Annotations, ErrorDescription, OutputUnit},
+    paths::InstancePath,
+    schema_node::SchemaNode,
 };
 use serde_json::Value;
-use std::fmt;
+use std::{collections::VecDeque, fmt};
 
+/// The Validate trait represents a predicate over some JSON value. Some validators are very simple
+/// predicates such as "a value which is a string", whereas others may be much more complex,
+/// consisting of several other validators composed together in various ways.
+///
+/// Much of the time all an application cares about is whether the predicate returns true or false,
+/// in that case the `is_valid` function is sufficient. Sometimes applications will want more
+/// detail about why a schema has failed, in which case the `validate` method can be used to
+/// iterate over the errors produced by this validator. Finally, applications may be interested in
+/// annotations produced by schemas over valid results, in this case the `apply` method can be used
+/// to obtain this information.
+///
+/// If you are implementing `Validate` it is often sufficient to implement `validate` and
+/// `is_valid`. `apply` is only necessary for validators which compose other validators. See the
+/// documentation for `apply` for more information.
 pub(crate) trait Validate: Send + Sync + core::fmt::Display {
     fn validate<'a, 'b>(
         &self,
@@ -15,6 +34,127 @@ pub(crate) trait Validate: Send + Sync + core::fmt::Display {
     // It is faster for cases when the result is not needed (like anyOf), since errors are
     // not constructed
     fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool;
+
+    /// `apply` applies this validator and any sub-validators it is composed of to the value in
+    /// question and collects the resulting annotations or errors. Note that the result of `apply`
+    /// is a `PartialApplication`.
+    ///
+    /// What does "partial" mean in this context? Each valdator can produce annotations or errors
+    /// in the case of successful or unsuccessful validation respectively. We're ultimately
+    /// producing these errors and annotations to produce the "basic" output format as specified in
+    /// the 2020-12 draft specification. In this format each annotation or error must include a
+    /// json pointer to the keyword in the schema and to the property in the instance. However,
+    /// most validators don't know where they are in the schema tree so we allow them to return the
+    /// errors or annotations they produce directly and leave it up to the parent validator to fill
+    /// in the path information. This means that only validators which are composed of other
+    /// validators must implement `apply`, for validators on the leaves of the validator tree the
+    /// default implementation which is defined in terms of `validate` will suffice.
+    ///
+    /// If you are writing a validator which is composed of other validators then your validator will
+    /// need to store references to the `SchemaNode`s which contain those other validators.
+    /// `SchemaNode` stores information about where it is in the schema tree and therefore provides an
+    /// `apply_rooted` method which returns a full `BasicOutput`. `BasicOutput` implements `AddAssign`
+    /// so a typical pattern is to compose results from sub validators using `+=` and then use the
+    /// `From<BasicOutput> for PartialApplication` impl to convert the composed outputs into a
+    /// `PartialApplication` to return. For example, here is the implementation of
+    /// `IfThenValidator`
+    ///
+    /// ```rust,ignore
+    /// // Note that self.schema is a `SchemaNode` and we use `apply_rooted` to return a `BasicOutput`
+    /// let mut if_result = self.schema.apply_rooted(schema, instance, instance_path);
+    /// if if_result.is_valid() {
+    ///     // here we use the `AddAssign` implementation to combine the results of subschemas
+    ///     if_result += self
+    ///         .then_schema
+    ///         .apply_rooted(schema, instance, instance_path);
+    ///     // Here we use the `From<BasicOutput> for PartialApplication impl
+    ///     if_result.into()
+    /// } else {
+    ///     self.else_schema
+    ///         .apply_rooted(schema, instance, instance_path)
+    ///         .into()
+    /// }
+    /// ```
+    ///
+    /// `BasicOutput` also implements `Sum<BasicOutput>` and `FromIterator<BasicOutput<'a>> for PartialApplication<'a>`
+    /// so you can use `sum()` and `collect()` in simple cases.
+    fn apply<'a>(
+        &'a self,
+        schema: &JSONSchema,
+        instance: &Value,
+        instance_path: &InstancePath,
+    ) -> PartialApplication<'a> {
+        let errors: Vec<ErrorDescription> = self
+            .validate(schema, instance, instance_path)
+            .map(ErrorDescription::from)
+            .collect();
+        if errors.is_empty() {
+            PartialApplication::valid_empty()
+        } else {
+            PartialApplication::invalid_empty(errors)
+        }
+    }
+}
+
+/// The result of applying a validator to an instance. As explained in the documentation for
+/// `Validate::apply` this is a "partial" result because it does not include information about
+/// where the error or annotation occurred.
+#[derive(Clone, PartialEq)]
+pub(crate) enum PartialApplication<'a> {
+    Valid {
+        /// Annotations produced by this validator
+        annotations: Option<Annotations<'a>>,
+        /// Any outputs produced by validators which are children of this validator
+        child_results: VecDeque<OutputUnit<Annotations<'a>>>,
+    },
+    Invalid {
+        /// Errors which caused this schema to be invalid
+        errors: Vec<ErrorDescription>,
+        /// Any error outputs produced by child validators of this validator
+        child_results: VecDeque<OutputUnit<ErrorDescription>>,
+    },
+}
+
+impl<'a> PartialApplication<'a> {
+    /// Create an empty `PartialApplication` which is valid
+    pub(crate) fn valid_empty() -> PartialApplication<'static> {
+        PartialApplication::Valid {
+            annotations: None,
+            child_results: VecDeque::new(),
+        }
+    }
+
+    /// Create an empty `PartialApplication` which is invalid
+    pub(crate) fn invalid_empty(errors: Vec<ErrorDescription>) -> PartialApplication<'static> {
+        PartialApplication::Invalid {
+            errors,
+            child_results: VecDeque::new(),
+        }
+    }
+
+    /// Set the annotation that will be returned for the current validator. If this
+    /// `PartialApplication` is invalid then this method does nothing
+    pub(crate) fn annotate(&mut self, new_annotations: Annotations<'a>) {
+        match self {
+            Self::Valid { annotations, .. } => *annotations = Some(new_annotations),
+            Self::Invalid { .. } => {}
+        }
+    }
+
+    /// Set the error that will be returned for the current validator. If this
+    /// `PartialApplication` is valid then this method converts this application into
+    /// `PartialApplication::Invalid`
+    pub(crate) fn mark_errored(&mut self, error: ErrorDescription) {
+        match self {
+            Self::Invalid { errors, .. } => errors.push(error),
+            Self::Valid { .. } => {
+                *self = Self::Invalid {
+                    errors: vec![error],
+                    child_results: VecDeque::new(),
+                }
+            }
+        }
+    }
 }
 
 impl fmt::Debug for dyn Validate + Send + Sync {
@@ -23,13 +163,15 @@ impl fmt::Debug for dyn Validate + Send + Sync {
     }
 }
 
-pub(crate) type Validators = Vec<BoxedValidator>;
-
-pub(crate) fn format_validators(validators: &[BoxedValidator]) -> String {
+pub(crate) fn format_validators<'a, I: ExactSizeIterator + Iterator<Item = &'a BoxedValidator>>(
+    mut validators: I,
+) -> String {
     match validators.len() {
         0 => "{}".to_string(),
         1 => {
-            let name = validators[0].to_string();
+            // Unwrap is okay due to the check on len
+            let validator = validators.next().unwrap();
+            let name = validator.to_string();
             match name.as_str() {
                 // boolean validators are represented as is, without brackets because if they
                 // occur in a vector, then the schema is not a key/value mapping
@@ -40,7 +182,6 @@ pub(crate) fn format_validators(validators: &[BoxedValidator]) -> String {
         _ => format!(
             "{{{}}}",
             validators
-                .iter()
                 .map(|validator| format!("{:?}", validator))
                 .collect::<Vec<String>>()
                 .join(", ")
@@ -48,18 +189,21 @@ pub(crate) fn format_validators(validators: &[BoxedValidator]) -> String {
     }
 }
 
-pub(crate) fn format_vec_of_validators(validators: &[Validators]) -> String {
+pub(crate) fn format_iter_of_validators<'a, G, I>(validators: I) -> String
+where
+    I: Iterator<Item = G>,
+    G: ExactSizeIterator + Iterator<Item = &'a BoxedValidator>,
+{
     validators
-        .iter()
-        .map(|v| format_validators(v))
+        .map(format_validators)
         .collect::<Vec<String>>()
         .join(", ")
 }
 
-pub(crate) fn format_key_value_validators(validators: &[(String, Validators)]) -> String {
+pub(crate) fn format_key_value_validators(validators: &[(String, SchemaNode)]) -> String {
     validators
         .iter()
-        .map(|(name, validators)| format!("{}: {}", name, format_validators(validators)))
+        .map(|(name, node)| format!("{}: {}", name, format_validators(node.validators())))
         .collect::<Vec<String>>()
         .join(", ")
 }

--- a/jsonschema/tests/output.rs
+++ b/jsonschema/tests/output.rs
@@ -1,0 +1,1020 @@
+use jsonschema::JSONSchema;
+use serde_json::json;
+use test_case::test_case;
+
+#[test_case{
+    &json!({"allOf": [{"type": "string", "typeannotation": "value"}, {"maxLength": 20, "lengthannotation": "value"}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/allOf/0",
+                "instanceLocation": "",
+                "annotations": {
+                    "typeannotation": "value"
+                }
+            },
+            {
+                "keywordLocation": "/allOf/1",
+                "instanceLocation": "",
+                "annotations": { "lengthannotation": "value" } }
+        ]
+    }); "valid allOf"
+}]
+#[test_case{
+    &json!({"allOf": [{"type": "array"}, {"maxLength": 4}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/allOf/0/type",
+                "instanceLocation": "",
+                "error": "\"some string\" is not of type \"array\""
+            },
+            {
+                "keywordLocation": "/allOf/1/maxLength",
+                "instanceLocation": "",
+                "error": "\"some string\" is longer than 4 characters"
+            }
+        ]
+    }); "invalid allOf"
+}]
+#[test_case{
+    &json!({"allOf": [{"type": "string", "typeannotation": "value"}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/allOf/0",
+                "instanceLocation": "",
+                "annotations": {
+                    "typeannotation": "value"
+                }
+            }
+        ]
+    }); "valid single value allOf"
+}]
+#[test_case{
+    &json!({"allOf": [{"type": "array"}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/allOf/0/type",
+                "instanceLocation": "",
+                "error": "\"some string\" is not of type \"array\""
+            }
+        ]
+    }); "invalid single value allOf"
+}]
+#[test_case{
+    &json!({"anyOf": [{"type": "string", "someannotation": "value"}, {"maxLength": 4}, {"minLength": 1}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/anyOf/0",
+                "instanceLocation": "",
+                "annotations": {
+                    "someannotation": "value"
+                }
+            }
+        ]
+    }); "valid anyOf"
+}]
+#[test_case{
+    &json!({"anyOf": [{"type": "object"}, {"maxLength": 4}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/anyOf/0/type",
+                "instanceLocation": "",
+                "error": "\"some string\" is not of type \"object\""
+            },
+            {
+                "keywordLocation": "/anyOf/1/maxLength",
+                "instanceLocation": "",
+                "error": "\"some string\" is longer than 4 characters"
+            }
+        ]
+    }); "invalid anyOf"
+}]
+#[test_case{
+    &json!({"oneOf": [{"type": "object", "someannotation": "somevalue"}, {"type": "string"}]}),
+    &json!{{"somekey": "some value"}},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/oneOf/0",
+                "instanceLocation": "",
+                "annotations": {
+                    "someannotation": "somevalue"
+                }
+            }
+        ]
+    }); "valid oneOf"
+}]
+#[test_case{
+    &json!({"oneOf": [{"type": "object"}, {"maxLength": 4}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/oneOf/0/type",
+                "instanceLocation": "",
+                "error": "\"some string\" is not of type \"object\""
+            },
+            {
+                "keywordLocation": "/oneOf/1/maxLength",
+                "instanceLocation": "",
+                "error": "\"some string\" is longer than 4 characters"
+            }
+        ]
+    }); "invalid oneOf"
+}]
+#[test_case{
+    &json!({"oneOf": [{"type": "string"}, {"maxLength": 40}]}),
+    &json!{"some string"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/oneOf",
+                "instanceLocation": "",
+                "error": "more than one subschema succeeded"
+            },
+        ]
+    }); "invalid oneOf multiple successes"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "then": {"maxLength": 20, "thenannotation": "thenvalue"}
+    }),
+    &json!{"some string"},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/if",
+                "instanceLocation": "",
+                "annotations": {
+                    "ifannotation": "ifvalue"
+                }
+            },
+            {
+                "keywordLocation": "/then",
+                "instanceLocation": "",
+                "annotations": {
+                    "thenannotation": "thenvalue"
+                }
+            },
+        ]
+    }); "valid if-then"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "then": {"maxLength": 4, "thenannotation": "thenvalue"}
+    }),
+    &json!{"some string"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/then/maxLength",
+                "instanceLocation": "",
+                "error": "\"some string\" is longer than 4 characters"
+            },
+        ]
+    }); "invalid if-then"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "object", "ifannotation": "ifvalue"},
+        "else": {"maxLength": 20, "elseannotation": "elsevalue"}
+    }),
+    &json!{"some string"},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/else",
+                "instanceLocation": "",
+                "annotations": {
+                    "elseannotation": "elsevalue"
+                }
+            },
+        ]
+    }); "valid if-else"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "else": {"type": "array", "elseannotation": "elsevalue"}
+    }),
+    &json!{{"some": "object"}},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/else/type",
+                "instanceLocation": "",
+                "error": "{\"some\":\"object\"} is not of type \"array\""
+            },
+        ]
+    }); "invalid if-else"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "then": {"maxLength": 20, "thenannotation": "thenvalue"},
+        "else": {"type": "number", "elseannotation": "elsevalue"}
+    }),
+    &json!{"some string"},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/if",
+                "instanceLocation": "",
+                "annotations": {
+                    "ifannotation": "ifvalue"
+                }
+            },
+            {
+                "keywordLocation": "/then",
+                "instanceLocation": "",
+                "annotations": {
+                    "thenannotation": "thenvalue"
+                }
+            },
+        ]
+    }); "valid if-then-else then-branch"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "then": {"maxLength": 20, "thenannotation": "thenvalue"},
+        "else": {"type": "number", "elseannotation": "elsevalue"}
+    }),
+    &json!{12},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/else",
+                "instanceLocation": "",
+                "annotations": {
+                    "elseannotation": "elsevalue"
+                }
+            },
+        ]
+    }); "valid if-then-else else-branch"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "then": {"maxLength": 4, "thenannotation": "thenvalue"},
+        "else": {"type": "number", "elseannotation": "elsevalue"}
+    }),
+    &json!{"12345"},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/then/maxLength",
+                "instanceLocation": "",
+                "error": "\"12345\" is longer than 4 characters"
+            },
+        ] }); "invalid if-then-else then branch"
+}]
+#[test_case{
+    &json!({
+        "if": {"type": "string", "ifannotation": "ifvalue"},
+        "then": {"maxLength": 20, "thenannotation": "thenvalue"},
+        "else": {"type": "number", "elseannotation": "elsevalue"}
+    }),
+    &json!{{"some": "object"}},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/else/type",
+                "instanceLocation": "",
+                "error": "{\"some\":\"object\"} is not of type \"number\""
+            },
+        ]
+    }); "invalid if-then-else else branch"
+}]
+#[test_case{
+    &json!({
+        "type": "array",
+        "items": {
+            "type": "number",
+            "annotation": "value"
+        }
+    }),
+    &json!{[1,2]},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/items",
+                "instanceLocation": "",
+                "annotations": true
+            },
+            {
+                "keywordLocation": "/items",
+                "instanceLocation": "/0",
+                "annotations": {
+                    "annotation": "value"
+                }
+            },
+            {
+                "keywordLocation": "/items",
+                "instanceLocation": "/1",
+                "annotations": {
+                    "annotation": "value"
+                }
+            },
+        ]
+    }); "valid items"
+}]
+#[test_case{
+    &json!({
+        "type": "array",
+        "items": {
+            "type": "number",
+            "annotation": "value"
+        }
+    }),
+    &json!{[]},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/items",
+                "instanceLocation": "",
+                "annotations": false
+            },
+        ]
+    }); "valid items empty array"
+}]
+#[test_case{
+    &json!({
+        "type": "array",
+        "items": {
+            "type": "string",
+            "annotation": "value"
+        }
+    }),
+    &json!{[1,2,"3"]},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/items/type",
+                "instanceLocation": "/0",
+                "error": "1 is not of type \"string\""
+            },
+            {
+                "keywordLocation": "/items/type",
+                "instanceLocation": "/1",
+                "error": "2 is not of type \"string\""
+            },
+        ]
+    }); "invalid items"
+}]
+#[test_case{
+    &json!({
+        "contains": {
+            "type": "number",
+            "annotation": "value",
+            "maximum": 2
+        }
+    }),
+    &json!{[1,3,2]},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/contains",
+                "instanceLocation": "",
+                "annotations": [0, 2]
+            },
+            {
+                "keywordLocation": "/contains",
+                "instanceLocation": "/0",
+                "annotations": {
+                    "annotation": "value"
+                }
+            },
+            {
+                "keywordLocation": "/contains",
+                "instanceLocation": "/2",
+                "annotations": {
+                    "annotation": "value"
+                }
+            }
+        ]
+    }); "valid contains"
+}]
+#[test_case{
+    &json!({
+        "contains": {
+            "type": "number",
+            "annotation": "value",
+            "maximum": 2
+        }
+    }),
+    &json!{["one"]},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/contains",
+                "instanceLocation": "",
+                "error": "None of [\"one\"] are valid under the given schema",
+            },
+        ]
+    }); "invalid contains"
+}]
+#[test_case{
+    &json!({
+        "properties": {
+            "name": {"type": "string", "some": "subannotation"},
+            "age": {"type": "number"}
+        }
+    }),
+    &json!{{
+        "name": "some name",
+        "age": 10
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/properties",
+                "instanceLocation": "",
+                "annotations": [
+                    "age",
+                    "name"
+                ]
+            },
+            {
+                "keywordLocation": "/properties/name",
+                "instanceLocation": "/name",
+                "annotations": {
+                    "some": "subannotation"
+                }
+            }
+        ]
+    }); "valid properties"
+}]
+#[test_case{
+    &json!({
+        "patternProperties": {
+            "numProp(\\d+)": {"type": "number", "some": "subannotation"},
+            "stringProp(\\d+)": {"type": "string"},
+            "unmatchedProp\\S": {"type": "object"},
+        }
+    }),
+    &json!{{
+        "numProp1": 1,
+        "numProp2": 2,
+        "stringProp1": "1"
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/patternProperties",
+                "instanceLocation": "",
+                "annotations": [
+                    "numProp1",
+                    "numProp2",
+                    "stringProp1"
+                ]
+            },
+            {
+                "keywordLocation": "/patternProperties/numProp(\\d+)",
+                "instanceLocation": "/numProp1",
+                "annotations": {
+                    "some": "subannotation"
+                }
+            },
+            {
+                "keywordLocation": "/patternProperties/numProp(\\d+)",
+                "instanceLocation": "/numProp2",
+                "annotations": {
+                    "some": "subannotation"
+                }
+            }
+        ]
+    }); "valid patternProperties"
+}]
+#[test_case{
+    &json!({
+        "patternProperties": {
+            "numProp(\\d+)": {"type": "number", "some": "subannotation"}
+        }
+    }),
+    &json!{{
+        "numProp1": 1,
+        "numProp2": 2,
+        "stringProp1": "1"
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/patternProperties",
+                "instanceLocation": "",
+                "annotations": [
+                    "numProp1",
+                    "numProp2",
+                ]
+            },
+            {
+                "keywordLocation": "/patternProperties/numProp(\\d+)",
+                "instanceLocation": "/numProp1",
+                "annotations": {
+                    "some": "subannotation"
+                }
+            },
+            {
+                "keywordLocation": "/patternProperties/numProp(\\d+)",
+                "instanceLocation": "/numProp2",
+                "annotations": {
+                    "some": "subannotation"
+                }
+            }
+        ]
+    }); "valid single value patternProperties"
+}]
+#[test_case{
+    &json!({
+        "propertyNames": {"maxLength": 10, "some": "annotation"}
+    }),
+    &json!{{
+        "name": "some name",
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/propertyNames",
+                "instanceLocation": "",
+                "annotations": {"some": "annotation"}
+            },
+        ]
+    }); "valid propertyNames"
+}]
+fn test_basic_output(
+    schema_json: &serde_json::Value,
+    instance: &serde_json::Value,
+    expected_output: &serde_json::Value,
+) {
+    let schema = JSONSchema::options().compile(schema_json).unwrap();
+    let output_json = serde_json::to_value(schema.apply(instance).basic()).unwrap();
+    assert_eq!(&output_json, expected_output);
+}
+
+/// These tests are separated from the rest of the basic output tests for convenience, there's
+/// nothing different about them but they are all tests of the additionalProperties keyword, which
+/// is complicated by the fact that there are eight different implementations based on the
+/// interaction between the properties, patternProperties, and additionalProperties keywords.
+/// Specifically there are these implementations:
+///
+/// - AdditionalPropertiesValidator
+/// - AdditionalPropertiesFalseValidator
+/// - AdditionalPropertiesNotEmptyFalseValidator
+/// - AdditionalPropertiesNotEmptyValidator
+/// - AdditionalPropertiesWithPatternsValidator
+/// - AdditionalPropertiesWithPatternsFalseValidator
+/// - AdditionalPropertiesWithPatternsNotEmptyValidator
+/// - AdditionalPropertiesWithPatternsNotEmptyFalseValidator
+///
+/// For each of these we need two test cases, one for errors and one for annotations
+#[test_case{
+    &json!({
+        "additionalProperties": {"type": "number" }
+    }),
+    &json!{{
+        "name": "somename",
+        "otherprop": "one"
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties/type",
+                "instanceLocation": "/name",
+                "error": "\"somename\" is not of type \"number\""
+            },
+            {
+                "keywordLocation": "/additionalProperties/type",
+                "instanceLocation": "/otherprop",
+                "error": "\"one\" is not of type \"number\""
+            },
+        ]
+    }); "invalid AdditionalPropertiesValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": {"type": "number", "some": "annotation" }
+    }),
+    &json!{{
+        "name": 1,
+        "otherprop": 2
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "annotations": ["name", "otherprop"]
+            },
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "/name",
+                "annotations": {
+                    "some": "annotation"
+                }
+            },
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "/otherprop",
+                "annotations": {
+                    "some": "annotation"
+                }
+            },
+        ]
+    }); "valid AdditionalPropertiesValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": false
+    }),
+    &json!{{
+        "name": "somename",
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "error": "False schema does not allow \"somename\""
+            },
+        ]
+    }); "invalid AdditionalPropertiesFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": false
+    }),
+    &json!{{}},
+    &json!({
+        "valid": true,
+        "annotations": []
+    }); "valid AdditionalPropertiesFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": false,
+        "properties": {
+            "name": {"type": "string", "prop": "annotation"}
+        }
+    }),
+    &json!{{
+        "name": "somename",
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/properties/name",
+                "instanceLocation": "/name",
+                "annotations": {"prop": "annotation"}
+            }
+        ]
+    }); "valid AdditionalPropertiesNotEmptyFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": false,
+        "properties": {
+            "name": {"type": "string", "prop": "annotation"}
+        }
+    }),
+    &json!{{
+        "name": "somename",
+        "other": "prop"
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "error": "Additional properties are not allowed ('other' was unexpected)"
+            }
+        ]
+    }); "invalid AdditionalPropertiesNotEmptyFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": {"type": "integer", "other": "annotation"},
+        "properties": {
+            "name": {"type": "string", "prop": "annotation"}
+        }
+    }),
+    &json!{{
+        "name": "somename",
+        "otherprop": 1
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "annotations": ["otherprop"]
+            },
+            {
+                "keywordLocation": "/properties/name",
+                "instanceLocation": "/name",
+                "annotations": {"prop": "annotation"}
+            },
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "/otherprop",
+                "annotations": {"other": "annotation"}
+            }
+        ]
+    }); "valid AdditionalPropertiesNotEmptyValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": {"type": "integer", "other": "annotation"},
+        "properties": {
+            "name": {"type": "string", "prop": "annotation"}
+        }
+    }),
+    &json!{{
+        "name": "somename",
+        "otherprop": "one"
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties/type",
+                "instanceLocation": "/otherprop",
+                "error": "\"one\" is not of type \"integer\""
+            },
+        ]
+    }); "invalid AdditionalPropertiesNotEmptyValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": {"type": "string", "other": "annotation"},
+        "patternProperties": {
+            "^x-": {"type": "integer", "minimum": 5, "patternio": "annotation"},
+        }
+    }),
+    &json!{{
+        "otherprop": "one",
+        "x-foo": 7
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "annotations": ["otherprop"]
+            },
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "/otherprop",
+                "annotations": {"other": "annotation"}
+            },
+            {
+                "keywordLocation": "/patternProperties/^x-",
+                "instanceLocation": "/x-foo",
+                "annotations": {"patternio": "annotation"}
+            },
+            {
+                "keywordLocation": "/patternProperties",
+                "instanceLocation": "",
+                "annotations": ["x-foo"]
+            }
+        ]
+    }); "valid AdditionalPropertiesWithPatternsValidator"
+}]
+#[test_case{
+    &json!({
+        "additionalProperties": {"type": "string" },
+        "patternProperties": {
+            "^x-": {"type": "integer", "minimum": 5 },
+        }
+    }),
+    &json!{{
+        "otherprop":1,
+        "x-foo": 3
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties/type",
+                "instanceLocation": "/otherprop",
+                "error": "1 is not of type \"string\""
+            },
+            {
+                "keywordLocation": "/patternProperties/^x-/minimum",
+                "instanceLocation": "/x-foo",
+                "error": "3 is less than the minimum of 5"
+            },
+        ]
+    }); "invalid AdditionalPropertiesWithPatternsValidator"
+}]
+#[test_case{
+    &json!({
+        "properties": {
+            "name": {"type": "string"}
+        },
+        "patternProperties": {
+            "stringProp(\\d+)": {"type": "string" }
+        },
+        "additionalProperties": {"type": "number" }
+    }),
+    &json!{{
+        "name": "somename",
+        "otherprop": "one"
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties/type",
+                "instanceLocation": "/otherprop",
+                "error": "\"one\" is not of type \"number\""
+            },
+        ]
+    }); "invalid AdditionalPropertiesWithPatternsNotEmptyValidator"
+}]
+#[test_case{
+    &json!({
+        "properties": {
+            "name": {"type": "string"}
+        },
+        "patternProperties": {
+            "stringProp(\\d+)": {"type": "string" }
+        },
+        "additionalProperties": {"type": "number" }
+    }),
+    &json!{{
+        "name": "somename",
+        "otherprop": 1
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "annotations": ["otherprop"]
+            }
+        ]
+    }); "valid AdditionalPropertiesWithPatternsNotEmptyValidator"
+}]
+#[test_case{
+    &json!({
+        "properties": {
+            "name": {"type": "string", "prop": "annotation"}
+        },
+        "patternProperties": {
+            "stringProp(\\d+)": {"type": "string" }
+        },
+        "additionalProperties": false
+    }),
+    &json!{{
+        "name": "somename",
+        "stringProp1": "one"
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/properties/name",
+                "instanceLocation": "/name",
+                "annotations": {
+                    "prop": "annotation"
+                }
+            }
+        ]
+    }); "valid AdditionalPropertiesWithPatternsNotEmptyFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "properties": {
+            "name": {"type": "string", "prop": "annotation"}
+        },
+        "patternProperties": {
+            "stringProp(\\d+)": {"type": "string" }
+        },
+        "additionalProperties": false
+    }),
+    &json!{{
+        "name": "somename",
+        "stringProp1": "one",
+        "otherprop": "something"
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "error": "Additional properties are not allowed ('otherprop' was unexpected)"
+            }
+        ]
+    }); "invalid AdditionalPropertiesWithPatternsNotEmptyFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "patternProperties": {
+            "stringProp(\\d+)": {"type": "string", "some": "annotation"}
+        },
+        "additionalProperties": false
+    }),
+    &json!{{
+        "stringProp1": "one",
+    }},
+    &json!({
+        "valid": true,
+        "annotations": [
+            {
+                "keywordLocation": "/patternProperties/stringProp(\\d+)",
+                "instanceLocation": "/stringProp1",
+                "annotations": {
+                    "some": "annotation"
+                }
+            },
+            {
+                "keywordLocation": "/patternProperties",
+                "instanceLocation": "",
+                "annotations": ["stringProp1"]
+            },
+        ]
+    }); "valid AdditionalPropertiesWithPatternsFalseValidator"
+}]
+#[test_case{
+    &json!({
+        "patternProperties": {
+            "stringProp(\\d+)": {"type": "string" }
+        },
+        "additionalProperties": false
+    }),
+    &json!{{
+        "stringProp1": "one",
+        "otherprop": "something"
+    }},
+    &json!({
+        "valid": false,
+        "errors": [
+            {
+                "keywordLocation": "/additionalProperties",
+                "instanceLocation": "",
+                "error": "Additional properties are not allowed ('otherprop' was unexpected)"
+            }
+        ]
+    }); "invalid AdditionalPropertiesWithPatternsFalseValidator"
+}]
+fn test_additional_properties_basic_output(
+    schema_json: &serde_json::Value,
+    instance: &serde_json::Value,
+    expected_output: &serde_json::Value,
+) {
+    let schema = JSONSchema::options().compile(schema_json).unwrap();
+    let output_json = serde_json::to_value(schema.apply(instance).basic()).unwrap();
+    if &output_json != expected_output {
+        let expected_str = serde_json::to_string_pretty(expected_output).unwrap();
+        let actual_str = serde_json::to_string_pretty(&output_json).unwrap();
+        panic!("\nExpected:\n{}\n\nGot:\n{}\n", expected_str, actual_str);
+    }
+}


### PR DESCRIPTION
The 2020-12 spec specifies a few things that are relevant for this PR.

- A "basic" output format which specifies how errors and annotations from failing or successful validations respectively should be structured
- A detailed specification of what annotations should be produced by "applicator" keywords - which are effectively control flow operators such as `oneOf`
- Explicitly specifying that unknown keywords must be retained and made available as annotations. For example the schema `{"name": "string","character": "narrator"}` must produce the annotation `{"character":"annotation"}`

This has implications which have led to the changes in this PR. Most importantly, we must collect unmatched keywords and store them in the validator tree so we can later produce annotations based on them. This has led me to introduce the `SchemaNode` struct, which replaces the `type Validators = Vec<Box<dyn Validator>>` type alias we were using to represent nodes in the schema tree previously.

Secondly, the `validate` method only returns errors. Rather than modifying that API and introducing severe breakage for existing clients I have introduced another method on the `Validate` trait called `apply`, which returns a data structure which can be turned into a `BasicOutput`, which in turn implements `serde::Serialize` in a manner conforming to the basic output format of the spec.

## `SchemaNode`

`SchemaNode` can be found in `src/schema_node.rs` and looks like this:

```rust
pub(crate) struct SchemaNode {
    validators: NodeValidators,
    relative_path: JSONPointer,
    absolute_path: Option<AbsolutePath>,
}
```

The `NodeValidators` enum captures the different contexts in which we create a node in the validator tree, see the docs for more information on that. In particular `NodeValidators` is where we store any unmatched keywords. We also record the relative and possible absolute path of the `Node` for use in producing the output formats.

We are able to implement `Validate` for `SchemaNode`.


## `Validate::apply`

We add the `apply` method which returns an output format including any annotations the validator may want to add. This may at first seem like it would require us to implement `apply` for _all_ of the existing keywords. However, this is unnecessary due to the introduction of the `SchemaNode` struct. Any applicator keywords have references to `SchemaNode`s containing their children, rather than directly to the child `Validate`s, this means that we can add a default implementation of `apply` in terms of `validate` and the `apply` implementation on `SchemaNode` takes care of adding annotations from unmatched keywords. This means that we must only implement `apply` for applicator keywords, which reduces the work somewhat.

Currently the implementation of `apply` for most keywords is very similar to the implementation of `validate`. It would be possible to reimplement `validate` in terms of `apply` for applicator keywords to reduce this duplication but I think that this is likely to have serious performance implications. To achieve good performance here I think we may need to look at using an arena allocator like `bumpalo` for collecting annotations and errors.

Note that there are extensive tests for the output formats in `tests/output.rs`

# Performance

Unfortunately introducing the `SchemaNode` does introduce some overhead. For `is_valid` this overhead is very low. Most benchmarks increased by less than 10 nanoseconds. I investigated this in detail and the generated assembly does include quite a few more instructions just for dereferencing the the additional data structures involved. I've managed to remove some of this for cases where a `SchemaNode` only has one child - which is the common case. I think increases of less than 10ns are acceptable.

`validate` unfortunately is significantly more affected. This is due to additional allocations which are necessary to make the lifetimes of `validate` match up when returning from `SchemaNode` - which wasn't a problem when were directly iterating over `Validators` before. As with the code duplication problem I think that the way to solve this is probably to investigate using an arena allocator.

I've attached before and after criterion baselines, but the top level performance changes are as follows:

| Benchmark Category | Fractional Change |
--|--|
| `validate` | 66% |
| `compile`  | 8%  |
| `is_valid` | 14% |

Note that if we exclude benchmarks which changed by less than 10ns we get

| Benchmark Category | Fractional Change |
--|--|
| `validate` | 66% |
| `compile`  | 8%  |
| `is_valid` | 9%  |

With several `is_valid` benchmarks actually decreasing (most of the format related ones). In fact, the only `is_valid` benchmarks which increased by more than 10ns are:

| Benchmark                      | Change % | Increased by |
---|---|---|
| jsonschema-rs CITM is_valid    | 4%       | 42µs         |
| jsonschema-rs geojson is_valid | 3%       | 52µs         |
| jsonschema-rs openapi is_valid | 9%       | 700µs        |
| jsonschema-rs swagger is_valid | 10%      | 700µs        |


I've looked into these a little and timings seem dominated by drop implementations. Regardless, these seem like acceptable numbers to me in return for supporting the basic output format. I also think performance can be improved back to the original number but I don't want to introduce an even larger change than this already large PR.

[baselines.zip](https://github.com/Stranger6667/jsonschema-rs/files/6983914/baselines.zip)

