### PR TITLE
Fix `unresolved import "syn::ItemFn"` when running tests

### DIFF
--- a/jsonschema-test-suite/proc_macro/Cargo.toml
+++ b/jsonschema-test-suite/proc_macro/Cargo.toml
@@ -28,4 +28,4 @@ regex = "1"
 quote = "1"
 serde = { version = "1", features = [ "derive" ] }
 serde_json = "1"
-syn = "1"
+syn = { version = "1", features = ["full"] }


### PR DESCRIPTION
`cargo test` fails with:

```
$ cargo test                                                                                                                                     master ✭
   Compiling json_schema_test_suite_proc_macro v0.3.0 (/home/auke/projects/jsonschema-rs/jsonschema-test-suite/proc_macro)
   Compiling jsonschema v0.17.1 (/home/auke/projects/jsonschema-rs/jsonschema)
error[E0432]: unresolved import `syn::ItemFn`
   --> /home/auke/projects/jsonschema-rs/jsonschema-test-suite/proc_macro/src/lib.rs:41:37
    |
41  | use syn::{parse_macro_input, Ident, ItemFn};
    |                                     ^^^^^^ no `ItemFn` in the root
    |
note: found an item that was configured out
   --> /home/auke/.cargo/registry/src/index.crates.io-6f17d22bba15001f/syn-1.0.109/src/lib.rs:365:32
    |
365 |     ItemEnum, ItemExternCrate, ItemFn, ItemForeignMod, ItemImpl, ItemMacro, ItemMacro2, ItemMod,
    |                                ^^^^^^
    = note: the item is gated behind the `full` feature

For more information about this error, try `rustc --explain E0432`.
```

This commit fixes the issue by applying the suggestion of the compiler.

Fixes #444 