### PR TITLE
Ignore trailing '#' in meta-schema URLs

### DIFF
--- a/jsonschema/src/schemas.rs
+++ b/jsonschema/src/schemas.rs
@@ -184,14 +184,14 @@ impl Draft {
 /// Get the `Draft` from a JSON Schema URL.
 #[inline]
 pub(crate) fn draft_from_url(url: &str) -> Option<Draft> {
-    match url {
+    match url.trim_end_matches('#') {
         #[cfg(feature = "draft202012")]
-        "https://json-schema.org/draft/2020-12/schema#" => Some(Draft::Draft202012),
+        "https://json-schema.org/draft/2020-12/schema" => Some(Draft::Draft202012),
         #[cfg(feature = "draft201909")]
-        "https://json-schema.org/draft/2019-09/schema#" => Some(Draft::Draft201909),
-        "http://json-schema.org/draft-07/schema#" => Some(Draft::Draft7),
-        "http://json-schema.org/draft-06/schema#" => Some(Draft::Draft6),
-        "http://json-schema.org/draft-04/schema#" => Some(Draft::Draft4),
+        "https://json-schema.org/draft/2019-09/schema" => Some(Draft::Draft201909),
+        "http://json-schema.org/draft-07/schema" => Some(Draft::Draft7),
+        "http://json-schema.org/draft-06/schema" => Some(Draft::Draft6),
+        "http://json-schema.org/draft-04/schema" => Some(Draft::Draft4),
         _ => None,
     }
 }
@@ -225,8 +225,8 @@ mod tests {
     use serde_json::{json, Value};
     use test_case::test_case;
 
-    #[cfg_attr(feature = "draft201909", test_case(&json!({"$schema": "https://json-schema.org/draft/2019-09/schema#"}), Some(Draft::Draft201909)))]
-    #[cfg_attr(feature = "draft202012", test_case(&json!({"$schema": "https://json-schema.org/draft/2020-12/schema#"}), Some(Draft::Draft202012)))]
+    #[cfg_attr(feature = "draft201909", test_case(&json!({"$schema": "https://json-schema.org/draft/2019-09/schema"}), Some(Draft::Draft201909)))]
+    #[cfg_attr(feature = "draft202012", test_case(&json!({"$schema": "https://json-schema.org/draft/2020-12/schema"}), Some(Draft::Draft202012)))]
     #[test_case(&json!({"$schema": "http://json-schema.org/draft-07/schema#"}), Some(Draft::Draft7))]
     #[test_case(&json!({"$schema": "http://json-schema.org/draft-06/schema#"}), Some(Draft::Draft6))]
     #[test_case(&json!({"$schema": "http://json-schema.org/draft-04/schema#"}), Some(Draft::Draft4))]


### PR DESCRIPTION
A single trailing # should be present for draft-07 and earlier, but **should not** be present for 2019-09 or 2020-12 (e.g. see the `$schema` value in [draft2020-12/schema.json](https://github.com/Stranger6667/jsonschema-rs/blob/master/jsonschema/meta_schemas/draft2020-12/schema.json)). But for simplicity and robustness, we can just ignore it in all cases.

With this change, the output of this example is now `true`:
```rust
let schema = JSONSchema::compile(&json!({
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "unevaluatedProperties": false
}))
.unwrap();

let value = json!({
    "blah": 1
});

println!("{}", schema.is_valid(&value));
```