### PR TITLE
Set default-features=false for reqwest

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -42,7 +42,7 @@ num-cmp = ">= 0.1"
 parking_lot = ">= 0.1"
 percent-encoding = "2"
 regex = "1"
-reqwest = { version = ">= 0.10", features = ["blocking", "json"], optional = true }
+reqwest = { version = ">= 0.10", features = ["blocking", "json"], default-features = false, optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = { version = ">= 0.3", optional = true }


### PR DESCRIPTION
fixes #335 .

Otherwise, reqwest will always use default-tls which is the native-tls even if jsonschema `reqwest-rustls-tls` feature is specified.