### PR TITLE
chore: Switch HTTP client TLS crypto backend from `aws-lc-rs` to `ring`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Exclude internal `tracker` field from `ValidationError` Debug output.
+- Switch HTTP client TLS crypto backend from `aws-lc-rs` to `ring` to simplify building from source on some Linux distributions. [#957](https://github.com/Stranger6667/jsonschema/issues/957)
 
 ### Fixed
 

--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Switch HTTP client TLS crypto backend from `aws-lc-rs` to `ring` to fix import errors when building from source on some Linux distributions. [#957](https://github.com/Stranger6667/jsonschema/issues/957)
+
 ### Fixed
 
 - `Draft4Validator` now correctly validates large Python integers outside the i64/u64 range (e.g., `-9223372036854775809`, `18446744073709551616`) as valid for `type: integer`.

--- a/crates/jsonschema/Cargo.toml
+++ b/crates/jsonschema/Cargo.toml
@@ -13,7 +13,7 @@ authors.workspace = true
 
 [features]
 default = ["resolve-http", "resolve-file"]
-resolve-http = ["reqwest"]
+resolve-http = ["reqwest", "rustls"]
 resolve-file = []
 resolve-async = [
     "referencing/retrieve-async",
@@ -25,10 +25,13 @@ resolve-async = [
 arbitrary-precision = ["serde_json/arbitrary_precision", "dep:num-bigint"]
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
-reqwest = { version = "0.13", features = [
+reqwest = { version = "0.13", default-features = false, features = [
   "blocking",
   "json",
+  "http2",
+  "rustls-no-provider",
 ], optional = true }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12"], optional = true }
 tokio = { version = "1.0", features = ["fs", "rt"], optional = true }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]


### PR DESCRIPTION
Resolves #957 