### PR TITLE
bump fraction from 0.10.0 to 0.11.0

### DIFF
--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -25,37 +25,37 @@ resolve-http = ["reqwest"]
 resolve-file = []
 
 [dependencies]
-ahash = { version = "0.7.6", features = ["serde"] }
-anyhow = "1.0.55"
-base64 = "0.13.0"
-bytecount = { version = "0.6.2", features = ["runtime-dispatch-simd"] }
-fancy-regex = "0.10.0"
-fraction = { version = "0.11.0", default-features = false, features = ["with-bigint"] }
-iso8601 = "0.4.1"
-itoa = "1.0.1"
-lazy_static = "1.4.0"
-memchr = "2.4.1"
-num-cmp = "0.1.0"
-parking_lot = "0.12.0"
-percent-encoding = "2.1.0"
-regex = "1.5.4"
-reqwest = { version = "0.11.9", features = ["blocking", "json"], default-features = false, optional = true }
-serde = { version = "1.0.136", features = ["derive"] }
-serde_json = "1.0.79"
-structopt = { version = "0.3.26", optional = true }
-time = { version = "0.3.7", features = ["parsing", "macros"] }
-url = "2.2.2"
-uuid = "1.0.0"
+ahash = { version = "0.8", features = ["serde"] }
+anyhow = "1.0"
+base64 = "0.13"
+bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
+fancy-regex = "0.10"
+fraction = { version = "0.11", default-features = false, features = ["with-bigint"] }
+iso8601 = "0.5"
+itoa = "1"
+lazy_static = "1.4"
+memchr = "2.5"
+num-cmp = "0.1"
+parking_lot = "0.12"
+percent-encoding = "2.1"
+regex = "1.6"
+reqwest = { version = "0.11", features = ["blocking", "json"], default-features = false, optional = true }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+structopt = { version = "0.3", optional = true }
+time = { version = "0.3", features = ["parsing", "macros"] }
+url = "2.2"
+uuid = "1"
 
 [dev-dependencies]
 bench_helpers = { path = "../bench_helpers" }
-criterion = "0.3.5"
+criterion = "0.3"
 json_schema_test_suite = { version = "0.3.0", path = "../jsonschema-test-suite" }
-jsonschema-valid = "0.4.0"
-mockito = "0.31.0"
-paste = "1.0.6"
-test-case = "2.0.2"
-valico = "3.6.0"
+jsonschema-valid = "0.5"
+mockito = "0.31"
+paste = "1.0"
+test-case = "2"
+valico = "3.6"
 
 # Benchmarks for `jsonschema`
 [[bench]]

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -30,7 +30,7 @@ anyhow = "1.0.55"
 base64 = "0.13.0"
 bytecount = { version = "0.6.2", features = ["runtime-dispatch-simd"] }
 fancy-regex = "0.10.0"
-fraction = { version = "0.10.0", default-features = false, features = ["with-bigint"] }
+fraction = { version = "0.11.0", default-features = false, features = ["with-bigint"] }
 iso8601 = "0.4.1"
 itoa = "1.0.1"
 lazy_static = "1.4.0"


### PR DESCRIPTION
this eliminates the dependency on num 0.2.1, allowing the use of num 0.4.0