### PR TITLE
Add string schema inputs to validator_for

### DIFF
--- a/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
+++ b/crates/jsonschema-py/python/jsonschema_rs/__init__.pyi
@@ -492,7 +492,7 @@ def bundle(
     """
     ...
 
-def validator_cls_for(schema: _SchemaT) -> type[Validator]:
+def validator_cls_for(schema: _SchemaT | str) -> type[Validator]:
     """Detect the JSON Schema draft for a schema and return the corresponding validator class.
 
     Draft is detected automatically from the $schema field. Defaults to Draft202012Validator.


### PR DESCRIPTION
Thanks for `jsonschema-rs`!

To align with the first chunk of [Python _Usage_](https://pypi.org/project/jsonschema-rs/#usage), this adds `str` as an acceptable `schema` value to `validator_for` as well as the also-useful `validator_cls_for`. 

I tried these interactively with the current latest PyPI releases. The `validate` function does _not_ accept a string, which might be nice for consistency.

As for avoiding stdlib `json.parse` (and even string decoding) in a few more places: I don't have the `rust `chops to dig much further, but it would be very nice if:

- the above validator builders also accepted `bytes`, and/or potentially `read`able file-like objects
- if validators were able to "`parse`, not `validate`" incoming JSON str/bytes
  - from a typing syntax perspective, it might be nice if these supported an `as_type` to refine the `Any` return value

Thanks again!
