### PR TITLE
Add annotation test harness for JSON Schema Test Suite (Python)

### DIFF
--- a/crates/jsonschema-py/tests-py/test_annotation_suite.py
+++ b/crates/jsonschema-py/tests-py/test_annotation_suite.py
@@ -9,6 +9,30 @@ SUITE_PATH = os.path.join(
     "../../jsonschema/tests/suite/annotations/tests",
 )
 
+XFAIL_IDS = {
+    "applicators.json::`anyOf`0",
+    "format.json::`format` is an annotation",
+    "unevaluated.json::`unevaluatedProperties` alone",
+    "unevaluated.json::`unevaluatedProperties` with `properties`",
+    "unevaluated.json::`unevaluatedProperties` with `patternProperties`",
+    "unevaluated.json::`unevaluatedProperties` with `dependentSchemas`",
+    "unevaluated.json::`unevaluatedProperties` with `if`, `then`, and `else`0",
+    "unevaluated.json::`unevaluatedProperties` with `if`, `then`, and `else`1",
+    "unevaluated.json::`unevaluatedProperties` with `allOf`",
+    "unevaluated.json::`unevaluatedProperties` with `anyOf`",
+    "unevaluated.json::`unevaluatedProperties` with `oneOf`",
+    "unevaluated.json::`unevaluatedProperties` with `not`",
+    "unevaluated.json::`unevaluatedItems` alone",
+    "unevaluated.json::`unevaluatedItems` with `prefixItems`",
+    "unevaluated.json::`unevaluatedItems` with `contains`",
+    "unevaluated.json::`unevaluatedItems` with `if`, `then`, and `else`0",
+    "unevaluated.json::`unevaluatedItems` with `if`, `then`, and `else`1",
+    "unevaluated.json::`unevaluatedItems` with `allOf`",
+    "unevaluated.json::`unevaluatedItems` with `anyOf`",
+    "unevaluated.json::`unevaluatedItems` with `oneOf`",
+    "unevaluated.json::`unevaluatedItems` with `not`",
+}
+
 def load_test_cases():
     cases = []
     for filename in sorted(os.listdir(SUITE_PATH)):
@@ -20,16 +44,19 @@ def load_test_cases():
         for suite_case in data.get("suite", []):
             schema = suite_case["schema"]
             description = suite_case.get("description", filename)
-            for test in suite_case.get("tests", []):
+            tests = suite_case.get("tests", [])
+            for idx, test in enumerate(tests):
                 instance = test["instance"]
                 assertions = test.get("assertions", [])
+                suffix = str(idx) if len(tests) > 1 else ""
+                test_id = f"{filename}::{description}{suffix}"
+                marks = (
+                    [pytest.mark.xfail(reason="Missing annotation support in the library, to be fixed upstream")]
+                    if test_id in XFAIL_IDS
+                    else []
+                )
                 cases.append(
-                    pytest.param(
-                        schema,
-                        instance,
-                        assertions,
-                        id=f"{filename}::{description}",
-                    )
+                    pytest.param(schema, instance, assertions, id=f"{filename}::{description}", marks=marks)
                 )
     return cases
 


### PR DESCRIPTION
Hey @Stranger6667 

## Summary
This is the first step (Python) of the annotation test harness 
for the official JSON Schema Annotation Test Suite.

Related to #1028

## What this PR adds
A pytest-based test harness in `crates/jsonschema-py/tests-py/test_annotation_suite.py` that:
Reads all test cases from the `annotations/tests/` folder of JSON Schema Test Suite
Runs them against `jsonschema-rs` Python bindings using `evaluate()` and `annotations()` API
Reports pass/fail per test with clear error messages

## Test Results
Total: 52 tests
 Passed: 31 
Failed: 21 

## Failing tests reveal gaps in annotation collection:
`format` keyword annotation not exposed
`anyOf` only returns annotation from first matching branch  
`unevaluatedProperties` / `unevaluatedItems` nested annotations missing

## Next Steps (as discussed)
 Step 2: Rust-level harness
 Step 3: Ruby-level harness