### PR TITLE
fix: Enable `reqwest/native-tls` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Enable `reqwest/native-tls` by default to avoid validation errors caused by `reqwest` missing a TLS backend. [#343](https://github.com/Stranger6667/jsonschema-rs/issues/343)
+
 ## [0.15.0] - 2022-01-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,10 +14,17 @@ Supported drafts:
 - Draft 6
 - Draft 4 (except optional `bignum.json` test case)
 
+Partially supported drafts (some keywords are not implemented):
+- Draft 2019-09 (requires the `draft201909` feature enabled)
+- Draft 2020-12 (requires the `draft202012` feature enabled)
+
 ```toml
 # Cargo.toml
 jsonschema = "0.15"
 ```
+
+By default `jsonschema` resolves remote references via HTTP by using `reqwest` with `native-tls`.
+If you'd like to use `rustls`, you have to explicitly enable `reqwest` and `rustls` features and disable `native-tls` via `default-features = false` in your `Cargo.toml` file.
 
 To validate documents against some schema and get validation errors (if any):
 

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -21,8 +21,11 @@ default = ["resolve-http", "resolve-file", "cli"]
 draft201909 = []
 draft202012 = []
 
-resolve-http = ["reqwest"]
+resolve-http = ["reqwest", "native-tls"]
 resolve-file = []
+
+native-tls = ["reqwest/default-tls"]
+rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 ahash = { version = "0.7.6", features = ["serde"] }
@@ -39,7 +42,7 @@ num-cmp = "0.1.0"
 parking_lot = "0.12.0"
 percent-encoding = "2.1.0"
 regex = "1.5.4"
-reqwest = { version = "0.11.9", features = ["blocking", "json"], default-features = false, optional = true }
+reqwest = { package = "reqwest", version = "0.11.9", features = ["blocking", "json"], default-features = false, optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 structopt = { version = "0.3.26", optional = true }
@@ -54,7 +57,6 @@ json_schema_test_suite = { version = "0.3.0", path = "../jsonschema-test-suite" 
 jsonschema-valid = "0.4.0"
 mockito = "0.31.0"
 paste = "1.0.6"
-reqwest = { version = "0.11.9", features = ["blocking", "json"] }
 test-case = "1.2.3"
 valico = "3.6.0"
 


### PR DESCRIPTION
To avoid validation errors caused by `reqwest` missing a TLS backend

Resolves #343 