### PR TITLE
Remove `schema`  from the `Validate` trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove unused private field in `JSONSchema`, that lead to improvement in the compilation performance.
 - Optimize the `multipleOf` implementation, which now can short-circuit in some cases.
 - Add special cases for arrays with 2 and 3 items in the `uniqueItems` keyword implementation.
+- Remove the `schema` argument from all methods of the `Validate` trait.
 
 ## [0.13.2] - 2021-11-04
 

--- a/jsonschema/src/keywords/additional_items.rs
+++ b/jsonschema/src/keywords/additional_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, context::CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext},
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{boolean::FalseValidator, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -28,12 +28,12 @@ impl AdditionalItemsObjectValidator {
     }
 }
 impl Validate for AdditionalItemsObjectValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             items
                 .iter()
                 .skip(self.items_count)
-                .all(|item| self.node.is_valid(schema, item))
+                .all(|item| self.node.is_valid(item))
         } else {
             true
         }
@@ -42,7 +42,6 @@ impl Validate for AdditionalItemsObjectValidator {
     #[allow(clippy::needless_collect)]
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -51,7 +50,7 @@ impl Validate for AdditionalItemsObjectValidator {
                 .iter()
                 .enumerate()
                 .skip(self.items_count)
-                .flat_map(|(idx, item)| self.node.validate(schema, item, &instance_path.push(idx)))
+                .flat_map(|(idx, item)| self.node.validate(item, &instance_path.push(idx)))
                 .collect();
             Box::new(errors.into_iter())
         } else {
@@ -87,7 +86,7 @@ impl AdditionalItemsBooleanValidator {
     }
 }
 impl Validate for AdditionalItemsBooleanValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             if items.len() > self.items_count {
                 return false;
@@ -98,7 +97,6 @@ impl Validate for AdditionalItemsBooleanValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/all_of.rs
+++ b/jsonschema/src/keywords/all_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, context::CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext},
     error::{ErrorIterator, ValidationError},
     output::BasicOutput,
     paths::{InstancePath, JSONPointer},
@@ -33,34 +33,32 @@ impl AllOfValidator {
 }
 
 impl Validate for AllOfValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        self.schemas.iter().all(|n| n.is_valid(schema, instance))
+    fn is_valid(&self, instance: &Value) -> bool {
+        self.schemas.iter().all(|n| n.is_valid(instance))
     }
 
     #[allow(clippy::needless_collect)]
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
         let errors: Vec<_> = self
             .schemas
             .iter()
-            .flat_map(move |node| node.validate(schema, instance, instance_path))
+            .flat_map(move |node| node.validate(instance, instance_path))
             .collect();
         Box::new(errors.into_iter())
     }
 
     fn apply<'a>(
         &'a self,
-        schema: &JSONSchema,
         instance: &Value,
         instance_path: &InstancePath,
     ) -> PartialApplication<'a> {
         self.schemas
             .iter()
-            .map(move |node| node.apply_rooted(schema, instance, instance_path))
+            .map(move |node| node.apply_rooted(instance, instance_path))
             .sum::<BasicOutput<'_>>()
             .into()
     }
@@ -93,28 +91,24 @@ impl SingleValueAllOfValidator {
 }
 
 impl Validate for SingleValueAllOfValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        self.node.is_valid(schema, instance)
+    fn is_valid(&self, instance: &Value) -> bool {
+        self.node.is_valid(instance)
     }
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        self.node.validate(schema, instance, instance_path)
+        self.node.validate(instance, instance_path)
     }
 
     fn apply<'a>(
         &'a self,
-        schema: &JSONSchema,
         instance: &Value,
         instance_path: &InstancePath,
     ) -> PartialApplication<'a> {
-        self.node
-            .apply_rooted(schema, instance, instance_path)
-            .into()
+        self.node.apply_rooted(instance, instance_path).into()
     }
 }
 

--- a/jsonschema/src/keywords/any_of.rs
+++ b/jsonschema/src/keywords/any_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, context::CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext},
     error::{error, no_error, ErrorIterator, ValidationError},
     paths::InstancePath,
     primitive_type::PrimitiveType,
@@ -46,17 +46,16 @@ impl AnyOfValidator {
 }
 
 impl Validate for AnyOfValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        self.schemas.iter().any(|s| s.is_valid(schema, instance))
