### PR TITLE
fix: convert python tuples into lists

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 - Set `jsonschema_rs.JSONSchema.__module__` to `jsonschema_rs`.
+- Convert tuples into lists for validation to fix `ValueError: Unsupported type: 'tuple'`
 
 ### Performance
 

--- a/bindings/python/src/ser.rs
+++ b/bindings/python/src/ser.rs
@@ -149,16 +149,11 @@ impl Serialize for SerializePyObject {
                     map.end()
                 }
             }
-            ObjectType::Tuple | ObjectType::List => {
+            ObjectType::List => {
                 if self.recursion_depth == RECURSION_LIMIT {
                     return Err(ser::Error::custom("Recursion limit reached"));
                 }
-
-                let length = match self.object_type {
-                    ObjectType::Tuple => unsafe { PyTuple_GET_SIZE(self.object) as usize },
-                    ObjectType::List => unsafe { PyList_GET_SIZE(self.object) as usize },
-                    _ => return Err(ser::Error::custom("Object is not a list or tuple")),
-                };
+                let length = unsafe { PyList_GET_SIZE(self.object) as usize };
                 if length == 0 {
                     serializer.serialize_seq(Some(0))?.end()
                 } else {
@@ -166,13 +161,35 @@ impl Serialize for SerializePyObject {
                     let mut ob_type = ObjectType::Str;
                     let mut sequence = serializer.serialize_seq(Some(length))?;
                     for i in 0..length {
-                        let elem = match self.object_type {
-                            ObjectType::Tuple => unsafe {
-                                PyTuple_GET_ITEM(self.object, i as isize)
-                            },
-                            ObjectType::List => unsafe { PyList_GET_ITEM(self.object, i as isize) },
-                            _ => return Err(ser::Error::custom("Object is not a list or tuple")),
-                        };
+                        let elem = unsafe { PyList_GET_ITEM(self.object, i as isize) };
+                        let current_ob_type = unsafe { Py_TYPE(elem) };
+                        if current_ob_type != type_ptr {
+                            type_ptr = current_ob_type;
+                            ob_type = get_object_type(current_ob_type);
+                        }
+                        #[allow(clippy::integer_arithmetic)]
+                        sequence.serialize_element(&SerializePyObject::with_obtype(
+                            elem,
+                            ob_type.clone(),
+                            self.recursion_depth + 1,
+                        ))?;
+                    }
+                    sequence.end()
+                }
+            }
+            ObjectType::Tuple => {
+                if self.recursion_depth == RECURSION_LIMIT {
+                    return Err(ser::Error::custom("Recursion limit reached"));
+                }
+                let length = unsafe { PyTuple_GET_SIZE(self.object) as usize };
+                if length == 0 {
+                    serializer.serialize_seq(Some(0))?.end()
+                } else {
+                    let mut type_ptr = std::ptr::null_mut();
+                    let mut ob_type = ObjectType::Str;
+                    let mut sequence = serializer.serialize_seq(Some(length))?;
+                    for i in 0..length {
+                        let elem = unsafe { PyTuple_GET_ITEM(self.object, i as isize) };
                         let current_ob_type = unsafe { Py_TYPE(elem) };
                         if current_ob_type != type_ptr {
                             type_ptr = current_ob_type;

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -1,6 +1,6 @@
 use pyo3::ffi::{
     PyDict_New, PyFloat_FromDouble, PyList_New, PyLong_FromLongLong, PyTypeObject, PyUnicode_New,
-    Py_None, Py_TYPE, Py_True,
+    Py_None, Py_TYPE, Py_True, PyTuple_New
 };
 use std::sync::Once;
 
@@ -13,6 +13,7 @@ pub static mut NONE_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut FLOAT_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut LIST_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 pub static mut DICT_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
+pub static mut TUPLE_TYPE: *mut PyTypeObject = 0 as *mut PyTypeObject;
 
 static INIT: Once = Once::new();
 
@@ -24,6 +25,7 @@ pub fn init() {
         TRUE = Py_True();
         STR_TYPE = Py_TYPE(PyUnicode_New(0, 255));
         DICT_TYPE = Py_TYPE(PyDict_New());
+        TUPLE_TYPE = Py_TYPE(PyTuple_New(1));
         LIST_TYPE = Py_TYPE(PyList_New(0_isize));
         NONE_TYPE = Py_TYPE(Py_None());
         BOOL_TYPE = Py_TYPE(TRUE);

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -1,6 +1,6 @@
 use pyo3::ffi::{
-    PyDict_New, PyFloat_FromDouble, PyList_New, PyLong_FromLongLong, PyTypeObject, PyUnicode_New,
-    Py_None, Py_TYPE, Py_True, PyTuple_New
+    PyDict_New, PyFloat_FromDouble, PyList_New, PyLong_FromLongLong, PyTuple_New, PyTypeObject,
+    PyUnicode_New, Py_None, Py_TYPE, Py_True,
 };
 use std::sync::Once;
 

--- a/bindings/python/src/types.rs
+++ b/bindings/python/src/types.rs
@@ -25,7 +25,7 @@ pub fn init() {
         TRUE = Py_True();
         STR_TYPE = Py_TYPE(PyUnicode_New(0, 255));
         DICT_TYPE = Py_TYPE(PyDict_New());
-        TUPLE_TYPE = Py_TYPE(PyTuple_New(1));
+        TUPLE_TYPE = Py_TYPE(PyTuple_New(0_isize));
         LIST_TYPE = Py_TYPE(PyList_New(0_isize));
         NONE_TYPE = Py_TYPE(Py_None());
         BOOL_TYPE = Py_TYPE(TRUE);

--- a/bindings/python/tests-py/test_jsonschema.py
+++ b/bindings/python/tests-py/test_jsonschema.py
@@ -1,3 +1,4 @@
+from collections import namedtuple
 from contextlib import suppress
 from functools import partial
 
@@ -85,6 +86,14 @@ def test_array_tuple_invalid(val):
     schema = {"type": "array", "items": {"type": "string"}}
     with pytest.raises(ValueError):
         validate(schema, val)
+
+
+def test_named_tuple():
+    Person = namedtuple("Person", "first_name last_name")
+    person_a = Person("Joe", "Smith")
+    schema = {"type": "array", "items": {"type": "string"}}
+    with pytest.raises(ValueError):
+        validate(schema, person_a)
 
 
 def test_recursive_dict():

--- a/bindings/python/tests-py/test_jsonschema.py
+++ b/bindings/python/tests-py/test_jsonschema.py
@@ -65,10 +65,26 @@ def test_from_str_error():
         JSONSchema.from_str(42)
 
 
-def test_tuple():
-    schema = {"properties": {"foo": {"type": "array"}}}
-    instance = {"foo": (1, 2, 3)}
-    assert is_valid(instance, schema) == True
+@pytest.mark.parametrize(
+    "val",
+    (
+        ("A", "B", "C"),
+        ["A", "B", "C"],
+    ),
+)
+def test_array_tuple(val):
+    schema = {"type": "array", "items": {"type": "string"}}
+    validate(schema, val)
+
+
+@pytest.mark.parametrize(
+    "val",
+    ((1, 2, 3), [1, 2, 3], {"foo": 1}),
+)
+def test_array_tuple_invalid(val):
+    schema = {"type": "array", "items": {"type": "string"}}
+    with pytest.raises(ValueError):
+        validate(schema, val)
 
 
 def test_recursive_dict():

--- a/bindings/python/tests-py/test_jsonschema.py
+++ b/bindings/python/tests-py/test_jsonschema.py
@@ -65,6 +65,12 @@ def test_from_str_error():
         JSONSchema.from_str(42)
 
 
+def test_tuple():
+    schema = {"properties": {"foo": {"type": "array"}}}
+    instance = {"foo": (1, 2, 3)}
+    assert is_valid(instance, schema) == True
+
+
 def test_recursive_dict():
     instance = {}
     instance["foo"] = instance


### PR DESCRIPTION
We use tuples for geographic coordinates and bounding boxes which doesn't seem to have a direct mapping in JSON Schema.

This pull requests converts the tuple into a list to fix `ValueError: Unsupported type: 'tuple'` when validating a object that contains a tuple.

```
{ "bbox": (1,2,3,4) }
```

