### PR TITLE
Document how to run tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,13 @@ The tests in [jsonschema/](jsonschema/) depend on the [JSON Schema Test Suite](h
 $ git submodule init
 $ git submodule update
 ```
-These commands clone the suite to [jsonschema/tests/suite/](jsonschema/test/suite/).
+These commands clone the suite to [jsonschema/tests/suite/](jsonschema/tests/suite/).
 
 Now, enter jsonschema/ folder and run `cargo test`.
 
 ```bash
 $ cd jsonschema
-$ cargo test
-```
+$ cargo test ```
 
 ## Performance
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ This library is functional and ready for use, but its API is still evolving to t
 - Ruby - a [crate](https://github.com/driv3r/rusty_json_schema) by @driv3r
 - NodeJS - a [package](https://github.com/ahungrynoob/jsonschema) by @ahungrynoob
 
+## `cargo test`
+
+The tests in [jsonschema/](jsonschema/) depend on the [JSON Schema Test Suite](https://github.com/json-schema-org/JSON-Schema-Test-Suite). Before calling `cargo test`, download the suite:
+
+```bash
+$ git submodule init
+$ git submodule update
+```
+These commands clone the suite to [jsonschema/tests/suite/](jsonschema/test/suite/).
+
+Now, enter jsonschema/ folder and run `cargo test`.
+
+```bash
+$ cd jsonschema
+$ cargo test
+```
+
 ## Performance
 
 There is a comparison with other JSON Schema validators written in Rust - `jsonschema_valid==0.4.0` and `valico==3.6.0`.


### PR DESCRIPTION
`cargo tests` depends on an external, undocumented dependency: the JSON Schema Test Suite.

This commit introduces instructions how to get test suite.

Without the test suite, `cargo test` fails with:

```bash
$ cargo test
error: custom attribute panicked
 --> tests/test_suite.rs:5:1
  |
5 | #[json_schema_test_suite("tests/suite", "draft4", {"optional_bignum_0_0", "optional_bignum_2_0"})]
  | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  |
  = help: message: Tests directory not found: tests/suite/tests/draft4
```

Fixes #443 