### PR TITLE
Don't depend on a particular ahash rng

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,38 @@ jobs:
       - run: cargo test --no-fail-fast --features ${{ matrix.draft }}
         working-directory: ./jsonschema
 
+  build-wasm32:
+    strategy:
+      fail-fast: false
+      matrix:
+        target: ['wasm32-unknown-unknown']
+
+    name: Build on ${{ matrix.target }}
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          target: ${{ matrix.target }}
+          override: true
+
+      - name: Cache cargo
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: stable-${{ matrix.target }}-cargo-cache
+
+      - run: cargo build --target ${{ matrix.target }} --no-default-features --features=cli
+        working-directory: ./jsonschema
+
   coverage:
     name: Run test coverage
     runs-on: ubuntu-20.04
@@ -163,7 +195,6 @@ jobs:
       - name: Installing sdist
         run: pip install dist/*
         working-directory: ./bindings/python
-
 
   fmt:
     name: Rustfmt

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -17,7 +17,7 @@ name = "jsonschema"
 
 [features]
 cli = ["clap"]
-default = ["resolve-http", "resolve-file", "cli"]
+default = ["resolve-http", "resolve-file", "cli", "ahash/runtime-rng"]
 draft201909 = []
 draft202012 = []
 
@@ -25,7 +25,7 @@ resolve-http = ["reqwest"]
 resolve-file = []
 
 [dependencies]
-ahash = { version = "0.8", features = ["serde"] }
+ahash = { version = "0.8", default-features = false, features = ["no-rng", "std", "serde"] }
 anyhow = "1.0"
 base64 = "0.13"
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }

--- a/jsonschema/Cargo.toml
+++ b/jsonschema/Cargo.toml
@@ -17,7 +17,7 @@ name = "jsonschema"
 
 [features]
 cli = ["clap"]
-default = ["resolve-http", "resolve-file", "cli", "ahash/runtime-rng"]
+default = ["resolve-http", "resolve-file", "cli"]
 draft201909 = []
 draft202012 = []
 
@@ -25,7 +25,7 @@ resolve-http = ["reqwest"]
 resolve-file = []
 
 [dependencies]
-ahash = { version = "0.8", default-features = false, features = ["no-rng", "std", "serde"] }
+ahash = { version = "0.8", features = ["serde"] }
 anyhow = "1.0"
 base64 = "0.13"
 bytecount = { version = "0.6", features = ["runtime-dispatch-simd"] }
@@ -46,6 +46,9 @@ serde_json = "1.0"
 time = { version = "0.3", features = ["parsing", "macros"] }
 url = "2.2"
 uuid = "1"
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+getrandom = { version = "0.2", features = ["js"] }
 
 [dev-dependencies]
 bench_helpers = { path = "../bench_helpers" }


### PR DESCRIPTION
I'm not very familiar with `ahash`, or WASM in general, but it seems like `ahash`'s default randomness source panics when run inside a WASM environment. This change should make it so that `jsonschema` uses the runtime randomness source by default, but will not require it when included with `default-features = false`.