### PR TITLE
fix: `unevaluatedProperties` doesn't correctly handle subschema validation

### DIFF
--- a/jsonschema/src/keywords/unevaluated_properties.rs
+++ b/jsonschema/src/keywords/unevaluated_properties.rs
@@ -1330,10 +1330,25 @@ mod tests {
     use crate::{tests_util, Draft};
     use serde_json::json;
 
+    #[cfg(all(feature = "draft201909", not(feature = "draft202012")))]
+    const fn get_draft_version() -> Draft {
+        Draft::Draft201909
+    }
+
+    #[cfg(all(feature = "draft202012", not(feature = "draft201909")))]
+    const fn get_draft_version() -> Draft {
+        Draft::Draft202012
+    }
+
+    #[cfg(all(feature = "draft201909", feature = "draft202012"))]
+    const fn get_draft_version() -> Draft {
+        Draft::Draft202012
+    }
+
     #[test]
     fn one_of() {
         tests_util::is_valid_with_draft(
-            Draft::Draft201909,
+            get_draft_version(),
             &json!({
                 "oneOf": [
                     { "properties": { "foo": { "const": "bar" } } },
@@ -1348,7 +1363,7 @@ mod tests {
     #[test]
     fn any_of() {
         tests_util::is_valid_with_draft(
-            Draft::Draft201909,
+            get_draft_version(),
             &json!({
                 "anyOf": [
                     { "properties": { "foo": { "minLength": 10 } } },
@@ -1363,7 +1378,7 @@ mod tests {
     #[test]
     fn all_of() {
         tests_util::is_not_valid_with_draft(
-            Draft::Draft201909,
+            get_draft_version(),
             &json!({
                 "allOf": [
                     { "properties": { "foo": { "type": "string" } } },

--- a/jsonschema/src/keywords/unevaluated_properties.rs
+++ b/jsonschema/src/keywords/unevaluated_properties.rs
@@ -1276,7 +1276,7 @@ fn value_has_object_key(value: &Value, key: &str) -> bool {
 fn get_unevaluated_props_schema(parent: &Map<String, Value>) -> &Value {
     parent
         .get("unevaluatedProperties")
-        .unwrap_or(&Value::Bool(false))
+        .unwrap_or(&Value::Bool(true))
 }
 
 pub(crate) fn compile<'a>(
@@ -1379,32 +1379,28 @@ mod tests {
     }
 
     #[test]
-    fn nested_variable_map() {
+    fn all_of_with_additional_props_subschema() {
         tests_util::is_valid_with_draft(
             get_draft_version(),
             &json!({
                 "allOf": [
                     {
-                        "type": "object",
-                        "properties": {
-                            "headers": {
-                                "type": "object",
-                                "additionalProperties": {
-                                    "type": "string"
-                                }
-                            },
-                        },
+                    "type": "object",
+                    "required": [
+                        "foo"
+                    ],
+                    "properties": {
+                        "foo": { "type": "string" }
+                    }
                     },
                     {
                         "type": "object",
-                        "properties": {
-                            "fixed": { "type": "number" }
-                        },
+                        "additionalProperties": { "type": "string" }
                     }
                 ],
                 "unevaluatedProperties": false
             }),
-            &json!({ "fixed": 23, "headers": { "some": "thing" } }),
+            &json!({ "foo": "wee", "another": "thing" }),
         )
     }
 }

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -125,10 +125,10 @@ pub fn is_valid(schema: &Value, instance: &Value) -> bool {
 #[cfg(test)]
 pub(crate) mod tests_util {
     use super::JSONSchema;
-    use crate::{Draft, ValidationError};
+    use crate::ValidationError;
     use serde_json::Value;
 
-    fn is_not_valid_inner(compiled: JSONSchema, instance: &Value) {
+    fn is_not_valid_inner(compiled: &JSONSchema, instance: &Value) {
         assert!(
             !compiled.is_valid(instance),
             "{} should not be valid (via is_valid)",
@@ -148,16 +148,16 @@ pub(crate) mod tests_util {
 
     pub(crate) fn is_not_valid(schema: &Value, instance: &Value) {
         let compiled = JSONSchema::compile(schema).unwrap();
-        is_not_valid_inner(compiled, instance)
+        is_not_valid_inner(&compiled, instance)
     }
 
     #[cfg(any(feature = "draft201909", feature = "draft202012"))]
-    pub(crate) fn is_not_valid_with_draft(draft: Draft, schema: &Value, instance: &Value) {
+    pub(crate) fn is_not_valid_with_draft(draft: crate::Draft, schema: &Value, instance: &Value) {
         let compiled = JSONSchema::options()
             .with_draft(draft)
             .compile(schema)
             .unwrap();
-        is_not_valid_inner(compiled, instance)
+        is_not_valid_inner(&compiled, instance)
     }
 
     pub(crate) fn expect_errors(schema: &Value, instance: &Value, errors: &[&str]) {
@@ -172,7 +172,7 @@ pub(crate) mod tests_util {
         )
     }
 
-    fn is_valid_inner(compiled: JSONSchema, instance: &Value) {
+    fn is_valid_inner(compiled: &JSONSchema, instance: &Value) {
         assert!(
             compiled.is_valid(instance),
             "{} should be valid (via is_valid)",
@@ -192,16 +192,16 @@ pub(crate) mod tests_util {
 
     pub(crate) fn is_valid(schema: &Value, instance: &Value) {
         let compiled = JSONSchema::compile(schema).unwrap();
-        is_valid_inner(compiled, instance);
+        is_valid_inner(&compiled, instance);
     }
 
     #[cfg(any(feature = "draft201909", feature = "draft202012"))]
-    pub(crate) fn is_valid_with_draft(draft: Draft, schema: &Value, instance: &Value) {
+    pub(crate) fn is_valid_with_draft(draft: crate::Draft, schema: &Value, instance: &Value) {
         let compiled = JSONSchema::options()
             .with_draft(draft)
             .compile(schema)
             .unwrap();
-        is_valid_inner(compiled, instance)
+        is_valid_inner(&compiled, instance)
     }
 
     pub(crate) fn validate(schema: &Value, instance: &Value) -> ValidationError<'static> {

--- a/jsonschema/src/lib.rs
+++ b/jsonschema/src/lib.rs
@@ -125,11 +125,10 @@ pub fn is_valid(schema: &Value, instance: &Value) -> bool {
 #[cfg(test)]
 pub(crate) mod tests_util {
     use super::JSONSchema;
-    use crate::ValidationError;
+    use crate::{Draft, ValidationError};
     use serde_json::Value;
 
-    pub(crate) fn is_not_valid(schema: &Value, instance: &Value) {
-        let compiled = JSONSchema::compile(schema).unwrap();
+    fn is_not_valid_inner(compiled: JSONSchema, instance: &Value) {
         assert!(
             !compiled.is_valid(instance),
             "{} should not be valid (via is_valid)",
@@ -147,6 +146,20 @@ pub(crate) mod tests_util {
         );
     }
 
+    pub(crate) fn is_not_valid(schema: &Value, instance: &Value) {
+        let compiled = JSONSchema::compile(schema).unwrap();
+        is_not_valid_inner(compiled, instance)
+    }
+
+    #[cfg(any(feature = "draft201909", feature = "draft202012"))]
+    pub(crate) fn is_not_valid_with_draft(draft: Draft, schema: &Value, instance: &Value) {
+        let compiled = JSONSchema::options()
+            .with_draft(draft)
+            .compile(schema)
+            .unwrap();
+        is_not_valid_inner(compiled, instance)
+    }
+
     pub(crate) fn expect_errors(schema: &Value, instance: &Value, errors: &[&str]) {
         assert_eq!(
             JSONSchema::compile(schema)
@@ -159,8 +172,7 @@ pub(crate) mod tests_util {
         )
     }
 
-    pub(crate) fn is_valid(schema: &Value, instance: &Value) {
-        let compiled = JSONSchema::compile(schema).unwrap();
+    fn is_valid_inner(compiled: JSONSchema, instance: &Value) {
         assert!(
             compiled.is_valid(instance),
             "{} should be valid (via is_valid)",
@@ -176,6 +188,20 @@ pub(crate) mod tests_util {
             "{} should be valid (via apply)",
             instance
         );
+    }
+
+    pub(crate) fn is_valid(schema: &Value, instance: &Value) {
+        let compiled = JSONSchema::compile(schema).unwrap();
+        is_valid_inner(compiled, instance);
+    }
+
+    #[cfg(any(feature = "draft201909", feature = "draft202012"))]
+    pub(crate) fn is_valid_with_draft(draft: Draft, schema: &Value, instance: &Value) {
+        let compiled = JSONSchema::options()
+            .with_draft(draft)
+            .compile(schema)
+            .unwrap();
+        is_valid_inner(compiled, instance)
     }
 
     pub(crate) fn validate(schema: &Value, instance: &Value) -> ValidationError<'static> {


### PR DESCRIPTION
Fixes #421.

## Context

As described in #421, my initial attempt at adding subschema validation handling in `unevaluatedProperties` was a brute-force approach that sufficed to pass the JSON Schema test suite, but didn't correctly evaluate real-world schemas/data.

Instead of only considering properties evaluated if the subschema they were part of was valid, taking into account the behavior of the validator keyword (i.e. `oneOf` can't have multiple matching subschemas), it took an approach of simply finding the first subschema which seemed to favorably evaluate/validate the property.

## Solution

`SubschemaSubvalidator` has been changed in two significant ways:

- it now properly considers the validation type (i.e. `allOf` vs `oneOf`)
- it validates the entire instance before validating the property

In practice, this means that we generate the `SchemaNode` for each subschema, as well as our stripped-down unevaluated properties validator based on the subschema, used for evaluating properties themselves. Using `oneOf` as an example:

- for each subschema in the `oneOf`:
  - validate the property against the property validator (`UnevaluatedPropertiesValidator`) and the property's parent instance against the node validator (`SchemaNode`)
- for each validation result pair:
  - if the instance result was valid, store the property validation result in a local
  - if the local was already populated, return `None` overall: more than one valid subschema in a `oneOf` is not valid
- return the local property validation result

This isn't particularly novel or anything, as it's just following the existing behavior for the `oneOf`/`allOf`/`anyOf` validators, with a little extra logic to thread through the evaluation status of the specific property.

## Testing

I've added three new unit tests -- one for each subschema validation mode -- with fairly simple examples, but they initially did not pass, and now, with this change, they do. 😂 

I've also created a simple CLI program to use `jsonschema` with for taking a schema and input data, and have used it successfully on a large schema document (~800KB, 200+ instances of `unevaluatedProperties: false`, 400-500 schema definitions, etc) where it properly detects... well, if a property is unevaluated or not.

It's still a little weird that the official JSON Schema test suite doesn't have a test for this, but I'm guessing it's based on the fact that their unofficial recommendation for implementing `unevaluatedProperties` is based on checking the output annotations from all of the other keywords, whereas we do it all ourselves in the `unevaluatedProperties` validator. That might be worth thinking about in the future, in terms of refactoring the validator to make it more robust... but for now, I'm just trying to get this working correctly. :)