### PR TITLE
Add support for `unevaluatedProperties` + a few other changes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
 - Bump `fraction` to `0.13`.
 - Bump `iso8601` to `0.6`.
 - Replace `lazy_static` with `once_cell`.
+- Add support for `unevaluatedProperties`. (gated by the `draft201909`/`draft202012` feature flags)
+- When using the draft 2019-09 or draft 2020-12 specification, `$ref` is now evaluated alongside
+  other keywords.
 
 ## [0.16.1] - 2022-10-20
 

--- a/jsonschema/src/keywords/mod.rs
+++ b/jsonschema/src/keywords/mod.rs
@@ -34,6 +34,8 @@ pub(crate) mod property_names;
 pub(crate) mod ref_;
 pub(crate) mod required;
 pub(crate) mod type_;
+#[cfg(any(feature = "draft201909", feature = "draft202012"))]
+pub(crate) mod unevaluated_properties;
 pub(crate) mod unique_items;
 use crate::{error, validator::Validate};
 

--- a/jsonschema/src/keywords/unevaluated_properties.rs
+++ b/jsonschema/src/keywords/unevaluated_properties.rs
@@ -1,0 +1,1108 @@
+use std::sync::Arc;
+
+use crate::{
+    compilation::{compile_validators, context::CompilationContext},
+    error::{no_error, ErrorIterator, ValidationError},
+    keywords::CompilationResult,
+    output::BasicOutput,
+    paths::{InstancePath, JSONPointer},
+    primitive_type::PrimitiveType,
+    properties::*,
+    schema_node::SchemaNode,
+    validator::{PartialApplication, Validate},
+};
+use ahash::AHashMap;
+use serde_json::{Map, Value};
+
+/// A validator for unevaluated properties.
+///
+/// In contrast to `additionalProperties`, which can only be used for properties defined in a schema
+/// of type `object`, `unevaluatedProperties` can "see through" advanced validation features like
+/// subschema validation (`allOf`, `oneOf`, `anyOf`), conditional validation (`if`/`then`/`else`),
+/// dependent schemas (`dependentSchemas`), and schema references (`$ref`), which allows applying
+/// `additionalProperties`-like behavior to schemas which use the aforementioned advanced validation
+/// keywords.
+#[derive(Debug)]
+struct UnevaluatedPropertiesValidator {
+    schema_path: JSONPointer,
+    unevaluated: UnevaluatedSubvalidator,
+    properties: Option<PropertySubvalidator>,
+    patterns: Option<PatternSubvalidator>,
+    conditional: Option<Box<ConditionalSubvalidator>>,
+    dependent: Option<DependentSchemaSubvalidator>,
+    reference: Option<ReferenceSubvalidator>,
+    subschemas: Option<Vec<SubschemaSubvalidator>>,
+}
+
+impl UnevaluatedPropertiesValidator {
+    fn compile<'a>(
+        parent: &'a Map<String, Value>,
+        schema: &'a Value,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        let unevaluated = UnevaluatedSubvalidator::from_value(parent, schema, context)?;
+
+        let properties = parent
+            .get("properties")
+            .map(|properties| PropertySubvalidator::from_value(properties, context))
+            .transpose()?;
+        let patterns = parent
+            .get("patternProperties")
+            .map(|pattern_properties| PatternSubvalidator::from_value(pattern_properties, context))
+            .transpose()?;
+
+        let conditional = parent
+            .get("if")
+            .map(|condition| {
+                let success = parent.get("then");
+                let failure = parent.get("else");
+
+                ConditionalSubvalidator::from_values(condition, success, failure, context)
+                    .map(Box::new)
+            })
+            .transpose()?;
+
+        let dependent = parent
+            .get("dependentSchemas")
+            .map(|dependent_schemas| {
+                DependentSchemaSubvalidator::from_value(dependent_schemas, context)
+            })
+            .transpose()?;
+
+        let reference = parent
+            .get("$ref")
+            .map(|reference| ReferenceSubvalidator::from_value(reference, context))
+            .transpose()?
+            .flatten();
+
+        let mut subschema_validators = vec![];
+        if let Some(Value::Array(subschemas)) = parent.get("allOf") {
+            let validator = SubschemaSubvalidator::from_values(subschemas, context)?;
+            subschema_validators.push(validator);
+        }
+
+        if let Some(Value::Array(subschemas)) = parent.get("anyOf") {
+            let validator = SubschemaSubvalidator::from_values(subschemas, context)?;
+            subschema_validators.push(validator);
+        }
+
+        if let Some(Value::Array(subschemas)) = parent.get("oneOf") {
+            let validator = SubschemaSubvalidator::from_values(subschemas, context)?;
+            subschema_validators.push(validator);
+        }
+
+        let subschemas = if subschema_validators.is_empty() {
+            None
+        } else {
+            Some(subschema_validators)
+        };
+
+        Ok(Self {
+            schema_path: JSONPointer::from(&context.schema_path),
+            unevaluated,
+            properties,
+            patterns,
+            conditional,
+            dependent,
+            reference,
+            subschemas,
+        })
+    }
+
+    fn is_valid_property(
+        &self,
+        instance: &Value,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<bool> {
+        self.properties
+            .as_ref()
+            .and_then(|prop_map| prop_map.is_valid_property(property_instance, property_name))
+            .or_else(|| {
+                self.patterns.as_ref().and_then(|patterns| {
+                    patterns.is_valid_property(property_instance, property_name)
+                })
+            })
+            .or_else(|| {
+                self.conditional.as_ref().and_then(|conditional| {
+                    conditional.is_valid_property(instance, property_instance, property_name)
+                })
+            })
+            .or_else(|| {
+                self.dependent.as_ref().and_then(|dependent| {
+                    dependent.is_valid_property(instance, property_instance, property_name)
+                })
+            })
+            .or_else(|| {
+                self.reference.as_ref().and_then(|reference| {
+                    reference.is_valid_property(instance, property_instance, property_name)
+                })
+            })
+            .or_else(|| {
+                self.subschemas.as_ref().and_then(|subschemas| {
+                    subschemas.iter().find_map(|subschema| {
+                        subschema.is_valid_property(instance, property_instance, property_name)
+                    })
+                })
+            })
+            .or_else(|| {
+                self.unevaluated
+                    .is_valid_property(property_instance, property_name)
+            })
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        self.properties
+            .as_ref()
+            .and_then(|prop_map| {
+                prop_map.validate_property(property_path, property_instance, property_name)
+            })
+            .or_else(|| {
+                self.patterns.as_ref().and_then(|patterns| {
+                    patterns.validate_property(property_path, property_instance, property_name)
+                })
+            })
+            .or_else(|| {
+                self.conditional.as_ref().and_then(|conditional| {
+                    conditional.validate_property(
+                        instance,
+                        instance_path,
+                        property_path,
+                        property_instance,
+                        property_name,
+                    )
+                })
+            })
+            .or_else(|| {
+                self.dependent.as_ref().and_then(|dependent| {
+                    dependent.validate_property(
+                        instance,
+                        instance_path,
+                        property_path,
+                        property_instance,
+                        property_name,
+                    )
+                })
+            })
+            .or_else(|| {
+                self.reference.as_ref().and_then(|reference| {
+                    reference.validate_property(
+                        instance,
+                        instance_path,
+                        property_path,
+                        property_instance,
+                        property_name,
+                    )
+                })
+            })
+            .or_else(|| {
+                let result = self.subschemas.as_ref().and_then(|subschemas| {
+                    subschemas.iter().find_map(|subschema| {
+                        subschema.validate_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+                });
+
+                result
+            })
+            .or_else(|| {
+                self.unevaluated
+                    .validate_property(property_path, property_instance, property_name)
+            })
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        instance: &Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        self.properties
+            .as_ref()
+            .and_then(|prop_map| {
+                prop_map.apply_property(property_path, property_instance, property_name)
+            })
+            .or_else(|| {
+                self.patterns.as_ref().and_then(|patterns| {
+                    patterns.apply_property(property_path, property_instance, property_name)
+                })
+            })
+            .or_else(|| {
+                self.conditional.as_ref().and_then(|conditional| {
+                    conditional.apply_property(
+                        instance,
+                        instance_path,
+                        property_path,
+                        property_instance,
+                        property_name,
+                    )
+                })
+            })
+            .or_else(|| {
+                self.dependent.as_ref().and_then(|dependent| {
+                    dependent.apply_property(
+                        instance,
+                        instance_path,
+                        property_path,
+                        property_instance,
+                        property_name,
+                    )
+                })
+            })
+            .or_else(|| {
+                self.reference.as_ref().and_then(|reference| {
+                    reference.apply_property(
+                        instance,
+                        instance_path,
+                        property_path,
+                        property_instance,
+                        property_name,
+                    )
+                })
+            })
+            .or_else(|| {
+                let result = self.subschemas.as_ref().and_then(|subschemas| {
+                    subschemas.iter().find_map(|subschema| {
+                        subschema.apply_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+                });
+
+                result
+            })
+            .or_else(|| {
+                self.unevaluated
+                    .apply_property(property_path, property_instance, property_name)
+            })
+    }
+}
+
+impl Validate for UnevaluatedPropertiesValidator {
+    fn is_valid(&self, instance: &Value) -> bool {
+        if let Value::Object(props) = instance {
+            props.iter().all(|(property_name, property_instance)| {
+                self.is_valid_property(instance, property_instance, property_name)
+                    .unwrap_or(false)
+            })
+        } else {
+            true
+        }
+    }
+
+    fn validate<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+    ) -> ErrorIterator<'instance> {
+        if let Value::Object(props) = instance {
+            let mut errors = vec![];
+            let mut unexpected = vec![];
+
+            for (property_name, property_instance) in props {
+                let property_path = instance_path.push(property_name.clone());
+                let maybe_property_errors = self.validate_property(
+                    instance,
+                    instance_path,
+                    &property_path,
+                    property_instance,
+                    property_name,
+                );
+
+                match maybe_property_errors {
+                    Some(property_errors) => errors.extend(property_errors),
+                    None => {
+                        // If we can't validate, that means that "unevaluatedProperties" is
+                        // "false", which means that this property was not expected.
+                        unexpected.push(property_name.to_string());
+                    }
+                }
+            }
+
+            if !unexpected.is_empty() {
+                errors.push(ValidationError::unevaluated_properties(
+                    self.schema_path.clone(),
+                    instance_path.into(),
+                    instance,
+                    unexpected,
+                ))
+            }
+            Box::new(errors.into_iter())
+        } else {
+            no_error()
+        }
+    }
+
+    fn apply<'a>(
+        &'a self,
+        instance: &Value,
+        instance_path: &InstancePath,
+    ) -> PartialApplication<'a> {
+        if let Value::Object(props) = instance {
+            let mut output = BasicOutput::default();
+            let mut unexpected = vec![];
+
+            for (property_name, property_instance) in props {
+                let property_path = instance_path.push(property_name.clone());
+                let maybe_property_output = self.apply_property(
+                    instance,
+                    instance_path,
+                    &property_path,
+                    property_instance,
+                    property_name,
+                );
+
+                match maybe_property_output {
+                    Some(property_output) => output += property_output,
+                    None => {
+                        // If we can't validate, that means that "unevaluatedProperties" is
+                        // "false", which means that this property was not expected.
+                        unexpected.push(property_name.to_string());
+                    }
+                }
+            }
+
+            let mut result: PartialApplication = output.into();
+            if !unexpected.is_empty() {
+                result.mark_errored(
+                    ValidationError::unevaluated_properties(
+                        self.schema_path.clone(),
+                        instance_path.into(),
+                        instance,
+                        unexpected,
+                    )
+                    .into(),
+                )
+            }
+            result
+        } else {
+            PartialApplication::valid_empty()
+        }
+    }
+}
+
+impl core::fmt::Display for UnevaluatedPropertiesValidator {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        "unevaluatedProperties: {}".fmt(f)
+    }
+}
+
+/// A subvalidator for properties.
+#[derive(Debug)]
+struct PropertySubvalidator {
+    prop_map: SmallValidatorsMap,
+}
+
+impl PropertySubvalidator {
+    fn from_value<'a>(
+        properties: &'a Value,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        properties
+            .as_object()
+            .ok_or_else(ValidationError::null_schema)
+            .and_then(|props| SmallValidatorsMap::from_map(props, context))
+            .map(|prop_map| Self { prop_map })
+    }
+
+    fn is_valid_property(&self, property_instance: &Value, property_name: &str) -> Option<bool> {
+        self.prop_map
+            .get_validator(property_name)
+            .map(|node| node.is_valid(property_instance))
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        self.prop_map
+            .get_key_validator(property_name)
+            .map(|(_, node)| node.validate(property_instance, property_path))
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        self.prop_map
+            .get_key_validator(property_name)
+            .map(|(_, node)| node.apply_rooted(property_instance, property_path))
+    }
+}
+
+/// A subvalidator for pattern properties.
+#[derive(Debug)]
+struct PatternSubvalidator {
+    patterns: PatternedValidators,
+}
+
+impl PatternSubvalidator {
+    fn from_value<'a>(
+        properties: &'a Value,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        properties
+            .as_object()
+            .ok_or_else(ValidationError::null_schema)
+            .and_then(|props| compile_patterns(props, context))
+            .map(|patterns| Self { patterns })
+    }
+
+    fn is_valid_property(&self, property_instance: &Value, property_name: &str) -> Option<bool> {
+        let mut had_match = false;
+
+        for (pattern, node) in &self.patterns {
+            if pattern.is_match(property_name).unwrap_or(false) {
+                had_match = true;
+
+                if !node.is_valid(property_instance) {
+                    return Some(false);
+                }
+            }
+        }
+
+        had_match.then(|| true)
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        let mut had_match = false;
+        let mut errors = vec![];
+
+        for (pattern, node) in &self.patterns {
+            if pattern.is_match(property_name).unwrap_or(false) {
+                had_match = true;
+
+                errors.extend(node.validate(property_instance, property_path));
+            }
+        }
+
+        let errors: ErrorIterator<'instance> = Box::new(errors.into_iter());
+        had_match.then(|| errors)
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        let mut had_match = false;
+        let mut output = BasicOutput::default();
+
+        for (pattern, node) in &self.patterns {
+            if pattern.is_match(property_name).unwrap_or(false) {
+                had_match = true;
+
+                let pattern_output = node.apply_rooted(property_instance, property_path);
+                output += pattern_output;
+            }
+        }
+
+        had_match.then(|| output)
+    }
+}
+
+/// A subvalidator for subschema validation such as `allOf`, `oneOf`, and `anyOf`.
+///
+/// Unlike the validation logic for `allOf`/`oneOf`/`anyOf` themselves, this subvalidator searches
+/// configured subvalidators in a first-match-wins process. For example, a property will be
+/// considered evaluated against subschemas defined via `oneOf` so long as one subschema would evaluate
+/// the property, even if, say, more than one subschema in `oneOf` is technically valid, which would
+/// otherwise be a failure for validation of `oneOf` in and of itself.
+#[derive(Debug)]
+struct SubschemaSubvalidator {
+    subvalidators: Vec<UnevaluatedPropertiesValidator>,
+}
+
+impl SubschemaSubvalidator {
+    fn from_values<'a>(
+        values: &'a [Value],
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        let mut subvalidators = vec![];
+        for value in values {
+            if let Value::Object(subschema) = value {
+                let subvalidator = UnevaluatedPropertiesValidator::compile(
+                    subschema,
+                    get_unevaluated_props_schema(subschema),
+                    context,
+                )?;
+                subvalidators.push(subvalidator);
+            }
+        }
+
+        Ok(Self { subvalidators })
+    }
+
+    fn is_valid_property(
+        &self,
+        instance: &Value,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<bool> {
+        self.subvalidators.iter().find_map(|subvalidator| {
+            subvalidator.is_valid_property(instance, property_instance, property_name)
+        })
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        self.subvalidators.iter().find_map(|subvalidator| {
+            subvalidator.validate_property(
+                instance,
+                instance_path,
+                property_path,
+                property_instance,
+                property_name,
+            )
+        })
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        instance: &Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        self.subvalidators.iter().find_map(|subvalidator| {
+            subvalidator.apply_property(
+                instance,
+                instance_path,
+                property_path,
+                property_instance,
+                property_name,
+            )
+        })
+    }
+}
+
+/// Unevaluated properties behavior.
+#[derive(Debug)]
+enum UnevaluatedBehavior {
+    /// Unevaluated properties are allowed, regardless of instance value.
+    Allow,
+
+    /// Unevaluated properties are not allowed, regardless of instance value.
+    Deny,
+
+    /// Unevaluated properties are allowed, so long as the instance is valid against the given
+    /// schema.
+    IfValid(SchemaNode),
+}
+
+/// A subvalidator for unevaluated properties.
+#[derive(Debug)]
+struct UnevaluatedSubvalidator {
+    behavior: UnevaluatedBehavior,
+}
+
+impl UnevaluatedSubvalidator {
+    fn from_value<'a>(
+        parent: &'a Map<String, Value>,
+        value: &'a Value,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        // We also examine the value of `additionalProperties` here, if present, because if it's
+        // specified as `true`, it can potentially override the behavior of the validator depending
+        // on the value of `unevaluatedProperties`.
+        //
+        // TODO: We probably need to think about this more because `unevaluatedProperties` affects
+        // subschema validation, when really all we want to have this do (based on the JSON Schema
+        // test suite cases) is disable the `unevaluatedProperties: false` bit _just_ for normal
+        // properties on the top-level instance.
+        let additional_properties = parent.get("additionalProperties");
+        let behavior = match (value, additional_properties) {
+            (Value::Bool(false), None) | (Value::Bool(false), Some(Value::Bool(false))) => {
+                UnevaluatedBehavior::Deny
+            }
+            (Value::Bool(true), _) | (Value::Bool(false), Some(Value::Bool(true))) => {
+                UnevaluatedBehavior::Allow
+            }
+            _ => UnevaluatedBehavior::IfValid(compile_validators(
+                value,
+                &context.with_path("unevaluatedProperties"),
+            )?),
+        };
+
+        Ok(Self { behavior })
+    }
+
+    fn is_valid_property(&self, property_instance: &Value, _property_name: &str) -> Option<bool> {
+        match &self.behavior {
+            UnevaluatedBehavior::Allow => Some(true),
+            UnevaluatedBehavior::Deny => None,
+            UnevaluatedBehavior::IfValid(node) => Some(node.is_valid(property_instance)),
+        }
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        _property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        match &self.behavior {
+            UnevaluatedBehavior::Allow => Some(no_error()),
+            UnevaluatedBehavior::Deny => None,
+            UnevaluatedBehavior::IfValid(node) => {
+                Some(node.validate(property_instance, property_path))
+            }
+        }
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        _property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        match &self.behavior {
+            UnevaluatedBehavior::Allow => Some(BasicOutput::default()),
+            UnevaluatedBehavior::Deny => None,
+            UnevaluatedBehavior::IfValid(node) => {
+                Some(node.apply_rooted(property_instance, property_path))
+            }
+        }
+    }
+}
+
+/// A subvalidator for any conditional subschemas.
+///
+/// This subvalidator handles any subschemas specified via `if`, and handles both the `then` case
+/// (`success`) and `else` case (`failure`).
+#[derive(Debug)]
+struct ConditionalSubvalidator {
+    // Validator created from the `if` schema to actually validate the given instance and
+    // determine whether or not to check the `then` or `else` schemas, if defined.
+    condition: SchemaNode,
+
+    // Validator for checking if the `if` schema evaluates a particular property.
+    node: Option<UnevaluatedPropertiesValidator>,
+
+    success: Option<UnevaluatedPropertiesValidator>,
+    failure: Option<UnevaluatedPropertiesValidator>,
+}
+
+impl ConditionalSubvalidator {
+    fn from_values<'a>(
+        schema: &'a Value,
+        success: Option<&'a Value>,
+        failure: Option<&'a Value>,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        compile_validators(schema, context).and_then(|condition| {
+            let node = schema
+                .as_object()
+                .map(|parent| {
+                    UnevaluatedPropertiesValidator::compile(
+                        parent,
+                        get_unevaluated_props_schema(parent),
+                        context,
+                    )
+                })
+                .transpose()?;
+            let success = success
+                .and_then(|value| value.as_object())
+                .map(|parent| {
+                    UnevaluatedPropertiesValidator::compile(
+                        parent,
+                        get_unevaluated_props_schema(parent),
+                        context,
+                    )
+                })
+                .transpose()?;
+            let failure = failure
+                .and_then(|value| value.as_object())
+                .map(|parent| {
+                    UnevaluatedPropertiesValidator::compile(
+                        parent,
+                        get_unevaluated_props_schema(parent),
+                        context,
+                    )
+                })
+                .transpose()?;
+
+            Ok(Self {
+                condition,
+                node,
+                success,
+                failure,
+            })
+        })
+    }
+
+    fn is_valid_property(
+        &self,
+        instance: &Value,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<bool> {
+        self.node
+            .as_ref()
+            .and_then(|node| node.is_valid_property(instance, property_instance, property_name))
+            .or_else(|| {
+                if self.condition.is_valid(instance) {
+                    self.success.as_ref().and_then(|success| {
+                        success.is_valid_property(instance, property_instance, property_name)
+                    })
+                } else {
+                    self.failure.as_ref().and_then(|failure| {
+                        failure.is_valid_property(instance, property_instance, property_name)
+                    })
+                }
+            })
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        self.node
+            .as_ref()
+            .and_then(|node| {
+                node.validate_property(
+                    instance,
+                    instance_path,
+                    property_path,
+                    property_instance,
+                    property_name,
+                )
+            })
+            .or_else(|| {
+                if self.condition.validate(instance, instance_path).count() == 0 {
+                    self.success.as_ref().and_then(|success| {
+                        success.validate_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+                } else {
+                    self.failure.as_ref().and_then(|failure| {
+                        failure.validate_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+                }
+            })
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        instance: &Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        self.node
+            .as_ref()
+            .and_then(|node| {
+                node.apply_property(
+                    instance,
+                    instance_path,
+                    property_path,
+                    property_instance,
+                    property_name,
+                )
+            })
+            .or_else(|| {
+                let partial = self.condition.apply(instance, instance_path);
+                if partial.is_valid() {
+                    self.success.as_ref().and_then(|success| {
+                        success.apply_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+                } else {
+                    self.failure.as_ref().and_then(|failure| {
+                        failure.apply_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+                }
+            })
+    }
+}
+
+/// A subvalidator for dependent schemas.
+#[derive(Debug)]
+struct DependentSchemaSubvalidator {
+    nodes: AHashMap<String, UnevaluatedPropertiesValidator>,
+}
+
+impl DependentSchemaSubvalidator {
+    fn from_value<'a>(
+        value: &'a Value,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>> {
+        let schemas = value
+            .as_object()
+            .ok_or_else(|| unexpected_type(context, value, PrimitiveType::Object))?;
+        let mut nodes = AHashMap::new();
+        for (dependent_property_name, dependent_schema) in schemas {
+            let parent = dependent_schema
+                .as_object()
+                .ok_or_else(ValidationError::null_schema)?;
+
+            let node = UnevaluatedPropertiesValidator::compile(
+                parent,
+                get_unevaluated_props_schema(parent),
+                context,
+            )?;
+            nodes.insert(dependent_property_name.to_string(), node);
+        }
+
+        Ok(Self { nodes })
+    }
+
+    fn is_valid_property(
+        &self,
+        instance: &Value,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<bool> {
+        self.nodes
+            .iter()
+            .find_map(|(dependent_property_name, node)| {
+                value_has_object_key(instance, dependent_property_name)
+                    .then(|| node)
+                    .and_then(|node| {
+                        node.is_valid_property(instance, property_instance, property_name)
+                    })
+            })
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        self.nodes
+            .iter()
+            .find_map(|(dependent_property_name, node)| {
+                value_has_object_key(instance, dependent_property_name)
+                    .then(|| node)
+                    .and_then(|node| {
+                        node.validate_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+            })
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        instance: &Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        self.nodes
+            .iter()
+            .find_map(|(dependent_property_name, node)| {
+                value_has_object_key(instance, dependent_property_name)
+                    .then(|| node)
+                    .and_then(|node| {
+                        node.apply_property(
+                            instance,
+                            instance_path,
+                            property_path,
+                            property_instance,
+                            property_name,
+                        )
+                    })
+            })
+    }
+}
+
+/// A subvalidator for a top-level schema reference. (`$ref`)
+#[derive(Debug)]
+struct ReferenceSubvalidator {
+    node: Box<UnevaluatedPropertiesValidator>,
+}
+
+impl ReferenceSubvalidator {
+    fn from_value<'a>(
+        value: &'a Value,
+        context: &CompilationContext,
+    ) -> Result<Option<Self>, ValidationError<'a>> {
+        let reference = value
+            .as_str()
+            .ok_or_else(|| unexpected_type(context, value, PrimitiveType::String))?;
+
+        let reference_url = context.build_url(reference)?;
+        let (scope, resolved) = context
+            .resolver
+            .resolve_fragment(context.config.draft(), &reference_url, reference)
+            .map_err(|e| e.into_owned())?;
+
+        let ref_context = CompilationContext::new(
+            scope.into(),
+            Arc::clone(&context.config),
+            Arc::clone(&context.resolver),
+        );
+
+        resolved
+            .as_object()
+            .map(|parent| {
+                UnevaluatedPropertiesValidator::compile(
+                    parent,
+                    get_unevaluated_props_schema(parent),
+                    &ref_context,
+                )
+                .map(|validator| ReferenceSubvalidator {
+                    node: Box::new(validator),
+                })
+                .map_err(|e| e.into_owned())
+            })
+            .transpose()
+    }
+
+    fn is_valid_property(
+        &self,
+        instance: &Value,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<bool> {
+        self.node
+            .is_valid_property(instance, property_instance, property_name)
+    }
+
+    fn validate_property<'instance>(
+        &self,
+        instance: &'instance Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &'instance Value,
+        property_name: &str,
+    ) -> Option<ErrorIterator<'instance>> {
+        self.node.validate_property(
+            instance,
+            instance_path,
+            property_path,
+            property_instance,
+            property_name,
+        )
+    }
+
+    fn apply_property<'a>(
+        &'a self,
+        instance: &Value,
+        instance_path: &InstancePath,
+        property_path: &InstancePath,
+        property_instance: &Value,
+        property_name: &str,
+    ) -> Option<BasicOutput<'a>> {
+        self.node.apply_property(
+            instance,
+            instance_path,
+            property_path,
+            property_instance,
+            property_name,
+        )
+    }
+}
+
+fn value_has_object_key(value: &Value, key: &str) -> bool {
+    match value {
+        Value::Object(map) => map.contains_key(key),
+        _ => false,
+    }
+}
+
+fn get_unevaluated_props_schema(parent: &Map<String, Value>) -> &Value {
+    parent
+        .get("unevaluatedProperties")
+        .unwrap_or(&Value::Bool(false))
+}
+
+pub(crate) fn compile<'a>(
+    parent: &'a Map<String, Value>,
+    schema: &'a Value,
+    context: &CompilationContext,
+) -> Option<CompilationResult<'a>> {
+    // Nothing to validate if `unevaluatedProperties` is set to `true`, which is the default:
+    if let Value::Bool(true) = schema {
+        return None;
+    }
+
+    match UnevaluatedPropertiesValidator::compile(parent, schema, context) {
+        Ok(compiled) => Some(Ok(Box::new(compiled))),
+        Err(e) => Some(Err(e)),
+    }
+}
+
+fn unexpected_type<'a>(
+    context: &CompilationContext,
+    instance: &'a Value,
+    expected_type: PrimitiveType,
+) -> ValidationError<'a> {
+    ValidationError::single_type_error(
+        JSONPointer::default(),
+        context.clone().into_pointer(),
+        instance,
+        expected_type,
+    )
+}

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -91,6 +91,7 @@ mod keywords;
 pub mod output;
 pub mod paths;
 pub mod primitive_type;
+pub(crate) mod properties;
 mod resolver;
 mod schema_node;
 mod schemas;

--- a/jsonschema/src/paths.rs
+++ b/jsonschema/src/paths.rs
@@ -213,6 +213,12 @@ impl From<&[PathChunk]> for JSONPointer {
     }
 }
 
