### PR TITLE
feat: Custom keyword validation

### DIFF
--- a/jsonschema/src/compilation/mod.rs
+++ b/jsonschema/src/compilation/mod.rs
@@ -6,7 +6,7 @@ pub(crate) mod options;
 
 use crate::{
     error::ErrorIterator,
-    keywords,
+    keywords::{self, custom_keyword::compile_custom_keyword_validator},
     output::Output,
     paths::{InstancePath, JSONPointer},
     primitive_type::{PrimitiveType, PrimitiveTypesBitMap},
@@ -205,6 +205,16 @@ pub(crate) fn compile_validators<'a, 'c>(
                         .and_then(|f| f(object, subschema, &context))
                     {
                         validators.push((keyword.clone(), validator?));
+                    } else if let Some(keyword_definition) =
+                        context.config.get_custom_keyword_definition(keyword)
+                    {
+                        let validator = compile_custom_keyword_validator(
+                            &context,
+                            keyword.clone(),
+                            keyword_definition,
+                            subschema.clone(),
+                        )?;
+                        validators.push((keyword.clone(), validator));
                     } else {
                         unmatched_keywords.insert(keyword.to_string(), subschema.clone());
                     }
@@ -244,9 +254,15 @@ pub(crate) fn compile_validators<'a, 'c>(
 #[cfg(test)]
 mod tests {
     use super::JSONSchema;
-    use crate::error::ValidationError;
+    use crate::{
+        compilation::options::CustomKeywordDefinition,
+        error::{TypeKind, ValidationError},
+        paths::JSONPointer,
+        primitive_type::PrimitiveType,
+        ErrorIterator,
+    };
     use serde_json::{from_str, json, Value};
-    use std::{fs::File, io::Read, path::Path};
+    use std::{borrow::Cow, fs::File, io::Read, path::Path, sync::Arc};
 
     fn load(path: &str, idx: usize) -> Value {
         let path = Path::new(path);
@@ -301,5 +317,78 @@ mod tests {
             r#"{"a":3} has less than 2 properties"#
         );
         assert_eq!(errors[1].to_string(), r#""a" is shorter than 3 characters"#);
+    }
+
+    #[test]
+    fn custom_keyword_defintion() {
+        // Define a custom validator that verifies the object's keys consist of
+        // only ASCII representable characters.
+        fn custom_object_validator(
+            instance: &Value,
+            instance_path: JSONPointer,
+            schema: Arc<Value>,
+            schema_path: JSONPointer,
+        ) -> ErrorIterator<'_> {
+            if schema.as_str().map_or(true, |str| str != "ascii-keys") {
+                let error = ValidationError {
+                    instance: Cow::Borrowed(instance),
+                    kind: crate::error::ValidationErrorKind::Schema,
+                    instance_path: instance_path.clone(),
+                    schema_path: schema_path.clone(),
+                };
+                return Box::new(Some(error).into_iter()); // Invalid schema
+            }
+            let mut errors = vec![];
+            for (key, _value) in instance.as_object().unwrap() {
+                if !key.is_ascii() {
+                    let error = ValidationError {
+                        instance: Cow::Borrowed(instance),
+                        kind: crate::error::ValidationErrorKind::Format { format: "ASCII" },
+                        instance_path: instance_path.clone(),
+                        schema_path: schema_path.clone(),
+                    };
+                    errors.push(error);
+                }
+            }
+            Box::new(errors.into_iter())
+        }
+        fn is_custom_object_valid(instance: &Value, schema: &Value) -> bool {
+            if schema.as_str().map_or(true, |str| str != "ascii-keys") {
+                return false; // Invalid schema
+            }
+            for (key, _value) in instance.as_object().unwrap() {
+                if !key.is_ascii() {
+                    return false;
+                }
+            }
+            true
+        }
+        let definition = CustomKeywordDefinition::Validator {
+            validate: custom_object_validator,
+            is_valid: is_custom_object_valid,
+        };
+
+        // Define a JSON schema that enforces the top level object has ASCII keys and has at least 1 property
+        let schema =
+            json!({ "custom-object-type": "ascii-keys", "type": "object", "minProperties": 1 });
+        let json_schema = JSONSchema::options()
+            .with_custom_keyword("custom-object-type", definition)
+            .compile(&schema)
+            .unwrap();
+
+        // Verify schema validation detects object with too few properties
+        let instance_err_not_object = json!({});
+        assert!(json_schema.validate(&instance_err_not_object).is_err());
+        assert!(!json_schema.is_valid(&instance_err_not_object));
+
+        // Verify validator succeeds on a valid custom-object-type
+        let instance_ok = json!({ "a" : 1 });
+        assert!(json_schema.validate(&instance_ok).is_ok());
+        assert!(json_schema.is_valid(&instance_ok));
+
+        // Verify validator detects invalid custom-object-type
+        let instance_err_non_ascii_keys = json!({ "å" : 1 });
+        assert!(json_schema.validate(&instance_err_non_ascii_keys).is_err());
+        assert!(!json_schema.is_valid(&instance_err_non_ascii_keys));
     }
 }

--- a/jsonschema/src/compilation/mod.rs
+++ b/jsonschema/src/compilation/mod.rs
@@ -255,10 +255,7 @@ pub(crate) fn compile_validators<'a, 'c>(
 mod tests {
     use super::JSONSchema;
     use crate::{
-        compilation::options::CustomKeywordDefinition,
-        error::{TypeKind, ValidationError},
-        paths::JSONPointer,
-        primitive_type::PrimitiveType,
+        compilation::options::CustomKeywordDefinition, error::ValidationError, paths::JSONPointer,
         ErrorIterator,
     };
     use serde_json::{from_str, json, Value};
@@ -266,7 +263,7 @@ mod tests {
 
     fn load(path: &str, idx: usize) -> Value {
         let path = Path::new(path);
-        let mut file = File::open(&path).unwrap();
+        let mut file = File::open(path).unwrap();
         let mut content = String::new();
         file.read_to_string(&mut content).ok().unwrap();
         let data: Value = from_str(&content).unwrap();
@@ -323,6 +320,7 @@ mod tests {
     fn custom_keyword_defintion() {
         // Define a custom validator that verifies the object's keys consist of
         // only ASCII representable characters.
+        #[allow(clippy::needless_pass_by_value)]
         fn custom_object_validator(
             instance: &Value,
             instance_path: JSONPointer,
@@ -333,8 +331,8 @@ mod tests {
                 let error = ValidationError {
                     instance: Cow::Borrowed(instance),
                     kind: crate::error::ValidationErrorKind::Schema,
-                    instance_path: instance_path.clone(),
-                    schema_path: schema_path.clone(),
+                    instance_path,
+                    schema_path,
                 };
                 return Box::new(Some(error).into_iter()); // Invalid schema
             }

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use ahash::AHashMap;
 use std::{
-    fmt::{self, Display},
+    fmt::{self},
     sync::Arc,
 };
 

--- a/jsonschema/src/compilation/options.rs
+++ b/jsonschema/src/compilation/options.rs
@@ -5,11 +5,15 @@ use crate::{
         DEFAULT_CONTENT_ENCODING_CHECKS_AND_CONVERTERS,
     },
     content_media_type::{ContentMediaTypeCheckType, DEFAULT_CONTENT_MEDIA_TYPE_CHECKS},
+    keywords::custom_keyword::{CustomIsValidFn, CustomValidateFn},
     resolver::{DefaultResolver, Resolver, SchemaResolver},
     schemas, ValidationError,
 };
 use ahash::AHashMap;
-use std::{fmt, sync::Arc};
+use std::{
+    fmt::{self, Display},
+    sync::Arc,
+};
 
 const EXPECT_MESSAGE: &str = "Valid meta-schema!";
 
@@ -222,6 +226,7 @@ pub struct CompilationOptions {
     validate_formats: Option<bool>,
     validate_schema: bool,
     ignore_unknown_formats: bool,
+    custom_keywords: AHashMap<String, CustomKeywordDefinition>,
 }
 
 impl Default for CompilationOptions {
@@ -236,6 +241,7 @@ impl Default for CompilationOptions {
             formats: AHashMap::default(),
             validate_formats: None,
             ignore_unknown_formats: true,
+            custom_keywords: AHashMap::default(),
         }
     }
 }
@@ -584,6 +590,50 @@ impl CompilationOptions {
     pub(crate) const fn are_unknown_formats_ignored(&self) -> bool {
         self.ignore_unknown_formats
     }
+
+    /// Register a custom keyword definition.
+    ///
+    /// Examples
+    ///
+    /// ```rust
+    /// # use jsonschema::{CustomKeywordDefinition, ErrorIterator, JSONSchema, paths::JSONPointer};
+    /// # use serde_json::{json, Value};
+    /// # use std::sync::Arc;
+    ///
+    /// fn validate(
+    ///     instance: &Value,
+    ///     instance_path: JSONPointer,
+    ///     schema: Arc<Value>,
+    ///     schema_path: JSONPointer,
+    /// ) -> ErrorIterator {
+    ///     // ... validate instance ...
+    ///     Box::new(None.into_iter())
+    /// }
+    /// fn is_valid(instance: &Value, schema: &Value) -> bool {
+    ///     // ... determine if instance is valid ...
+    ///     return true;
+    /// }
+    /// let definition = CustomKeywordDefinition::Validator { validate, is_valid };
+    /// assert!(JSONSchema::options()
+    ///     .with_custom_keyword("my-type", definition)
+    ///     .compile(&json!({ "my-type": "my-schema"}))
+    ///     .expect("A valid schema")
+    ///     .is_valid(&json!({ "a": "b"})));
+    /// ```
+    pub fn with_custom_keyword<T>(mut self, keyword: T, definition: CustomKeywordDefinition) -> Self
+    where
+        T: Into<String>,
+    {
+        self.custom_keywords.insert(keyword.into(), definition);
+        self
+    }
+
+    pub(crate) fn get_custom_keyword_definition(
+        &self,
+        keyword: &str,
+    ) -> Option<&CustomKeywordDefinition> {
+        self.custom_keywords.get(keyword)
+    }
 }
 // format name & a pointer to a check function
 type FormatKV<'a> = Option<(&'a &'static str, &'a fn(&str) -> bool)>;
@@ -598,6 +648,34 @@ impl fmt::Debug for CompilationOptions {
                 &self.content_encoding_checks_and_converters.keys(),
             )
             .finish()
+    }
+}
+
+/// Define a custom keyword validation
+///
+/// Currently supports validation functions.
+/// Schema based custom validation is a potential future addition.
+#[derive(Clone)]
+pub enum CustomKeywordDefinition {
+    /// Validate [instance](serde_json::Value) according to a custom specification
+    ///
+    /// A custom keyword validator may be used when a validation that cannot, or
+    /// cannot be be easily or efficiently expressed in JSON schema.
+    ///
+    /// The custom validation is applied in addition to the JSON schema validation.
+    Validator {
+        /// Validate an instance returning any and all detected validation errors
+        validate: CustomValidateFn,
+        /// Determine if an instance is valid
+        is_valid: CustomIsValidFn,
+    },
+}
+
+impl fmt::Debug for CustomKeywordDefinition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Validator { .. } => write!(f, "CustomKeywordDefinition::Validator"),
+        }
     }
 }
 

--- a/jsonschema/src/keywords/custom_keyword.rs
+++ b/jsonschema/src/keywords/custom_keyword.rs
@@ -8,6 +8,8 @@ use serde_json::Value;
 use std::fmt::{Display, Formatter};
 use std::sync::Arc;
 
+// An Arc<Value> is used so the borrow checker doesn't need explicit lifetime parameters.
+// This would pollute dependents with lifetime parameters. 
 pub(crate) type CustomValidateFn =
     fn(&Value, JSONPointer, Arc<Value>, JSONPointer) -> ErrorIterator;
 pub(crate) type CustomIsValidFn = fn(&Value, &Value) -> bool;

--- a/jsonschema/src/keywords/custom_keyword.rs
+++ b/jsonschema/src/keywords/custom_keyword.rs
@@ -1,0 +1,65 @@
+use crate::compilation::context::CompilationContext;
+use crate::compilation::options::CustomKeywordDefinition;
+use crate::keywords::CompilationResult;
+use crate::paths::{InstancePath, JSONPointer, PathChunk};
+use crate::validator::Validate;
+use crate::ErrorIterator;
+use serde_json::Value;
+use std::fmt::{Display, Formatter};
+use std::sync::Arc;
+
+pub(crate) type CustomValidateFn =
+    fn(&Value, JSONPointer, Arc<Value>, JSONPointer) -> ErrorIterator;
+pub(crate) type CustomIsValidFn = fn(&Value, &Value) -> bool;
+
+/// Custom keyword validation implemented by user provided validation functions.
+pub(crate) struct CustomKeywordValidator {
+    schema: Arc<Value>,
+    schema_path: JSONPointer,
+    validate: CustomValidateFn,
+    is_valid: CustomIsValidFn,
+}
+
+impl Display for CustomKeywordValidator {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "")
+    }
+}
+
+impl Validate for CustomKeywordValidator {
+    fn validate<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+    ) -> ErrorIterator<'instance> {
+        (self.validate)(
+            instance,
+            instance_path.into(),
+            self.schema.clone(),
+            self.schema_path.clone(),
+        )
+    }
+
+    fn is_valid(&self, instance: &Value) -> bool {
+        (self.is_valid)(instance, &self.schema)
+    }
+}
+
+pub(crate) fn compile_custom_keyword_validator<'a>(
+    context: &CompilationContext,
+    keyword: impl Into<PathChunk>,
+    keyword_definition: &CustomKeywordDefinition,
+    schema: Value,
+) -> CompilationResult<'a> {
+    let schema_path = context.as_pointer_with(keyword);
+    match keyword_definition {
+        CustomKeywordDefinition::Validator { validate, is_valid } => {
+            Ok(Box::new(CustomKeywordValidator {
+                schema: Arc::new(schema),
+                schema_path,
+                validate: *validate,
+                is_valid: *is_valid,
+            }))
+        }
+    }
+}