+    fn is_valid(&self, instance: &Value) -> bool {
+        self.schemas.iter().any(|s| s.is_valid(instance))
     }
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::any_of(
@@ -69,14 +68,13 @@ impl Validate for AnyOfValidator {
 
     fn apply<'a>(
         &'a self,
-        schema: &JSONSchema,
         instance: &Value,
         instance_path: &InstancePath,
     ) -> PartialApplication<'a> {
         let mut successes = Vec::new();
         let mut failures = Vec::new();
         for node in &self.schemas {
-            let result = node.apply_rooted(schema, instance, instance_path);
+            let result = node.apply_rooted(instance, instance_path);
             if result.is_valid() {
                 successes.push(result);
             } else {

--- a/jsonschema/src/keywords/boolean.rs
+++ b/jsonschema/src/keywords/boolean.rs
@@ -1,7 +1,6 @@
 use crate::paths::{InstancePath, JSONPointer};
 
 use crate::{
-    compilation::JSONSchema,
     error::{error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     validator::Validate,
@@ -18,13 +17,12 @@ impl FalseValidator {
     }
 }
 impl Validate for FalseValidator {
-    fn is_valid(&self, _: &JSONSchema, _: &Value) -> bool {
+    fn is_valid(&self, _: &Value) -> bool {
         false
     }
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/const_.rs
+++ b/jsonschema/src/keywords/const_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers, CompilationResult},
     validator::Validate,
@@ -26,11 +26,10 @@ impl Validate for ConstArrayValidator {
     #[inline]
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::constant_array(
@@ -43,7 +42,7 @@ impl Validate for ConstArrayValidator {
     }
 
     #[inline]
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(instance_value) = instance {
             helpers::equal_arrays(&self.value, instance_value)
         } else {
@@ -79,11 +78,10 @@ impl Validate for ConstBooleanValidator {
     #[inline]
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::constant_boolean(
@@ -96,7 +94,7 @@ impl Validate for ConstBooleanValidator {
     }
 
     #[inline]
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Bool(instance_value) = instance {
             &self.value == instance_value
         } else {
@@ -123,11 +121,10 @@ impl Validate for ConstNullValidator {
     #[inline]
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::constant_null(
@@ -139,7 +136,7 @@ impl Validate for ConstNullValidator {
     }
 
     #[inline]
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_null()
     }
 }
@@ -172,11 +169,10 @@ impl ConstNumberValidator {
 impl Validate for ConstNumberValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::constant_number(
@@ -188,7 +184,7 @@ impl Validate for ConstNumberValidator {
         }
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             (self.value - item.as_f64().expect("Always representable as f64")).abs() < EPSILON
         } else {
@@ -224,11 +220,10 @@ impl ConstObjectValidator {
 impl Validate for ConstObjectValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::constant_object(
@@ -240,7 +235,7 @@ impl Validate for ConstObjectValidator {
         }
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             helpers::equal_objects(&self.value, item)
         } else {
@@ -281,11 +276,10 @@ impl ConstStringValidator {
 impl Validate for ConstStringValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::constant_string(
@@ -297,7 +291,7 @@ impl Validate for ConstStringValidator {
         }
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             &self.value == item
         } else {

--- a/jsonschema/src/keywords/contains.rs
+++ b/jsonschema/src/keywords/contains.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, context::CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext},
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -32,9 +32,9 @@ impl ContainsValidator {
 }
 
 impl Validate for ContainsValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
-            items.iter().any(|i| self.node.is_valid(schema, i))
+            items.iter().any(|i| self.node.is_valid(i))
         } else {
             true
         }
@@ -42,12 +42,11 @@ impl Validate for ContainsValidator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
         if let Value::Array(items) = instance {
-            if items.iter().any(|i| self.node.is_valid(schema, i)) {
+            if items.iter().any(|i| self.node.is_valid(i)) {
                 return no_error();
             }
             error(ValidationError::contains(
@@ -62,7 +61,6 @@ impl Validate for ContainsValidator {
 
     fn apply<'a>(
         &'a self,
-        schema: &JSONSchema,
         instance: &Value,
         instance_path: &InstancePath,
     ) -> PartialApplication<'a> {
@@ -71,7 +69,7 @@ impl Validate for ContainsValidator {
             let mut indices = Vec::new();
             for (idx, item) in items.iter().enumerate() {
                 let path = instance_path.push(idx);
-                let result = self.node.apply_rooted(schema, item, &path);
+                let result = self.node.apply_rooted(item, &path);
                 if result.is_valid() {
                     indices.push(idx);
                     results.push(result);
@@ -133,7 +131,6 @@ impl MinContainsValidator {
 impl Validate for MinContainsValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -147,7 +144,7 @@ impl Validate for MinContainsValidator {
                 if self
                     .node
                     .validators()
-                    .all(|validator| validator.is_valid(schema, item))
+                    .all(|validator| validator.is_valid(item))
                 {
                     matches += 1;
                     // Shortcircuit - there is enough matches to satisfy `minContains`
@@ -171,14 +168,14 @@ impl Validate for MinContainsValidator {
         }
     }
 
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             let mut matches = 0;
             for item in items {
                 if self
                     .node
                     .validators()
-                    .all(|validator| validator.is_valid(schema, item))
+                    .all(|validator| validator.is_valid(item))
                 {
                     matches += 1;
                     if matches >= self.min_contains {
@@ -232,7 +229,6 @@ impl MaxContainsValidator {
 impl Validate for MaxContainsValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -246,7 +242,7 @@ impl Validate for MaxContainsValidator {
                 if self
                     .node
                     .validators()
-                    .all(|validator| validator.is_valid(schema, item))
+                    .all(|validator| validator.is_valid(item))
                 {
                     matches += 1;
                     // Shortcircuit - there should be no more than `self.max_contains` matches
@@ -276,14 +272,14 @@ impl Validate for MaxContainsValidator {
         }
     }
 
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             let mut matches = 0;
             for item in items {
                 if self
                     .node
                     .validators()
-                    .all(|validator| validator.is_valid(schema, item))
+                    .all(|validator| validator.is_valid(item))
                 {
                     matches += 1;
                     if matches > self.max_contains {
@@ -341,7 +337,6 @@ impl MinMaxContainsValidator {
 impl Validate for MinMaxContainsValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -351,7 +346,7 @@ impl Validate for MinMaxContainsValidator {
                 if self
                     .node
                     .validators()
-                    .all(|validator| validator.is_valid(schema, item))
+                    .all(|validator| validator.is_valid(item))
                 {
                     matches += 1;
                     // Shortcircuit - there should be no more than `self.max_contains` matches
@@ -379,14 +374,14 @@ impl Validate for MinMaxContainsValidator {
         }
     }
 
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             let mut matches = 0;
             for item in items {
                 if self
                     .node
                     .validators()
-                    .all(|validator| validator.is_valid(schema, item))
+                    .all(|validator| validator.is_valid(item))
                 {
                     matches += 1;
                     if matches > self.max_contains {

--- a/jsonschema/src/keywords/content.rs
+++ b/jsonschema/src/keywords/content.rs
@@ -1,6 +1,6 @@
 //! Validators for `contentMediaType` and `contentEncoding` keywords.
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     content_encoding::{ContentEncodingCheckType, ContentEncodingConverterType},
     content_media_type::ContentMediaTypeCheckType,
     error::{error, no_error, ErrorIterator, ValidationError},
@@ -35,7 +35,7 @@ impl ContentMediaTypeValidator {
 
 /// Validator delegates validation to the stored function.
 impl Validate for ContentMediaTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             (self.func)(item)
         } else {
@@ -45,7 +45,6 @@ impl Validate for ContentMediaTypeValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -95,7 +94,7 @@ impl ContentEncodingValidator {
 }
 
 impl Validate for ContentEncodingValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             (self.func)(item)
         } else {
@@ -105,7 +104,6 @@ impl Validate for ContentEncodingValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -162,7 +160,7 @@ impl ContentMediaTypeAndEncodingValidator {
 
 /// Decode the input value & check media type
 impl Validate for ContentMediaTypeAndEncodingValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             match (self.converter)(item) {
                 Ok(None) | Err(_) => false,
@@ -175,7 +173,6 @@ impl Validate for ContentMediaTypeAndEncodingValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/dependencies.rs
+++ b/jsonschema/src/keywords/dependencies.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, context::CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext},
     error::{no_error, ErrorIterator, ValidationError},
     keywords::{required, unique_items, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -50,12 +50,12 @@ impl DependenciesValidator {
 }
 
 impl Validate for DependenciesValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             self.dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .all(move |(_, node)| node.is_valid(schema, instance))
+                .all(move |(_, node)| node.is_valid(instance))
         } else {
             true
         }
@@ -64,7 +64,6 @@ impl Validate for DependenciesValidator {
     #[allow(clippy::needless_collect)]
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -73,7 +72,7 @@ impl Validate for DependenciesValidator {
                 .dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .flat_map(move |(_, node)| node.validate(schema, instance, instance_path))
+                .flat_map(move |(_, node)| node.validate(instance, instance_path))
                 .collect();
             // TODO. custom error message for "required" case
             Box::new(errors.into_iter())
@@ -146,19 +145,18 @@ impl DependentRequiredValidator {
     }
 }
 impl Validate for DependentRequiredValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             self.dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .all(move |(_, node)| node.is_valid(schema, instance))
+                .all(move |(_, node)| node.is_valid(instance))
         } else {
             true
         }
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -167,7 +165,7 @@ impl Validate for DependentRequiredValidator {
                 .dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .flat_map(move |(_, node)| node.validate(schema, instance, instance_path))
+                .flat_map(move |(_, node)| node.validate(instance, instance_path))
                 .collect();
             Box::new(errors.into_iter())
         } else {
@@ -214,19 +212,18 @@ impl DependentSchemasValidator {
     }
 }
 impl Validate for DependentSchemasValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             self.dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .all(move |(_, node)| node.is_valid(schema, instance))
+                .all(move |(_, node)| node.is_valid(instance))
         } else {
             true
         }
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -235,7 +232,7 @@ impl Validate for DependentSchemasValidator {
                 .dependencies
                 .iter()
                 .filter(|(property, _)| item.contains_key(property))
-                .flat_map(move |(_, node)| node.validate(schema, instance, instance_path))
+                .flat_map(move |(_, node)| node.validate(instance, instance_path))
                 .collect();
             Box::new(errors.into_iter())
         } else {

--- a/jsonschema/src/keywords/enum_.rs
+++ b/jsonschema/src/keywords/enum_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -40,11 +40,10 @@ impl EnumValidator {
 impl Validate for EnumValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::enumeration(
@@ -56,7 +55,7 @@ impl Validate for EnumValidator {
         }
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         // If the input value type is not in the types present among the enum options, then there
         // is no reason to compare it against all items - we know that
         // there are no items with such type at all
@@ -107,11 +106,10 @@ impl SingleValueEnumValidator {
 impl Validate for SingleValueEnumValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::enumeration(
@@ -123,7 +121,7 @@ impl Validate for SingleValueEnumValidator {
         }
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         helpers::equal(&self.value, instance)
     }
 }

--- a/jsonschema/src/keywords/exclusive_maximum.rs
+++ b/jsonschema/src/keywords/exclusive_maximum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -30,11 +30,10 @@ macro_rules! validate {
         impl Validate for $validator {
             fn validate<'a, 'b>(
                 &self,
-                schema: &'a JSONSchema,
                 instance: &'b Value,
                 instance_path: &InstancePath,
             ) -> ErrorIterator<'b> {
-                if self.is_valid(schema, instance) {
+                if self.is_valid(instance) {
                     no_error()
                 } else {
                     error(ValidationError::exclusive_maximum(
@@ -46,7 +45,7 @@ macro_rules! validate {
                 }
             }
 
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+            fn is_valid(&self, instance: &Value) -> bool {
                 if let Value::Number(item) = instance {
                     if let Some(item) = item.as_u64() {
                         NumCmp::num_lt(item, self.limit)
@@ -73,7 +72,7 @@ validate!(ExclusiveMaximumU64Validator);
 validate!(ExclusiveMaximumI64Validator);
 
 impl Validate for ExclusiveMaximumF64Validator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             if let Some(item) = item.as_u64() {
                 NumCmp::num_lt(item, self.limit)
@@ -90,11 +89,10 @@ impl Validate for ExclusiveMaximumF64Validator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::exclusive_maximum(

--- a/jsonschema/src/keywords/exclusive_minimum.rs
+++ b/jsonschema/src/keywords/exclusive_minimum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -30,11 +30,10 @@ macro_rules! validate {
         impl Validate for $validator {
             fn validate<'a, 'b>(
                 &self,
-                schema: &'a JSONSchema,
                 instance: &'b Value,
                 instance_path: &InstancePath,
             ) -> ErrorIterator<'b> {
-                if self.is_valid(schema, instance) {
+                if self.is_valid(instance) {
                     no_error()
                 } else {
                     error(ValidationError::exclusive_minimum(
@@ -46,7 +45,7 @@ macro_rules! validate {
                 }
             }
 
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+            fn is_valid(&self, instance: &Value) -> bool {
                 if let Value::Number(item) = instance {
                     return if let Some(item) = item.as_u64() {
                         NumCmp::num_gt(item, self.limit)
@@ -72,7 +71,7 @@ validate!(ExclusiveMinimumU64Validator);
 validate!(ExclusiveMinimumI64Validator);
 
 impl Validate for ExclusiveMinimumF64Validator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             return if let Some(item) = item.as_u64() {
                 NumCmp::num_gt(item, self.limit)
@@ -88,11 +87,10 @@ impl Validate for ExclusiveMinimumF64Validator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::exclusive_minimum(

--- a/jsonschema/src/keywords/format.rs
+++ b/jsonschema/src/keywords/format.rs
@@ -7,7 +7,7 @@ use url::Url;
 use uuid::Uuid;
 
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{pattern, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -60,12 +60,11 @@ macro_rules! validate {
     ($format:expr) => {
         fn validate<'a, 'b>(
             &self,
-            schema: &'a JSONSchema,
             instance: &'b Value,
             instance_path: &InstancePath,
         ) -> ErrorIterator<'b> {
             if let Value::String(_item) = instance {
-                if !self.is_valid(schema, instance) {
+                if !self.is_valid(instance) {
                     return error(ValidationError::format(
                         self.schema_path.clone(),
                         instance_path.into(),
@@ -82,7 +81,7 @@ macro_rules! validate {
 format_validator!(DateValidator, "date");
 impl Validate for DateValidator {
     validate!("date");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             if time::Date::parse(
                 item,
@@ -107,7 +106,7 @@ impl Validate for DateValidator {
 format_validator!(DateTimeValidator, "date-time");
 impl Validate for DateTimeValidator {
     validate!("date-time");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             time::OffsetDateTime::parse(item, &time::format_description::well_known::Rfc3339)
                 .is_ok()
@@ -139,7 +138,7 @@ fn is_valid_email(email: &str) -> bool {
 format_validator!(EmailValidator, "email");
 impl Validate for EmailValidator {
     validate!("email");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             is_valid_email(item)
         } else {
@@ -150,7 +149,7 @@ impl Validate for EmailValidator {
 format_validator!(IDNEmailValidator, "idn-email");
 impl Validate for IDNEmailValidator {
     validate!("idn-email");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             is_valid_email(item)
         } else {
@@ -161,7 +160,7 @@ impl Validate for IDNEmailValidator {
 format_validator!(HostnameValidator, "hostname");
 impl Validate for HostnameValidator {
     validate!("hostname");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             !(item.ends_with('-')
                 || item.starts_with('-')
@@ -181,7 +180,7 @@ impl Validate for HostnameValidator {
 format_validator!(IDNHostnameValidator, "idn-hostname");
 impl Validate for IDNHostnameValidator {
     validate!("idn-hostname");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             !(item.ends_with('-')
                 || item.starts_with('-')
@@ -201,7 +200,7 @@ impl Validate for IDNHostnameValidator {
 format_validator!(IpV4Validator, "ipv4");
 impl Validate for IpV4Validator {
     validate!("ipv4");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             if item.starts_with('0') {
                 return false;
@@ -219,7 +218,7 @@ impl Validate for IpV4Validator {
 format_validator!(IpV6Validator, "ipv6");
 impl Validate for IpV6Validator {
     validate!("ipv6");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             match IpAddr::from_str(item.as_str()) {
                 Ok(i) => i.is_ipv6(),
@@ -233,7 +232,7 @@ impl Validate for IpV6Validator {
 format_validator!(IRIValidator, "iri");
 impl Validate for IRIValidator {
     validate!("iri");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             Url::from_str(item).is_ok()
         } else {
@@ -244,7 +243,7 @@ impl Validate for IRIValidator {
 format_validator!(URIValidator, "uri");
 impl Validate for URIValidator {
     validate!("uri");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             Url::from_str(item).is_ok()
         } else {
@@ -255,7 +254,7 @@ impl Validate for URIValidator {
 format_validator!(IRIReferenceValidator, "iri-reference");
 impl Validate for IRIReferenceValidator {
     validate!("iri-reference");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             IRI_REFERENCE_RE
                 .is_match(item)
@@ -268,7 +267,7 @@ impl Validate for IRIReferenceValidator {
 format_validator!(JSONPointerValidator, "json-pointer");
 impl Validate for JSONPointerValidator {
     validate!("json-pointer");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             JSON_POINTER_RE
                 .is_match(item)
@@ -281,7 +280,7 @@ impl Validate for JSONPointerValidator {
 format_validator!(RegexValidator, "regex");
 impl Validate for RegexValidator {
     validate!("regex");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             pattern::convert_regex(item).is_ok()
         } else {
@@ -292,7 +291,7 @@ impl Validate for RegexValidator {
 format_validator!(RelativeJSONPointerValidator, "relative-json-pointer");
 impl Validate for RelativeJSONPointerValidator {
     validate!("relative-json-pointer");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             RELATIVE_JSON_POINTER_RE
                 .is_match(item)
@@ -305,7 +304,7 @@ impl Validate for RelativeJSONPointerValidator {
 format_validator!(TimeValidator, "time");
 impl Validate for TimeValidator {
     validate!("time");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             TIME_RE.is_match(item).expect("Simple TIME_RE pattern")
         } else {
@@ -316,7 +315,7 @@ impl Validate for TimeValidator {
 format_validator!(URIReferenceValidator, "uri-reference");
 impl Validate for URIReferenceValidator {
     validate!("uri-reference");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             URI_REFERENCE_RE
                 .is_match(item)
@@ -329,7 +328,7 @@ impl Validate for URIReferenceValidator {
 format_validator!(URITemplateValidator, "uri-template");
 impl Validate for URITemplateValidator {
     validate!("uri-template");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             URI_TEMPLATE_RE
                 .is_match(item)
@@ -343,7 +342,7 @@ impl Validate for URITemplateValidator {
 format_validator!(UUIDValidator, "uuid");
 impl Validate for UUIDValidator {
     validate!("uuid");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             Uuid::from_str(item.as_str()).is_ok()
         } else {
@@ -355,7 +354,7 @@ impl Validate for UUIDValidator {
 format_validator!(DurationValidator, "duration");
 impl Validate for DurationValidator {
     validate!("duration");
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             iso8601::duration(item).is_ok()
         } else {
@@ -392,12 +391,11 @@ impl core::fmt::Display for CustomFormatValidator {
 impl Validate for CustomFormatValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
         if let Value::String(_item) = instance {
-            if !self.is_valid(schema, instance) {
+            if !self.is_valid(instance) {
                 return error(ValidationError::format(
                     self.schema_path.clone(),
                     instance_path.into(),
@@ -409,7 +407,7 @@ impl Validate for CustomFormatValidator {
         no_error()
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             (self.check)(item)
         } else {

--- a/jsonschema/src/keywords/legacy/type_draft_4.rs
+++ b/jsonschema/src/keywords/legacy/type_draft_4.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{type_, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -49,7 +49,7 @@ impl MultipleTypesValidator {
 }
 
 impl Validate for MultipleTypesValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         match instance {
             Value::Array(_) => self.types.contains_type(PrimitiveType::Array),
             Value::Bool(_) => self.types.contains_type(PrimitiveType::Boolean),
@@ -64,11 +64,10 @@ impl Validate for MultipleTypesValidator {
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::multiple_type_error(
@@ -107,7 +106,7 @@ impl IntegerTypeValidator {
 }
 
 impl Validate for IntegerTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(num) = instance {
             is_integer(num)
         } else {
@@ -117,11 +116,10 @@ impl Validate for IntegerTypeValidator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(

--- a/jsonschema/src/keywords/max_items.rs
+++ b/jsonschema/src/keywords/max_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -24,7 +24,7 @@ impl MaxItemsValidator {
 }
 
 impl Validate for MaxItemsValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             if (items.len() as u64) > self.limit {
                 return false;
@@ -35,7 +35,6 @@ impl Validate for MaxItemsValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/max_length.rs
+++ b/jsonschema/src/keywords/max_length.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -24,7 +24,7 @@ impl MaxLengthValidator {
 }
 
 impl Validate for MaxLengthValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             if (bytecount::num_chars(item.as_bytes()) as u64) > self.limit {
                 return false;
@@ -35,7 +35,6 @@ impl Validate for MaxLengthValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/max_properties.rs
+++ b/jsonschema/src/keywords/max_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -24,7 +24,7 @@ impl MaxPropertiesValidator {
 }
 
 impl Validate for MaxPropertiesValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             if (item.len() as u64) > self.limit {
                 return false;
@@ -35,7 +35,6 @@ impl Validate for MaxPropertiesValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/maximum.rs
+++ b/jsonschema/src/keywords/maximum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -30,11 +30,10 @@ macro_rules! validate {
         impl Validate for $validator {
             fn validate<'a, 'b>(
                 &self,
-                schema: &'a JSONSchema,
                 instance: &'b Value,
                 instance_path: &InstancePath,
             ) -> ErrorIterator<'b> {
-                if self.is_valid(schema, instance) {
+                if self.is_valid(instance) {
                     no_error()
                 } else {
                     error(ValidationError::maximum(
@@ -46,7 +45,7 @@ macro_rules! validate {
                 }
             }
 
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+            fn is_valid(&self, instance: &Value) -> bool {
                 if let Value::Number(item) = instance {
                     return if let Some(item) = item.as_u64() {
                         !NumCmp::num_gt(item, self.limit)
@@ -72,7 +71,7 @@ validate!(MaximumU64Validator);
 validate!(MaximumI64Validator);
 
 impl Validate for MaximumF64Validator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             return if let Some(item) = item.as_u64() {
                 !NumCmp::num_gt(item, self.limit)
@@ -88,11 +87,10 @@ impl Validate for MaximumF64Validator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::maximum(

--- a/jsonschema/src/keywords/min_items.rs
+++ b/jsonschema/src/keywords/min_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -24,7 +24,7 @@ impl MinItemsValidator {
 }
 
 impl Validate for MinItemsValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             if (items.len() as u64) < self.limit {
                 return false;
@@ -35,7 +35,6 @@ impl Validate for MinItemsValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/min_length.rs
+++ b/jsonschema/src/keywords/min_length.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -24,7 +24,7 @@ impl MinLengthValidator {
 }
 
 impl Validate for MinLengthValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::String(item) = instance {
             if (bytecount::num_chars(item.as_bytes()) as u64) < self.limit {
                 return false;
@@ -35,7 +35,6 @@ impl Validate for MinLengthValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/min_properties.rs
+++ b/jsonschema/src/keywords/min_properties.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::fail_on_non_positive_integer, CompilationResult},
     paths::{InstancePath, JSONPointer},
@@ -24,7 +24,7 @@ impl MinPropertiesValidator {
 }
 
 impl Validate for MinPropertiesValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             if (item.len() as u64) < self.limit {
                 return false;
@@ -35,7 +35,6 @@ impl Validate for MinPropertiesValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {

--- a/jsonschema/src/keywords/minimum.rs
+++ b/jsonschema/src/keywords/minimum.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -30,11 +30,10 @@ macro_rules! validate {
         impl Validate for $validator {
             fn validate<'a, 'b>(
                 &self,
-                schema: &'a JSONSchema,
                 instance: &'b Value,
                 instance_path: &InstancePath,
             ) -> ErrorIterator<'b> {
-                if self.is_valid(schema, instance) {
+                if self.is_valid(instance) {
                     no_error()
                 } else {
                     error(ValidationError::minimum(
@@ -46,7 +45,7 @@ macro_rules! validate {
                 }
             }
 
-            fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+            fn is_valid(&self, instance: &Value) -> bool {
                 if let Value::Number(item) = instance {
                     return if let Some(item) = item.as_u64() {
                         !NumCmp::num_lt(item, self.limit)
@@ -72,7 +71,7 @@ validate!(MinimumU64Validator);
 validate!(MinimumI64Validator);
 
 impl Validate for MinimumF64Validator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             return if let Some(item) = item.as_u64() {
                 !NumCmp::num_lt(item, self.limit)
@@ -88,11 +87,10 @@ impl Validate for MinimumF64Validator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::minimum(

--- a/jsonschema/src/keywords/multiple_of.rs
+++ b/jsonschema/src/keywords/multiple_of.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -26,7 +26,7 @@ impl MultipleOfFloatValidator {
 }
 
 impl Validate for MultipleOfFloatValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             let item = item.as_f64().expect("Always valid");
             let remainder = (item / self.multiple_of) % 1.;
@@ -48,11 +48,10 @@ impl Validate for MultipleOfFloatValidator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if !self.is_valid(schema, instance) {
+        if !self.is_valid(instance) {
             return error(ValidationError::multiple_of(
                 self.schema_path.clone(),
                 instance_path.into(),
@@ -86,7 +85,7 @@ impl MultipleOfIntegerValidator {
 }
 
 impl Validate for MultipleOfIntegerValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(item) = instance {
             let item = item.as_f64().expect("Always valid");
             // As the divisor has its fractional part as zero, then any value with a non-zero
@@ -99,11 +98,10 @@ impl Validate for MultipleOfIntegerValidator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if !self.is_valid(schema, instance) {
+        if !self.is_valid(instance) {
             return error(ValidationError::multiple_of(
                 self.schema_path.clone(),
                 instance_path.into(),

--- a/jsonschema/src/keywords/not.rs
+++ b/jsonschema/src/keywords/not.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{compile_validators, context::CompilationContext, JSONSchema},
+    compilation::{compile_validators, context::CompilationContext},
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -31,17 +31,16 @@ impl NotValidator {
 }
 
 impl Validate for NotValidator {
-    fn is_valid(&self, schema: &JSONSchema, instance: &Value) -> bool {
-        !self.node.is_valid(schema, instance)
+    fn is_valid(&self, instance: &Value) -> bool {
+        !self.node.is_valid(instance)
     }
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::not(

--- a/jsonschema/src/keywords/required.rs
+++ b/jsonschema/src/keywords/required.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     paths::{InstancePath, JSONPointer},
@@ -38,7 +38,7 @@ impl RequiredValidator {
 }
 
 impl Validate for RequiredValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             self.required
                 .iter()
@@ -50,7 +50,6 @@ impl Validate for RequiredValidator {
 
     fn validate<'a, 'b>(
         &self,
-        _: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
@@ -99,11 +98,10 @@ impl SingleItemRequiredValidator {
 impl Validate for SingleItemRequiredValidator {
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if !self.is_valid(schema, instance) {
+        if !self.is_valid(instance) {
             return error(ValidationError::required(
                 self.schema_path.clone(),
                 instance_path.into(),
@@ -115,7 +113,7 @@ impl Validate for SingleItemRequiredValidator {
         no_error()
     }
 
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Object(item) = instance {
             item.contains_key(&self.value)
         } else {

--- a/jsonschema/src/keywords/type_.rs
+++ b/jsonschema/src/keywords/type_.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::CompilationResult,
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
@@ -50,7 +50,7 @@ impl MultipleTypesValidator {
 }
 
 impl Validate for MultipleTypesValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         match instance {
             Value::Array(_) => self.types.contains_type(PrimitiveType::Array),
             Value::Bool(_) => self.types.contains_type(PrimitiveType::Boolean),
@@ -65,11 +65,10 @@ impl Validate for MultipleTypesValidator {
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::multiple_type_error(
@@ -108,16 +107,15 @@ impl NullTypeValidator {
 }
 
 impl Validate for NullTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_null()
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
@@ -148,16 +146,15 @@ impl BooleanTypeValidator {
 }
 
 impl Validate for BooleanTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_boolean()
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
@@ -188,17 +185,16 @@ impl StringTypeValidator {
 }
 
 impl Validate for StringTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_string()
     }
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
@@ -228,17 +224,16 @@ impl ArrayTypeValidator {
 }
 
 impl Validate for ArrayTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_array()
     }
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
@@ -269,16 +264,15 @@ impl ObjectTypeValidator {
 }
 
 impl Validate for ObjectTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_object()
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
@@ -309,16 +303,15 @@ impl NumberTypeValidator {
 }
 
 impl Validate for NumberTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         instance.is_number()
     }
     fn validate<'a, 'b>(
         &self,
-        config: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(config, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(
@@ -347,7 +340,7 @@ impl IntegerTypeValidator {
 }
 
 impl Validate for IntegerTypeValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Number(num) = instance {
             is_integer(num)
         } else {
@@ -356,11 +349,10 @@ impl Validate for IntegerTypeValidator {
     }
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::single_type_error(

--- a/jsonschema/src/keywords/unique_items.rs
+++ b/jsonschema/src/keywords/unique_items.rs
@@ -1,5 +1,5 @@
 use crate::{
-    compilation::{context::CompilationContext, JSONSchema},
+    compilation::context::CompilationContext,
     error::{error, no_error, ErrorIterator, ValidationError},
     keywords::{helpers::equal, CompilationResult},
     validator::Validate,
@@ -98,7 +98,7 @@ impl UniqueItemsValidator {
 }
 
 impl Validate for UniqueItemsValidator {
-    fn is_valid(&self, _: &JSONSchema, instance: &Value) -> bool {
+    fn is_valid(&self, instance: &Value) -> bool {
         if let Value::Array(items) = instance {
             if !is_unique(items) {
                 return false;
@@ -109,11 +109,10 @@ impl Validate for UniqueItemsValidator {
 
     fn validate<'a, 'b>(
         &self,
-        schema: &'a JSONSchema,
         instance: &'b Value,
         instance_path: &InstancePath,
     ) -> ErrorIterator<'b> {
-        if self.is_valid(schema, instance) {
+        if self.is_valid(instance) {
             no_error()
         } else {
             error(ValidationError::unique_items(

--- a/jsonschema/src/output.rs
+++ b/jsonschema/src/output.rs
@@ -105,7 +105,7 @@ impl<'a, 'b> Output<'a, 'b> {
     /// ```
     pub fn basic(&self) -> BasicOutput<'a> {
         self.root_node
-            .apply_rooted(self.schema, self.instance, &InstancePath::new())
+            .apply_rooted(self.instance, &InstancePath::new())
     }
 }
 

--- a/jsonschema/src/resolver.rs
+++ b/jsonschema/src/resolver.rs
@@ -234,7 +234,6 @@ fn parse_index(s: &str) -> Option<usize> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::JSONSchema;
     use serde_json::json;
     use std::sync::Arc;
     use url::Url;
@@ -493,28 +492,5 @@ mod tests {
         let (resource, resolved) = resolver.resolve_fragment(Draft::Draft7, &url).unwrap();
         assert_eq!(resource, Url::parse("json-schema:///").unwrap());
         assert_eq!(resolved.as_ref(), schema.pointer("/definitions/a").unwrap());
-    }
-
-    #[test]
-    fn id_value_is_cleaned() {
-        let schema = json!({
-            "$id": "http://foo.com/schema.json#",
-            "properties": {
-                "foo": {
-                    "$ref": "#/definitions/Bar"
-                }
-            },
-            "definitions": {
-                "Bar": {
-                    "const": 42
-                }
-            }
-        });
-        let compiled = JSONSchema::compile(&schema).unwrap();
-        // `#` should be removed
-        assert!(compiled
-            .resolver
-            .schemas
-            .contains_key("http://foo.com/schema.json"));
     }
 }


### PR DESCRIPTION
It gives a stable 6% time improvement on the `geojson` benchmark. It is visible there as there are a lot of small objects and `is_valid` / `validate` are called many times. The effect is not that visible on other benchmarks