+impl From<&str> for JSONPointer {
+    fn from(value: &str) -> Self {
+        JSONPointer(vec![value.to_string().into()])
+    }
+}
+
 /// An absolute reference
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AbsolutePath(url::Url);

--- a/jsonschema/src/properties.rs
+++ b/jsonschema/src/properties.rs
@@ -1,0 +1,180 @@
+use ahash::AHashMap;
+use fancy_regex::Regex;
+use serde_json::{Map, Value};
+
+use crate::{
+    compilation::{compile_validators, context::CompilationContext},
+    paths::JSONPointer,
+    schema_node::SchemaNode,
+    validator::Validate,
+    ValidationError,
+};
+
+pub(crate) type PatternedValidators = Vec<(Regex, SchemaNode)>;
+
+/// A value that can look up property validators by name.
+pub(crate) trait PropertiesValidatorsMap: Send + Sync {
+    fn from_map<'a>(
+        map: &'a Map<String, Value>,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>>
+    where
+        Self: Sized;
+
+    fn get_validator(&self, property: &str) -> Option<&SchemaNode>;
+    fn get_key_validator(&self, property: &str) -> Option<(&String, &SchemaNode)>;
+}
+
+// We're defining two different property validator map implementations, one for small map sizes and
+// one for large map sizes, to optimize the performance depending on the number of properties
+// present.
+//
+// Implementors should use `compile_dynamic_prop_map_validator!` for building their validator maps
+// at runtime, as it wraps up all of the logic to choose the right map size and then build and
+// compile the validator.
+pub(crate) type SmallValidatorsMap = Vec<(String, SchemaNode)>;
+pub(crate) type BigValidatorsMap = AHashMap<String, SchemaNode>;
+
+impl PropertiesValidatorsMap for SmallValidatorsMap {
+    fn from_map<'a>(
+        map: &'a Map<String, Value>,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>>
+    where
+        Self: Sized,
+    {
+        compile_small_map(map, context)
+    }
+
+    #[inline]
+    fn get_validator(&self, property: &str) -> Option<&SchemaNode> {
+        for (prop, node) in self {
+            if prop == property {
+                return Some(node);
+            }
+        }
+        None
+    }
+    #[inline]
+    fn get_key_validator(&self, property: &str) -> Option<(&String, &SchemaNode)> {
+        for (prop, node) in self {
+            if prop == property {
+                return Some((prop, node));
+            }
+        }
+        None
+    }
+}
+
+impl PropertiesValidatorsMap for BigValidatorsMap {
+    fn from_map<'a>(
+        map: &'a Map<String, Value>,
+        context: &CompilationContext,
+    ) -> Result<Self, ValidationError<'a>>
+    where
+        Self: Sized,
+    {
+        compile_big_map(map, context)
+    }
+
+    #[inline]
+    fn get_validator(&self, property: &str) -> Option<&SchemaNode> {
+        self.get(property)
+    }
+
+    #[inline]
+    fn get_key_validator(&self, property: &str) -> Option<(&String, &SchemaNode)> {
+        self.get_key_value(property)
+    }
+}
+
+pub(crate) fn compile_small_map<'a>(
+    map: &'a Map<String, Value>,
+    context: &CompilationContext,
+) -> Result<SmallValidatorsMap, ValidationError<'a>> {
+    let mut properties = Vec::with_capacity(map.len());
+    let keyword_context = context.with_path("properties");
+    for (key, subschema) in map {
+        let property_context = keyword_context.with_path(key.clone());
+        properties.push((
+            key.clone(),
+            compile_validators(subschema, &property_context)?,
+        ));
+    }
+    Ok(properties)
+}
+
+pub(crate) fn compile_big_map<'a>(
+    map: &'a Map<String, Value>,
+    context: &CompilationContext,
+) -> Result<BigValidatorsMap, ValidationError<'a>> {
+    let mut properties = AHashMap::with_capacity(map.len());
+    let keyword_context = context.with_path("properties");
+    for (key, subschema) in map {
+        let property_context = keyword_context.with_path(key.clone());
+        properties.insert(
+            key.clone(),
+            compile_validators(subschema, &property_context)?,
+        );
+    }
+    Ok(properties)
+}
+
+pub(crate) fn are_properties_valid<M, F>(prop_map: &M, props: &Map<String, Value>, check: F) -> bool
+where
+    M: PropertiesValidatorsMap,
+    F: Fn(&Value) -> bool,
+{
+    props.iter().all(|(property, instance)| {
+        if let Some(validator) = prop_map.get_validator(property) {
+            validator.is_valid(instance)
+        } else {
+            check(instance)
+        }
+    })
+}
+
+/// Create a vector of pattern-validators pairs.
+#[inline]
+pub(crate) fn compile_patterns<'a>(
+    obj: &'a Map<String, Value>,
+    context: &CompilationContext,
+) -> Result<PatternedValidators, ValidationError<'a>> {
+    let keyword_context = context.with_path("patternProperties");
+    let mut compiled_patterns = Vec::with_capacity(obj.len());
+    for (pattern, subschema) in obj {
+        let pattern_context = keyword_context.with_path(pattern.to_string());
+        if let Ok(compiled_pattern) = Regex::new(pattern) {
+            let node = compile_validators(subschema, &pattern_context)?;
+            compiled_patterns.push((compiled_pattern, node));
+        } else {
+            return Err(ValidationError::format(
+                JSONPointer::default(),
+                keyword_context.clone().into_pointer(),
+                subschema,
+                "regex",
+            ));
+        }
+    }
+    Ok(compiled_patterns)
+}
+
+macro_rules! compile_dynamic_prop_map_validator {
+    ($validator:tt, $properties:ident, $( $arg:expr ),* $(,)*) => {{
+        if let Value::Object(map) = $properties {
+            if map.len() < 40 {
+                Some($validator::<SmallValidatorsMap>::compile(
+                    map, $($arg, )*
+                ))
+            } else {
+                Some($validator::<BigValidatorsMap>::compile(
+                    map, $($arg, )*
+                ))
+            }
+        } else {
+            Some(Err(ValidationError::null_schema()))
+        }
+    }};
+}
+
+pub(crate) use compile_dynamic_prop_map_validator;

