### PR TITLE
test: sort results so that tests are stable

### DIFF
--- a/crates/jsonschema/src/keywords/additional_properties.rs
+++ b/crates/jsonschema/src/keywords/additional_properties.rs
@@ -1885,7 +1885,7 @@ mod tests {
     #[test_case(&json!({"faz": 1}), &["Additional properties are not allowed (\'faz\' was unexpected)"], &["/additionalProperties"])]
     #[test_case(&json!({"faz": 1, "haz": 1}), &["Additional properties are not allowed (\'faz\', \'haz\' were unexpected)"], &["/additionalProperties"])]
     // `properties.foo` - should be a string & `patternProperties.^bar` - invalid
-    #[test_case(&json!({"foo": 3, "bar": 4}), &["4 is less than the minimum of 5", "3 is not of type \"string\""], &["/patternProperties/^bar/minimum", "/properties/foo/type"])]
+    #[test_case(&json!({"foo": 3, "bar": 4}), &["3 is not of type \"string\"","4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum","/properties/foo/type"])]
     // `properties.barbaz` - valid; `patternProperties.^bar` - invalid
     #[test_case(&json!({"barbaz": 3}), &["3 is less than the minimum of 5"], &["/patternProperties/^bar/minimum"])]
     // `patternProperties.^bar` (should be >=5)
@@ -1893,7 +1893,7 @@ mod tests {
     // `patternProperties.spam$` (should be <=10)
     #[test_case(&json!({"spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - both values are invalid
-    #[test_case(&json!({"bar": 4, "spam": 11}), &["4 is less than the minimum of 5", "11 is greater than the maximum of 10"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
+    #[test_case(&json!({"bar": 4, "spam": 11}), &["11 is greater than the maximum of 10","4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is valid, `spam` is invalid
     #[test_case(&json!({"bar": 6, "spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is invalid, `spam` is valid
@@ -1906,16 +1906,16 @@ mod tests {
     #[test_case(
       &json!({"bar": 4, "spam": 11, "foo": 3, "faz": 1}),
       &[
-          "4 is less than the minimum of 5",
-          "3 is not of type \"string\"",
           "11 is greater than the maximum of 10",
-          "Additional properties are not allowed (\'faz\' was unexpected)"
+          "3 is not of type \"string\"",
+          "4 is less than the minimum of 5",
+          "Additional properties are not allowed (\'faz\' was unexpected)",
       ],
       &[
+          "/additionalProperties",
           "/patternProperties/^bar/minimum",
-          "/properties/foo/type",
           "/patternProperties/spam$/maximum",
-          "/additionalProperties"
+          "/properties/foo/type",
       ]
     )]
     fn schema_1_invalid(instance: &Value, expected: &[&str], locations: &[&str]) {
@@ -1962,7 +1962,7 @@ mod tests {
     // `patternProperties.spam$` (should be <=10)
     #[test_case(&json!({"spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - both values are invalid
-    #[test_case(&json!({"bar": 4, "spam": 11}), &["4 is less than the minimum of 5", "11 is greater than the maximum of 10"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
+    #[test_case(&json!({"bar": 4, "spam": 11}), &["11 is greater than the maximum of 10","4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is valid, `spam` is invalid
     #[test_case(&json!({"bar": 6, "spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is invalid, `spam` is valid
@@ -1975,14 +1975,14 @@ mod tests {
     #[test_case(
       &json!({"bar": 4, "spam": 11, "faz": 1}),
       &[
-          "4 is less than the minimum of 5",
           "11 is greater than the maximum of 10",
-          "Additional properties are not allowed (\'faz\' was unexpected)"
+          "4 is less than the minimum of 5",
+          "Additional properties are not allowed (\'faz\' was unexpected)",
       ],
       &[
+          "/additionalProperties",
           "/patternProperties/^bar/minimum",
           "/patternProperties/spam$/maximum",
-          "/additionalProperties"
       ]
     )]
     fn schema_2_invalid(instance: &Value, expected: &[&str], locations: &[&str]) {
@@ -2026,8 +2026,8 @@ mod tests {
             "Additional properties are not allowed (\'faz\' was unexpected)",
         ],
         &[
-            "/properties/foo/type",
             "/additionalProperties",
+            "/properties/foo/type",
         ]
     )]
     fn schema_3_invalid(instance: &Value, expected: &[&str], locations: &[&str]) {
@@ -2072,7 +2072,7 @@ mod tests {
         {"foo": 3, "bar": "a"}),
         &[
             "\"a\" is not of type \"integer\"",
-            "3 is not of type \"string\""
+            "3 is not of type \"string\"",
         ],
         &[
             "/additionalProperties/type",
@@ -2132,7 +2132,7 @@ mod tests {
     #[test_case(&json!({"faz": "a"}), &["\"a\" is not of type \"integer\""], &["/additionalProperties/type"])]
     #[test_case(&json!({"faz": "a", "haz": "a"}), &["\"a\" is not of type \"integer\"", "\"a\" is not of type \"integer\""], &["/additionalProperties/type", "/additionalProperties/type"])]
     // `properties.foo` - should be a string & `patternProperties.^bar` - invalid
-    #[test_case(&json!({"foo": 3, "bar": 4}), &["4 is less than the minimum of 5", "3 is not of type \"string\""], &["/patternProperties/^bar/minimum", "/properties/foo/type"])]
+    #[test_case(&json!({"foo": 3, "bar": 4}), &["3 is not of type \"string\"","4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum","/properties/foo/type"])]
     // `properties.barbaz` - valid; `patternProperties.^bar` - invalid
     #[test_case(&json!({"barbaz": 3}), &["3 is less than the minimum of 5"], &["/patternProperties/^bar/minimum"])]
     // `patternProperties.^bar` (should be >=5)
@@ -2140,7 +2140,7 @@ mod tests {
     // `patternProperties.spam$` (should be <=10)
     #[test_case(&json!({"spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - both values are invalid
-    #[test_case(&json!({"bar": 4, "spam": 11}), &["4 is less than the minimum of 5", "11 is greater than the maximum of 10"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
+    #[test_case(&json!({"bar": 4, "spam": 11}), &["11 is greater than the maximum of 10","4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is valid, `spam` is invalid
     #[test_case(&json!({"bar": 6, "spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is invalid, `spam` is valid
@@ -2153,16 +2153,16 @@ mod tests {
     #[test_case(
       &json!({"bar": 4, "spam": 11, "foo": 3, "faz": "a", "fam": 42}),
       &[
-          "4 is less than the minimum of 5",
           "\"a\" is not of type \"integer\"",
-          "3 is not of type \"string\"",
           "11 is greater than the maximum of 10",
+          "3 is not of type \"string\"",
+          "4 is less than the minimum of 5",
       ],
       &[
-          "/patternProperties/^bar/minimum",
           "/additionalProperties/type",
-          "/properties/foo/type",
+          "/patternProperties/^bar/minimum",
           "/patternProperties/spam$/maximum",
+          "/properties/foo/type",
       ]
     )]
     fn schema_5_invalid(instance: &Value, expected: &[&str], locations: &[&str]) {
@@ -2208,13 +2208,13 @@ mod tests {
     #[test_case(&json!({"faz": "a"}), &["\"a\" is not of type \"integer\""], &["/additionalProperties/type"])]
     #[test_case(&json!({"faz": "a", "haz": "a"}), &["\"a\" is not of type \"integer\"", "\"a\" is not of type \"integer\""], &["/additionalProperties/type", "/additionalProperties/type"])]
     // `additionalProperties` - should be an integer & `patternProperties.^bar` - invalid
-    #[test_case(&json!({"foo": "a", "bar": 4}), &["4 is less than the minimum of 5", "\"a\" is not of type \"integer\""], &["/patternProperties/^bar/minimum", "/additionalProperties/type"])]
+    #[test_case(&json!({"foo": "a", "bar": 4}), &["\"a\" is not of type \"integer\"","4 is less than the minimum of 5"], &["/additionalProperties/type","/patternProperties/^bar/minimum"])]
     // `patternProperties.^bar` (should be >=5)
     #[test_case(&json!({"bar": 4}), &["4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum"])]
     // `patternProperties.spam$` (should be <=10)
     #[test_case(&json!({"spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - both values are invalid
-    #[test_case(&json!({"bar": 4, "spam": 11}), &["4 is less than the minimum of 5", "11 is greater than the maximum of 10"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
+    #[test_case(&json!({"bar": 4, "spam": 11}), &["11 is greater than the maximum of 10","4 is less than the minimum of 5"], &["/patternProperties/^bar/minimum", "/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is valid, `spam` is invalid
     #[test_case(&json!({"bar": 6, "spam": 11}), &["11 is greater than the maximum of 10"], &["/patternProperties/spam$/maximum"])]
     // `patternProperties` - `bar` is invalid, `spam` is valid
@@ -2227,13 +2227,13 @@ mod tests {
     #[test_case(
       &json!({"bar": 4, "spam": 11, "faz": "a", "fam": 42}),
       &[
-          "4 is less than the minimum of 5",
           "\"a\" is not of type \"integer\"",
           "11 is greater than the maximum of 10",
+          "4 is less than the minimum of 5",
       ],
       &[
-          "/patternProperties/^bar/minimum",
           "/additionalProperties/type",
+          "/patternProperties/^bar/minimum",
           "/patternProperties/spam$/maximum",
       ]
     )]

--- a/crates/jsonschema/src/keywords/mod.rs
+++ b/crates/jsonschema/src/keywords/mod.rs
@@ -537,7 +537,7 @@ mod tests {
     #[test_case(&json!({"minimum": 3.0}), &json!(2.5), r"2.5 is less than the minimum of 3.0")]
     #[test_case(&json!({"maxItems": 2}), &json!([1, 2, 3]), r"[1,2,3] has more than 2 items")]
     #[test_case(&json!({"maxLength": 2}), &json!("foo"), r#""foo" is longer than 2 characters"#)]
-    #[test_case(&json!({"maxProperties": 2}), &json!({"foo": 1, "bar": 2, "baz": 3}), r#"{"bar":2,"baz":3,"foo":1} has more than 2 properties"#)]
+    #[test_case(&json!({"maxProperties": 2}), &json!({"bar": 2, "baz": 3, "foo": 1}), r#"{"bar":2,"baz":3,"foo":1} has more than 2 properties"#)]
     #[test_case(&json!({"minimum": 1.1}), &json!(0.6), r"0.6 is less than the minimum of 1.1")]
     #[test_case(&json!({"minItems": 1}), &json!([]), r"[] has less than 1 item")]
     #[test_case(&json!({"minLength": 2}), &json!("f"), r#""f" is shorter than 2 characters"#)]

--- a/crates/jsonschema/src/keywords/prefix_items.rs
+++ b/crates/jsonschema/src/keywords/prefix_items.rs
@@ -159,90 +159,95 @@ mod tests {
         let validator = crate::validator_for(&schema).expect("schema compiles");
         let evaluation = validator.evaluate(&json!({"name": "Alice", "age": 1}));
 
+        let mut actual = serde_json::to_value(evaluation.list()).unwrap();
+        actual.sort_all_objects();
         assert_eq!(
-            serde_json::to_value(evaluation.list()).unwrap(),
+            actual,
             json!({
                 "valid": true,
                 "details": [
-                    {"evaluationPath": "", "instanceLocation": "", "schemaLocation": "", "valid": true},
+                    {"valid":true, "evaluationPath": "", "schemaLocation": "", "instanceLocation": ""},
                     {
                         "valid": true,
                         "evaluationPath": "/type",
+                        "schemaLocation": "/type",
                         "instanceLocation": "",
-                        "schemaLocation": "/type"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/required",
+                        "schemaLocation": "/required",
                         "instanceLocation": "",
-                        "schemaLocation": "/required"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/properties",
-                        "instanceLocation": "",
                         "schemaLocation": "/properties",
+                        "instanceLocation": "",
                         "annotations": ["age", "name"]
                     },
+
                     {
                         "valid": true,
                         "evaluationPath": "/properties/age",
+                        "schemaLocation": "/properties/age",
                         "instanceLocation": "/age",
-                        "schemaLocation": "/properties/age"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/properties/age/type",
+                        "schemaLocation": "/properties/age/type",
                         "instanceLocation": "/age",
-                        "schemaLocation": "/properties/age/type"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/properties/age/minimum",
+                        "schemaLocation": "/properties/age/minimum",
                         "instanceLocation": "/age",
-                        "schemaLocation": "/properties/age/minimum"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/properties/name",
+                        "schemaLocation": "/properties/name",
                         "instanceLocation": "/name",
-                        "schemaLocation": "/properties/name"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/properties/name/type",
+                        "schemaLocation": "/properties/name/type",
                         "instanceLocation": "/name",
-                        "schemaLocation": "/properties/name/type"
-                    }
+                    },
                 ]
             })
         );
 
+        let mut actual = serde_json::to_value(evaluation.hierarchical()).unwrap();
+        actual.sort_all_objects();
         assert_eq!(
-            serde_json::to_value(evaluation.hierarchical()).unwrap(),
+            actual,
             json!({
                 "valid": true,
                 "evaluationPath": "",
-                "instanceLocation": "",
                 "schemaLocation": "",
+                "instanceLocation": "",
                 "details": [
                     {
                         "valid": true,
                         "evaluationPath": "/type",
+                        "schemaLocation": "/type",
                         "instanceLocation": "",
-                        "schemaLocation": "/type"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/required",
+                        "schemaLocation": "/required",
                         "instanceLocation": "",
-                        "schemaLocation": "/required"
                     },
                     {
                         "valid": true,
                         "evaluationPath": "/properties",
-                        "instanceLocation": "",
                         "schemaLocation": "/properties",
+                        "instanceLocation": "",
                         "annotations": ["age", "name"],
                         "details": [
                             {

--- a/crates/jsonschema/src/lib.rs
+++ b/crates/jsonschema/src/lib.rs
@@ -2551,14 +2551,13 @@ pub(crate) mod tests_util {
     }
 
     pub(crate) fn expect_errors(schema: &Value, instance: &Value, errors: &[&str]) {
-        assert_eq!(
-            crate::validator_for(schema)
-                .expect("Should be a valid schema")
-                .iter_errors(instance)
-                .map(|e| e.to_string())
-                .collect::<Vec<String>>(),
-            errors
-        );
+        let mut actual = crate::validator_for(schema)
+            .expect("Should be a valid schema")
+            .iter_errors(instance)
+            .map(|e| e.to_string())
+            .collect::<Vec<String>>();
+        actual.sort();
+        assert_eq!(actual, errors);
     }
 
     #[track_caller]
@@ -2623,9 +2622,13 @@ pub(crate) mod tests_util {
     #[track_caller]
     pub(crate) fn assert_locations(schema: &Value, instance: &Value, expected: &[&str]) {
         let validator = crate::validator_for(schema).unwrap();
-        let errors = validator.iter_errors(instance);
+        let mut errors: Vec<_> = validator
+            .iter_errors(instance)
+            .map(|error| error.schema_path().as_str().to_string())
+            .collect();
+        errors.sort();
         for (error, location) in errors.into_iter().zip(expected) {
-            assert_eq!(error.schema_path().as_str(), *location);
+            assert_eq!(error, *location);
         }
     }
 


### PR DESCRIPTION
This PR makes the unit tests for `jsonschema` stable. 

This is done be sorting the results where it is necessary.
