### PR TITLE
Disable format validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `uuid` format validator. [#266](https://github.com/Stranger6667/jsonschema-rs/issues/266)
 - `duration` format validator. [#265](https://github.com/Stranger6667/jsonschema-rs/issues/265)
 - Collect annotations whilst evaulating schemas.[#262](https://github.com/Stranger6667/jsonschema-rs/issues/262)
+- Option to turn off processing of the `format` keyword. [#261](https://github.com/Stranger6667/jsonschema-rs/issues/261)
 - `basic` & `flag` output formatting styles. [#100](https://github.com/Stranger6667/jsonschema-rs/issues/100)
 
 ### Changed

--- a/jsonschema-test-suite/README.md
+++ b/jsonschema-test-suite/README.md
@@ -11,7 +11,7 @@ described by [JSON-Schema-Test-Suite](https://github.com/json-schema-org/JSON-Sc
 The main objective is to ensure that for each test a mock server is started and will be able to
 capture all the requests, ensuring that tests can be ran only interacting with `cargo test`
 
-In order to ude the procedural macro attribute there are few assumptions that are made:
+In order to use the procedural macro attribute there are few assumptions that are made:
 
 * [`lazy_static`](https://crates.io/crates/lazy_static) dependency is added into your `[dev-dependencies]`
   section of the `Cargo.toml` file

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -135,6 +135,7 @@ pub struct CompilationOptions {
         AHashMap<&'static str, Option<(ContentEncodingCheckType, ContentEncodingConverterType)>>,
     store: AHashMap<String, Arc<serde_json::Value>>,
     formats: AHashMap<&'static str, fn(&str) -> bool>,
+    validate_formats: Option<bool>,
     validate_schema: bool,
 }
 
@@ -147,6 +148,7 @@ impl Default for CompilationOptions {
             content_encoding_checks_and_converters: AHashMap::default(),
             store: AHashMap::default(),
             formats: AHashMap::default(),
+            validate_formats: None,
         }
     }
 }
@@ -459,6 +461,18 @@ impl CompilationOptions {
     pub(crate) fn without_schema_validation(&mut self) -> &mut Self {
         self.validate_schema = false;
         self
+    }
+    #[inline]
+    /// Force enable or disable format validation.
+    /// The default behavior is dependent on draft version, but the default behavior can be
+    /// overridden to validate or not regardless of draft.
+    pub fn should_validate_formats(&mut self, validate_formats: bool) -> &mut Self {
+        self.validate_formats = Some(validate_formats);
+        self
+    }
+    pub(crate) fn validate_formats(&self) -> bool {
+        self.validate_formats
+            .unwrap_or_else(|| self.draft().validate_formats_by_default())
     }
 }
 // format name & a pointer to a check function

--- a/jsonschema/src/schemas.rs
+++ b/jsonschema/src/schemas.rs
@@ -22,6 +22,16 @@ impl Default for Draft {
     }
 }
 
+impl Draft {
+    pub(crate) const fn validate_formats_by_default(self) -> bool {
+        match self {
+            Draft::Draft4 | Draft::Draft6 | Draft::Draft7 => true,
+            #[cfg(feature = "draft201909")]
+            Draft::Draft201909 => false,
+        }
+    }
+}
+
 type CompileFunc<'a> = fn(
     &'a Map<String, Value>,
     &'a Value,

--- a/jsonschema/tests/test_suite.rs
+++ b/jsonschema/tests/test_suite.rs
@@ -51,6 +51,7 @@ fn test_draft(_server_address: &str, test_case: TestCase) {
     let compiled = JSONSchema::options()
         .with_draft(draft_version)
         .with_meta_schemas()
+        .should_validate_formats(true)
         .compile(&test_case.schema)
         .unwrap();
 


### PR DESCRIPTION
Prior to draft versions 2019-09, format validation is enabled by default (though should be able to be disabled), and vice versa afterword. This patch adds `should_validate_formats` to CompilationOptions to force the option one way or another.

If not specified, it will fallback to a default based on the draft version (enabled by default before draft 2019-09).

I also rolled a small typo fix into this PR in a separate commit, let me know if you'd like me to squash the commits, or if you'd like that as a separate PR, or something else.

Closes #261