### PR TITLE
feat: optional unknown formats as compilation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add a compilation option (`should_ignore_unknown_formats()`) that allows treating unknown formats as compilation errors.
+
 ## [0.16.0] - 2022-04-21
 
 ### Fixed
@@ -236,7 +240,7 @@
 ### Fixed
 
 - Reject IPv4 addresses with leading zeroes. As per the new test case in the JSONSchema test suite. [More info](https://sick.codes/universal-netmask-npm-package-used-by-270000-projects-vulnerable-to-octal-input-data-server-side-request-forgery-remote-file-inclusion-local-file-inclusion-and-more-cve-2021-28918/)
-- Do not look for sub-schemas inside `const` and `enum` keywords. Fixes an issue checked by [these tests](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/471) 
+- Do not look for sub-schemas inside `const` and `enum` keywords. Fixes an issue checked by [these tests](https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/471)
 - Check all properties in the `required` keyword implementation. [#190](https://github.com/Stranger6667/jsonschema-rs/issues/190)
 
 ### Removed

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -221,6 +221,7 @@ pub struct CompilationOptions {
     formats: AHashMap<&'static str, fn(&str) -> bool>,
     validate_formats: Option<bool>,
     validate_schema: bool,
+    ignore_unknown_formats: bool,
 }
 
 impl Default for CompilationOptions {
@@ -234,6 +235,7 @@ impl Default for CompilationOptions {
             store: AHashMap::default(),
             formats: AHashMap::default(),
             validate_formats: None,
+            ignore_unknown_formats: true,
         }
     }
 }
@@ -567,6 +569,20 @@ impl CompilationOptions {
     pub(crate) fn validate_formats(&self) -> bool {
         self.validate_formats
             .unwrap_or_else(|| self.draft().validate_formats_by_default())
+    }
+
+    /// Set the `false` if unrecognized formats should be reported as a validation error.
+    /// By default unknown formats are silently ignored.
+    pub fn should_ignore_unknown_formats(
+        &mut self,
+        should_ignore_unknown_formats: bool,
+    ) -> &mut Self {
+        self.ignore_unknown_formats = should_ignore_unknown_formats;
+        self
+    }
+
+    pub(crate) const fn are_unknown_formats_ignored(&self) -> bool {
+        self.ignore_unknown_formats
     }
 }
 // format name & a pointer to a check function


### PR DESCRIPTION
enable the possibility of treating the unknown formats as errors. Currently, all unknown formats are silently ignored.

The PR isn't a breaking change -the default behavior remains unchanged.
