### PR TITLE
chore: remove deprecated epsilon reference

### DIFF
--- a/jsonschema/src/keywords/multiple_of.rs
+++ b/jsonschema/src/keywords/multiple_of.rs
@@ -8,7 +8,6 @@ use crate::{
 };
 use fraction::{BigFraction, BigUint};
 use serde_json::{Map, Value};
-use std::f64::EPSILON;
 
 pub(crate) struct MultipleOfFloatValidator {
     multiple_of: f64,
@@ -39,7 +38,7 @@ impl Validate for MultipleOfFloatValidator {
                     true
                 }
             } else {
-                remainder < EPSILON
+                remainder < f64::EPSILON
             }
         } else {
             true


### PR DESCRIPTION
See https://doc.rust-lang.org/std/f64/constant.EPSILON.html
Updated to https://doc.rust-lang.org/std/primitive.f64.html#associatedconstant.EPSILON
