### PR TITLE
feat(python): support validation of dict subclasses

### DIFF
--- a/bindings/python/CHANGELOG.md
+++ b/bindings/python/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support subclasses of Python `dict`s [#427](https://github.com/Stranger6667/jsonschema-rs/issues/427)
+
 ## [0.17.2] - 2024-03-03
 
 ### Added

--- a/bindings/python/tests-py/test_jsonschema.py
+++ b/bindings/python/tests-py/test_jsonschema.py
@@ -1,6 +1,6 @@
 import sys
 import uuid
-from collections import namedtuple
+from collections import namedtuple, OrderedDict
 from contextlib import suppress
 from enum import Enum
 from functools import partial
@@ -248,3 +248,30 @@ def test_dict_with_non_str_keys():
     with pytest.raises(ValueError) as exec_info:
         validate(schema, instance)
     assert exec_info.value.args[0] == "Dict key must be str. Got 'UUID'"
+
+
+class MyDict(dict):
+    pass
+
+
+class MyDict2(MyDict):
+    pass
+
+
+@pytest.mark.parametrize(
+    "type_, value, expected",
+    (
+        (dict, 1, True),
+        (dict, "bar", False),
+        (OrderedDict, 1, True),
+        (OrderedDict, "bar", False),
+        (MyDict, 1, True),
+        (MyDict, "bar", False),
+        (MyDict2, 1, True),
+        (MyDict2, "bar", False),
+    ),
+)
+def test_dict_subclasses(type_, value, expected):
+    schema = {"type": "object", "properties": {"foo": {"type": "integer"}}}
+    document = type_({"foo": value})
+    assert is_valid(schema, document) is expected


### PR DESCRIPTION
Disclaimer: This is a low-confidence PR as I have zero experience with Rust and the pyo3 library. Feel free to be hard on me :)

Currently, attempting to validate an instance of a dict subclass will raise a `ValueError`. This should not be happening, since the instance is still dict. Achieve compatibility by checking the subclasses' inheritance tree, and treat the instance like a dict if that check passes.

Resolves #427 