### PR TITLE
feat: Custom Resolvers for external references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Added
+
+- The `SchemaResolver` trait to support resolving external schema references. [#341](https://github.com/Stranger6667/jsonschema-rs/pull/341)
+- `resolve-file` feature to resolve external schema files via `std::fs`. [#341](https://github.com/Stranger6667/jsonschema-rs/pull/341)
+
+### Changed
+
+- The `reqwest` feature was changed to `resolve-http`. [#341](https://github.com/Stranger6667/jsonschema-rs/pull/341)
+
 ### Performance
 
 - CLI: Use `serde::from_reader` instead of `serde::from_str`.

--- a/bindings/python/Cargo.toml
+++ b/bindings/python/Cargo.toml
@@ -22,7 +22,7 @@ built = { version = "0.5", features = ["chrono"] }
 path = "../../jsonschema"
 version = "*"
 default-features = false
-features = ["reqwest"]
+features = ["resolve-http", "resolve-file"]
 
 [dependencies]
 serde_json = "1"

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -17,19 +17,16 @@ name = "jsonschema"
 
 [features]
 cli = ["structopt"]
-default = ["reqwest", "cli"]
+default = ["resolve-http", "resolve-file", "cli"]
 draft201909 = []
 draft202012 = []
-reqwest-native-tls = ["reqwest/native-tls"]
-reqwest-native-tls-alpn = ["reqwest/native-tls-alpn"]
-reqwest-native-tls-vendored = ["reqwest/native-tls-vendored"]
-reqwest-rustls-tls = ["reqwest/rustls-tls"]
-reqwest-rustls-tls-manual-roots = ["reqwest/rustls-tls-manual-roots"]
-reqwest-rustls-tls-native-roots = ["reqwest/rustls-tls-native-roots"]
-reqwest-rustls-tls-webpki-roots = ["reqwest/rustls-tls-webpki-roots"]
+
+resolve-http = ["reqwest"]
+resolve-file = []
 
 [dependencies]
 ahash = { version = "0.7", features = ["serde"] }
+anyhow = "1.0.53"
 base64 = ">= 0.2"
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 fancy-regex = "^0.7.1"
@@ -47,7 +44,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = { version = ">= 0.3", optional = true }
 time = { version = ">= 0.3.3", features = ["parsing", "macros"] }
-url = "2"
+url = "2.2.2"
 uuid = "0.8"
 
 [dev-dependencies]

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -26,7 +26,7 @@ resolve-file = []
 
 [dependencies]
 ahash = { version = "0.7", features = ["serde"] }
-anyhow = "1.0.53"
+anyhow = "1"
 base64 = ">= 0.2"
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
 fancy-regex = "^0.7.1"

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -44,7 +44,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 structopt = { version = ">= 0.3", optional = true }
 time = { version = ">= 0.3.3", features = ["parsing", "macros"] }
-url = "2.2.2"
+url = "2"
 uuid = "0.8"
 
 [dev-dependencies]

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -5,7 +5,7 @@ use crate::{
         DEFAULT_CONTENT_ENCODING_CHECKS_AND_CONVERTERS,
     },
     content_media_type::{ContentMediaTypeCheckType, DEFAULT_CONTENT_MEDIA_TYPE_CHECKS},
-    resolver::{DefaultResolver, SchemaResolver, Resolver},
+    resolver::{DefaultResolver, Resolver, SchemaResolver},
     schemas, ValidationError,
 };
 use ahash::AHashMap;

--- a/jsonschema/src/error.rs
+++ b/jsonschema/src/error.rs
@@ -704,14 +704,6 @@ impl<'a> ValidationError<'a> {
             schema_path,
         }
     }
-    pub(crate) fn unknown_reference_scheme(scheme: String) -> ValidationError<'a> {
-        ValidationError {
-            instance_path: JSONPointer::default(),
-            instance: Cow::Owned(Value::Null),
-            kind: ValidationErrorKind::UnknownReferenceScheme { scheme },
-            schema_path: JSONPointer::default(),
-        }
-    }
     pub(crate) fn utf8(error: Utf8Error) -> ValidationError<'a> {
         ValidationError {
             instance_path: JSONPointer::default(),

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -173,7 +173,7 @@ mod tests {
     use super::*;
     use crate::{
         compilation::{context::BaseUri, DEFAULT_SCOPE},
-        resolver::{Resolver, DefaultResolver},
+        resolver::{DefaultResolver, Resolver},
         tests_util, JSONSchema,
     };
     use serde_json::{json, Value};

--- a/jsonschema/src/keywords/pattern.rs
+++ b/jsonschema/src/keywords/pattern.rs
@@ -173,7 +173,7 @@ mod tests {
     use super::*;
     use crate::{
         compilation::{context::BaseUri, DEFAULT_SCOPE},
-        resolver::Resolver,
+        resolver::{Resolver, DefaultResolver},
         tests_util, JSONSchema,
     };
     use serde_json::{json, Value};
@@ -207,6 +207,7 @@ mod tests {
         let schema = JSONSchema::compile(&schema_json).unwrap();
         let resolver = Arc::new(
             Resolver::new(
+                Arc::new(DefaultResolver),
                 Default::default(),
                 &DEFAULT_SCOPE,
                 schema_json,

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -98,7 +98,9 @@ mod validator;
 
 pub use compilation::{options::CompilationOptions, JSONSchema};
 pub use error::{ErrorIterator, ValidationError};
+pub use resolver::{SchemaResolver, SchemaResolverError};
 pub use schemas::Draft;
+
 use serde_json::Value;
 
 /// A shortcut for validating `instance` against `schema`. Draft version is detected automatically.

--- a/jsonschema/src/resolver.rs
+++ b/jsonschema/src/resolver.rs
@@ -17,16 +17,16 @@ pub type SchemaResolverError = anyhow::Error;
 
 /// A resolver that resolves external schema references.
 /// Internal references such as `#/definitions` and JSON pointers are handled internally.
-/// 
+///
 /// All operations are blocking and it is not possible to return futures.
 /// As a workaround, errors can be returned that will contain the schema URLs to resolve
 /// and can be resolved outside the validation process if needed.
-/// 
+///
 /// # Example
-/// 
+///
 /// ```rust,ignore
 /// struct MyCustomResolver;
-/// 
+///
 /// impl SchemaResolver for MyCustomResolver {
 ///     fn resolve(&self, root_schema: &Value, url: &Url) -> Result<Arc<Value>, SchemaResolverError> {
 ///         match url.scheme() {
@@ -42,7 +42,7 @@ pub type SchemaResolverError = anyhow::Error;
 /// ```
 pub trait SchemaResolver: Send + Sync {
     /// Resolve an external schema via an URL.
-    /// 
+    ///
     /// Relative URLs are resolved based on the root schema's ID,
     /// if there is no root schema ID available, the schema `json-schema` is used
     /// and any relative paths are turned into absolutes.
@@ -80,12 +80,10 @@ impl SchemaResolver for DefaultResolver {
                     Err(anyhow::anyhow!("`resolve-file` feature or a custom resolver is required to resolve external schemas via files"))
                 }
             }
-            "json-schema" => {
-                Err(anyhow::anyhow!("cannot resolve relative external schema without root schema ID"))
-            }
-            _ => {
-                Err(anyhow::anyhow!("unknown scheme {}", url.scheme()))
-            }
+            "json-schema" => Err(anyhow::anyhow!(
+                "cannot resolve relative external schema without root schema ID"
+            )),
+            _ => Err(anyhow::anyhow!("unknown scheme {}", url.scheme())),
         }
     }
 }

--- a/jsonschema/src/resolver.rs
+++ b/jsonschema/src/resolver.rs
@@ -76,6 +76,11 @@ impl SchemaResolver for DefaultResolver {
     ) -> Result<Arc<Value>, SchemaResolverError> {
         match url.scheme() {
             "http" | "https" => {
+                #[cfg(all(feature = "reqwest", not(feature = "resolve-http")))]
+                {
+                    compile_error!("the `reqwest` feature does not enable HTTP schema resolving anymore, use the `resolve-http` feature instead");
+                }
+
                 #[cfg(any(feature = "resolve-http", test))]
                 {
                     let response = reqwest::blocking::get(url.as_str())?;

--- a/jsonschema/src/resolver.rs
+++ b/jsonschema/src/resolver.rs
@@ -34,7 +34,7 @@ pub type SchemaResolverError = anyhow::Error;
 /// struct MyCustomResolver;
 ///
 /// impl SchemaResolver for MyCustomResolver {
-///     fn resolve(&self, root_schema: &Value, url: &Url) -> Result<Arc<Value>, SchemaResolverError> {
+///     fn resolve(&self, root_schema: &Value, url: &Url, _original_reference: &str) -> Result<Arc<Value>, SchemaResolverError> {
 ///         match url.scheme() {
 ///             "json-schema" => {
 ///                 Err(anyhow!("cannot resolve schema without root schema ID"))


### PR DESCRIPTION
A PR for #246. It does not touch on the `async` feature, but makes the library build on `wasm32-unknown-unknown` with `default-features = false` and enables my use-case in [taplo](https://github.com/tamasfe/taplo).

### Added

The `SchemaResolver` trait that is supposed to resolve external schemas by given URLs along with a `DefaultResolver` that does what was already implemented, and additionally also resolves `file` schemes via std.

I decided to just use `Arc<dyn SchemaResolver>` as it is only used by ref validators currently, and adding generics everywhere would've added too much complexity.

A `ValidationError::Resolver` variant was also added accordingly to report if any of the external resolutions failed.

A compiler option to set a custom resolver was also added.

The following features were added to customize the default resolver:

- `resolve-http`: blocking reqwest
- `resolve-file`: resolution via `std::fs`

Both of them are enabled by default so there should be no breaking changes for current users.

### Removed

The reqwest error variant.

All `reqwest-*` features, the users of the library can add `reqwest` as a dependency itself and enable the features they wish, this is a breaking change, although I don't know if anyone used these features.

### Additional Dependencies

- **anyhow**: It's very commonly used, and is somewhat better than bare `Box<dyn std::error::Error>`, although it's not strictly required for this PR.

### TODO

More documentation and tests perhaps?

Also I haven't yet ran or compared the benchmarks, but I don't think that there would be any visible performance hits.