--- a/jsonschema/src/keywords/mod.rs
+++ b/jsonschema/src/keywords/mod.rs
@@ -6,6 +6,7 @@ pub(crate) mod boolean;
 pub(crate) mod const_;
 pub(crate) mod contains;
 pub(crate) mod content;
+pub(crate) mod custom_keyword;
 pub(crate) mod dependencies;
 pub(crate) mod enum_;
 pub(crate) mod exclusive_maximum;

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -96,7 +96,10 @@ mod schema_node;
 mod schemas;
 mod validator;
 
-pub use compilation::{options::CompilationOptions, JSONSchema};
+pub use compilation::{
+    options::{CompilationOptions, CustomKeywordDefinition},
+    JSONSchema,
+};
 pub use error::{ErrorIterator, ValidationError};
 pub use resolver::{SchemaResolver, SchemaResolverError};
 pub use schemas::Draft;

--- a/jsonschema/tests/test_suite.rs
+++ b/jsonschema/tests/test_suite.rs
@@ -1,5 +1,5 @@
-use json_schema_test_suite::{json_schema_test_suite, TestCase};
-use jsonschema::{Draft, JSONSchema};
+use json_schema_test_suite::json_schema_test_suite;
+use jsonschema::JSONSchema;
 use std::fs;
 
 #[json_schema_test_suite("tests/suite", "draft4", {"optional_bignum_0_0", "optional_bignum_2_0"})]


