### PR TITLE
feat(python): Support for `decimal.Decimal` type in both schemas and instances

### DIFF
--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- Support for `decimal.Decimal` type in both schemas and instances. [#319](https://github.com/Stranger6667/jsonschema/issues/319)
+
 ### Performance
 
 - `jsonschema_rs.validate()` and `Validator.validate()` run 5–10% faster in some workloads thanks to slimmer `ValidationError` objects.

--- a/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
+++ b/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
@@ -4,8 +4,8 @@ from typing import Any, Callable, List, Protocol, TypeAlias, TypeVar, TypedDict,
 
 _SchemaT = TypeVar("_SchemaT", bool, dict[str, Any])
 _FormatFunc = TypeVar("_FormatFunc", bound=Callable[[str], bool])
-JSONType: TypeAlias = dict[str, Any] | list | str | int | float | bool | None
-JSONPrimitive: TypeAlias = str | int | float | bool | None
+JSONType: TypeAlias = dict[str, Any] | list | str | int | float | Decimal | bool | None
+JSONPrimitive: TypeAlias = str | int | float | Decimal | bool | None
 
 class EvaluationAnnotation(TypedDict):
     schemaLocation: str

--- a/crates/jsonschema-py/tests-py/test_jsonschema.py
+++ b/crates/jsonschema-py/tests-py/test_jsonschema.py
@@ -848,3 +848,25 @@ def test_float_precision_from_string_schema(instance, expected):
     # Schema values are no longer converted to f64, maintaining better precision
     validator = validator_for('{"multipleOf": 0.01}')
     assert validator.is_valid(instance) == expected
+
+
+@pytest.mark.parametrize(
+    "instance, expected",
+    [
+        (Decimal("10.5"), True),
+        (Decimal("5.5"), False),
+        (Decimal("99999999999999999999.123456789"), True),
+    ],
+)
+def test_decimal_support(instance, expected):
+    # Python's Decimal type should be supported, preserving precision
+    validator = validator_for({"type": "number", "minimum": 10})
+    assert validator.is_valid(instance) == expected
+
+
+def test_decimal_in_schema():
+    # Test that Decimal can be used in schema definitions too
+    validator = validator_for({"type": "number", "minimum": Decimal("10.5")})
+    assert validator.is_valid(11) is True
+    assert validator.is_valid(10) is False
+    assert validator.is_valid(Decimal("10.6")) is True


### PR DESCRIPTION
Resolves #319 