### PR TITLE
chore(python): Exclude `rust-toolchain.toml` from wheels

### DIFF
--- a/crates/jsonschema-py/CHANGELOG.md
+++ b/crates/jsonschema-py/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Reduce dynamic dispatch overhead for non-recursive `$ref` resolution.
 - Cache ECMA regex transformations during `format: "regex"` validation.
 
+### Packaging
+
+- Exclude `rust-toolchain.toml` from wheels. [#1012](https://github.com/Stranger6667/jsonschema/issues/1012)
+
 ## [0.42.0] - 2026-02-14
 
 ### Fixed

--- a/crates/jsonschema-py/pyproject.toml
+++ b/crates/jsonschema-py/pyproject.toml
@@ -56,7 +56,7 @@ Funding = 'https://github.com/sponsors/Stranger6667'
 [tool.maturin]
 python-source = "python"
 strip = true
-include = [{ path = "rust-toolchain.toml", format = ["sdist", "wheel"] }]
+include = [{ path = "rust-toolchain.toml", format = ["sdist"] }]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
Resolves #1012 