### PR TITLE
fix!: specify precise dependency versions in `Cargo.toml` and upgrade all versions

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -25,37 +25,37 @@ resolve-http = ["reqwest"]
 resolve-file = []
 
 [dependencies]
-ahash = { version = "0.7", features = ["serde"] }
-anyhow = "1"
-base64 = ">= 0.2"
-bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
-fancy-regex = "^0.7.1"
-fraction = { version = "0.9", default-features = false, features = ["with-bigint"] }
-iso8601 = "0.4"
-itoa = "1"
-lazy_static = "1"
-memchr = "2.4"
-num-cmp = ">= 0.1"
-parking_lot = ">= 0.1"
-percent-encoding = "2"
-regex = "1"
-reqwest = { version = ">= 0.10", features = ["blocking", "json"], default-features = false, optional = true }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-structopt = { version = ">= 0.3", optional = true }
-time = { version = ">= 0.3.3", features = ["parsing", "macros"] }
-url = "2"
-uuid = "0.8"
+ahash = { version = "0.7.6", features = ["serde"] }
+anyhow = "1.0.55"
+base64 = "0.13.0"
+bytecount = { version = "0.6.2", features = ["runtime-dispatch-simd"] }
+fancy-regex = "0.8.0"
+fraction = { version = "0.10.0", default-features = false, features = ["with-bigint"] }
+iso8601 = "0.4.1"
+itoa = "1.0.1"
+lazy_static = "1.4.0"
+memchr = "2.4.1"
+num-cmp = "0.1.0"
+parking_lot = "0.12.0"
+percent-encoding = "2.1.0"
+regex = "1.5.4"
+reqwest = { version = "0.11.9", features = ["blocking", "json"], default-features = false, optional = true }
+serde = { version = "1.0.136", features = ["derive"] }
+serde_json = "1.0.79"
+structopt = { version = "0.3.26", optional = true }
+time = { version = "0.3.7", features = ["parsing", "macros"] }
+url = "2.2.2"
+uuid = "0.8.2"
 
 [dev-dependencies]
 bench_helpers = { path = "../bench_helpers" }
-criterion = ">= 0.1"
-json_schema_test_suite = { version = ">= 0.3", path = "../jsonschema-test-suite" }
+criterion = "0.3.5"
+json_schema_test_suite = { version = "0.3.0", path = "../jsonschema-test-suite" }
 jsonschema-valid = "0.4.0"
-mockito = ">= 0"
-paste = ">= 0.1"
-reqwest = { version = ">= 0.10", features = ["blocking", "json"] }
-test-case = "1"
+mockito = "0.31.0"
+paste = "1.0.6"
+reqwest = { version = "0.11.9", features = ["blocking", "json"] }
+test-case = "1.2.3"
 valico = "3.6.0"
 
 # Benchmarks for `jsonschema`


### PR DESCRIPTION
As of the latest master (778b424b3de65f2ed6df64a2558bde7341c0094b) the library does not compile with cargo `minimal-versions` for the default features:

```shell
cargo +nightly update -Z minimal-versions && cargo +nightly check
```

This PR:
- Specifies precise dependency versions in `Cargo.toml` (as discussed [here](https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277))
- Upgrades all dependancies to the latest compatible versions such that the test suite passes with `--all-features`

Note that I was not able to determine the minimal version updates to allow the library to build with `minimal-versions` and so I took the sledge-hammer approach and upgraded everything.

And finally, thank you for proving this library to the community!