### PR TITLE
Fix compile error with no features enabled

### DIFF
--- a/jsonschema/src/resolver.rs
+++ b/jsonschema/src/resolver.rs
@@ -76,11 +76,11 @@ impl SchemaResolver for DefaultResolver {
     ) -> Result<Arc<Value>, SchemaResolverError> {
         match url.scheme() {
             "http" | "https" => {
-                #[cfg(not(any(
-                    feature = "resolve-http",
-                    all(feature = "reqwest", feature = "rustls"),
-                    test
-                )))]
+                #[cfg(all(
+                    feature = "reqwest",
+                    not(feature = "rustls"),
+                    not(feature = "resolve-http")
+                ))]
                 {
                     compile_error!(
                         r#"the `reqwest` feature alone does not enable HTTP schema resolving anymore.


### PR DESCRIPTION
Since 0.15.1, jsonschema no longer compiles with HTTP resolution disabled altogether. The problem seems to be that the feature condition [here](https://github.com/Stranger6667/jsonschema-rs/blob/e2d09aa932145db970556eb1fe1ed6edb824a270/jsonschema/src/resolver.rs#L79-L83) is not specific enough; being the direct inverse of the feature gate for the HTTP resolution block below, it makes it impossible to disable said block without triggering a compile-time error. With this change, the compile error only triggers for an actual misconfiguration. It's lenient about redundantly specifying both reqwest and resolve-http, since that's what I would have done based on that error message.

I manually verified successful compilation with a dummy crate depending on jsonschema using the following feature sets:
 - `default-features = true`  -> compiles
 - `default-features = false` -> compiles (this being what failed before)
 - `default-features = false, features = ["reqwest"]` -> correctly triggers a compile error telling the user to use resolve-http or rustls as well
 - `default-features = false, features = ["reqwest", "resolve-http"]` -> compiles
 - `default-features = false, features = ["resolve-http"]` -> compiles
 - `default-features = false, features = ["reqwest", "rustls"]` -> compiles

Side note: it seems odd to me that this change was made within a SemVer-compatible version. Adding a compile error seems like a breaking change to me. In fact, it *did* break the crate I'm working on, forcing me to use `=0.15.0` for now.

See also #356, though they seem to take issue with the feature mechanism in general. I'm neutral in that regard, since I don't use any of them.