--- a/jsonschema/src/schemas.rs
+++ b/jsonschema/src/schemas.rs
@@ -50,6 +50,7 @@ impl Draft {
     #[allow(clippy::match_same_arms)]
     pub(crate) fn get_validator(self, keyword: &str) -> Option<CompileFunc> {
         match keyword {
+            "$ref" => Some(keywords::ref_::compile),
             "additionalItems" => Some(keywords::additional_items::compile),
             "additionalProperties" => Some(keywords::additional_properties::compile),
             "allOf" => Some(keywords::all_of::compile),
@@ -166,6 +167,13 @@ impl Draft {
                 Draft::Draft201909 => Some(keywords::type_::compile),
                 #[cfg(feature = "draft202012")]
                 Draft::Draft202012 => Some(keywords::type_::compile),
+            },
+            "unevaluatedProperties" => match self {
+                #[cfg(feature = "draft201909")]
+                Draft::Draft201909 => Some(keywords::unevaluated_properties::compile),
+                #[cfg(feature = "draft202012")]
+                Draft::Draft202012 => Some(keywords::unevaluated_properties::compile),
+                _ => None,
             },
             "uniqueItems" => Some(keywords::unique_items::compile),
             _ => None,

--- a/jsonschema/src/validator.rs
+++ b/jsonschema/src/validator.rs
@@ -129,6 +129,15 @@ impl<'a> PartialApplication<'a> {
         }
     }
 
+    /// A shortcut to check whether the partial represents passed validation.
+    #[must_use]
+    pub(crate) const fn is_valid(&self) -> bool {
+        match self {
+            Self::Valid { .. } => true,
+            Self::Invalid { .. } => false,
+        }
+    }
+
     /// Set the annotation that will be returned for the current validator. If this
     /// `PartialApplication` is invalid then this method does nothing
     pub(crate) fn annotate(&mut self, new_annotations: Annotations<'a>) {


### PR DESCRIPTION
Closes #288.

This PR adds support for `unevaluatedProperties` when using the `draft201909` or `draft202012` feature flags.

## Overall approach

I took a somewhat similar approach to the Python code linked in the issue for this feature, where the validator for `unevaluatedProperties` uses a subvalidator for each relevant keyword -- `properties`, `patternProperties`, `dependentSchemas`, `$ref`, etc -- that performs the relevant logic for determining if the given schema for the keyword would evaluate the property.

Each subvalidator exposes an interface that looks a lot like the `Validate` trait, but is oriented towards checking solely if a property would be valid against the schema, and has an optional return value to indicate evaluated vs not evaluated. The validator code, overall, is a bit verbose, not unlike `additionalProperties`... but there's a possibility of turning the API into an actual trait which would theoretically allow us to reduce a lot of boilerplate when we check each subvalidator in `UnevaluatedPropertiesValidator::is_valid_property`, and so on.

## Code deduplication and refactoring

Beyond that, I ended up refactoring a little bit of the shared code between `unevaluatedProperties` and `additionalProperties`. I tried, initially, to carry over the logic for switching between a small and big validator map, but it got a little too complex when considering that `UnevaluatedPropertiesValidator` is inherently recursive, and it didn't make a lot of sense propagating a generic validator map type all the way through. I'm happy to try and revisit this if you think it matters enough.

## Fixing `$ref` for draft 2019-09 and newer

In order to fully support `unevaluatedProperties`, I had to do a small bit of refactoring in terms of how `$ref` is handled. This also had the nice side effect of fixing `$ref` usage when using draft 2019-09 and newer, as now it can be evaluated alongside other keywords.

Beyond that, there's just a lot of boilerplate, and I tried to pick a code style/pattern and just stick to that and be consistent about it, but I'm happy to do any of the aforementioned refactoring ideas, or anything else, to bring the code more in line with your expectations.