### PR DESCRIPTION
Add support for user defined custom keyword validation. The user provides and registers custom validator functions when configuring a JSONSchema.

Custom keyword validators may be used when the user wants to enforce constraints that can't, or can't easily, be expressed in JSON schema.

This PR addresses at least some of the features requested in #379 by @tamasfe as well as my own. The same pros and cons described in #379 apply. The PR also follows the structure of #354, but of course uses validation functions as opposed to sub-schema for validation.

We could collapse the two user implementable validation functions into a single trait, mirroring the internal `Validate` trait. Implementations would have to sit behind an `Arc`.

Example usage
```rust
use jsonschema::{CustomKeywordDefinition, ErrorIterator, JSONSchema, paths::JSONPointer};
use serde_json::{json, Value};
use std::sync::Arc;

fn validate(
    instance: &Value,
    instance_path: JSONPointer,
    schema: Arc<Value>,
    schema_path: JSONPointer,
) -> ErrorIterator {
    // ... validate instance ... 
    Box::new(None.into_iter())
}
fn is_valid(instance: &Value, schema: &Value) -> bool {
    // ... determine if instance is valid ... 
    return true;
}
let definition = CustomKeywordDefinition::Validator { validate, is_valid };
assert!(JSONSchema::options()
    .with_custom_keyword("my-type", definition)
    .compile(&json!({ "my-type": "my-schema"}))
    .expect("A valid schema")
    .is_valid(&json!({ "a": "b"})));
``` 