### PR TITLE
fix: Various compilation issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Library compilation with no default features. [#356](https://github.com/Stranger6667/jsonschema-rs/issues/356)
+- Compilation with `resolve-file` only. [#358](https://github.com/Stranger6667/jsonschema-rs/issues/358)
+
+### Changed
+
+- **BREAKING**: Revert changes from [#353](https://github.com/Stranger6667/jsonschema-rs/issues/353) and [#343](https://github.com/Stranger6667/jsonschema-rs/issues/343), as they caused compilation issues.
+
 ## [0.15.2] - 2022-04-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ Partially supported drafts (some keywords are not implemented):
 jsonschema = "0.15"
 ```
 
-By default `jsonschema` resolves remote references via HTTP by using `reqwest` with `native-tls`.
-If you'd like to use `rustls`, you have to explicitly enable `reqwest` and `rustls` features and disable `native-tls` via `default-features = false` in your `Cargo.toml` file.
-
 To validate documents against some schema and get validation errors (if any):
 
 ```rust
@@ -120,6 +117,17 @@ fn main() {
     );
 }
 ```
+
+## Reference resolving and TLS
+
+By default, `jsonschema` resolves HTTP references via `reqwest` without TLS support.
+If you'd like to resolve HTTPS, you need to enable TLS support in `reqwest`:
+
+```toml
+reqwest = { version = "*", features = [ "rustls-tls" ] }
+```
+
+Otherwise, you might get validation errors like `invalid URL, scheme is not http`.
 
 ## Status
 

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -21,11 +21,8 @@ default = ["resolve-http", "resolve-file", "cli"]
 draft201909 = []
 draft202012 = []
 
-resolve-http = ["reqwest", "native-tls"]
+resolve-http = ["reqwest"]
 resolve-file = []
-
-native-tls = ["reqwest/default-tls"]
-rustls = ["reqwest/rustls-tls"]
 
 [dependencies]
 ahash = { version = "0.7.6", features = ["serde"] }
@@ -42,7 +39,7 @@ num-cmp = "0.1.0"
 parking_lot = "0.12.0"
 percent-encoding = "2.1.0"
 regex = "1.5.4"
-reqwest = { package = "reqwest", version = "0.11.9", features = ["blocking", "json"], default-features = false, optional = true }
+reqwest = { version = "0.11.9", features = ["blocking", "json"], default-features = false, optional = true }
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = "1.0.79"
 structopt = { version = "0.3.26", optional = true }


### PR DESCRIPTION
Resolves #356
Resolves #358
Resolves #359

@tamasfe @jqnatividad @samueldotj @garypen @qdot @rawkode

Sorry for tagging, but as you opened issues about compilation problems or features not working properly, I assume, this change might affect you. I'd like to let you know about this change upfront, so you can try it out and share your concerns. 

It effectively reverts #351 and #355, so if one wants to enable a specific TLS backend, then it requires an explicit `reqwest` feature:

```toml
reqwest = { version = "*", features = [ "rustls-tls" ] }
```

I am also open to submitting PRs to your open repos when the new `jsonschema` version is released, let me know if I can help there.

As a separate measure, I'd also work on including [cargo-hack](https://github.com/taiki-e/cargo-hack) into the pipeline to avoid compilation errors due to feature config in the future.

Once again, sorry for the complication.